### PR TITLE
Fix -Wmissing-prototypes warnings across the driver (2179 → 42)

### DIFF
--- a/core/crypto/ccmp.c
+++ b/core/crypto/ccmp.c
@@ -176,7 +176,7 @@ u8 * ccmp_decrypt(_adapter *padapter, const u8 *tk, const struct ieee80211_hdr *
 }
 
 
-void ccmp_get_pn(u8 *pn, const u8 *data)
+static void ccmp_get_pn(u8 *pn, const u8 *data)
 {
 	pn[0] = data[7]; /* PN5 */
 	pn[1] = data[6]; /* PN4 */

--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -1015,7 +1015,7 @@ _exit:
 }
 #endif
 
-void rtw_init_bmc_sta_tx_rate(_adapter *padapter, struct sta_info *psta)
+static void rtw_init_bmc_sta_tx_rate(_adapter *padapter, struct sta_info *psta)
 {
 /* ToDo: need API to query hal_sta->ra_info.ramask */
 #if 0
@@ -1050,7 +1050,7 @@ void rtw_init_bmc_sta_tx_rate(_adapter *padapter, struct sta_info *psta)
 }
 
 #if defined(CONFIG_80211N_HT) && defined(CONFIG_BEAMFORMING)
-void update_sta_info_apmode_ht_bf_cap(_adapter *padapter, struct sta_info *psta)
+static void update_sta_info_apmode_ht_bf_cap(_adapter *padapter, struct sta_info *psta)
 {
 	struct _ADAPTER_LINK *padapter_link = psta->padapter_link;
 	struct link_mlme_priv *pmlmepriv = &(padapter_link->mlmepriv);
@@ -1756,7 +1756,7 @@ void rtw_core_ap_start(_adapter *padapter, struct createbss_parm *parm)
 	}
 #endif
 }
-void rtw_core_ap_chan_decision(_adapter *padapter, struct createbss_parm *parm)
+static void rtw_core_ap_chan_decision(_adapter *padapter, struct createbss_parm *parm)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
 	/* ToDo CONFIG_RTW_MLD: [currently primary link only] */
@@ -3079,7 +3079,7 @@ int rtw_ap_set_wep_key(_adapter *padapter, struct _ADAPTER_LINK *padapter_link,
 	return rtw_ap_set_key(padapter, padapter_link, key, alg, keyid, set_tx);
 }
 
-u8 rtw_ap_bmc_frames_hdl(_adapter *padapter)
+static u8 rtw_ap_bmc_frames_hdl(_adapter *padapter)
 {
 #define HIQ_XMIT_COUNTS (6)
 	struct sta_info *psta_bmc;
@@ -6640,7 +6640,7 @@ static enum phl_mdl_ret_code _ap_start_req_abort(void *dispr, void *priv)
 	return MDL_RET_SUCCESS;
 }
 
-const char *ap_get_evt_str(u32 evt)
+static const char *ap_get_evt_str(u32 evt)
 {
 	switch (evt) {
 	/* AP */

--- a/core/rtw_cmd.c
+++ b/core/rtw_cmd.c
@@ -1402,7 +1402,7 @@ exit:
 
 }
 
-void free_assoc_resources_hdl(_adapter *padapter, u8 lock_scanned_queue)
+static void free_assoc_resources_hdl(_adapter *padapter, u8 lock_scanned_queue)
 {
 	rtw_free_assoc_resources(padapter, lock_scanned_queue);
 }
@@ -1636,7 +1636,7 @@ exit:
 	return res;
 }
 
-u8 rtw_ssmps_wk_hdl(_adapter *adapter, struct ssmps_cmd_parm *ssmp_param)
+static u8 rtw_ssmps_wk_hdl(_adapter *adapter, struct ssmps_cmd_parm *ssmp_param)
 {
 	u8 res = _SUCCESS;
 	struct sta_info *sta = ssmp_param->sta;
@@ -2210,7 +2210,7 @@ static struct turbo_edca_setting ctrl_turbo_edca[TURBO_EDCA_MODE_NUM] = {
 	#endif /*CONFIG_RTW_IPCAM_APPLICATION*/
 };
 
-void rtw_turbo_edca(_adapter *padapter)
+static void rtw_turbo_edca(_adapter *padapter)
 {
 	struct registry_priv *pregpriv = &padapter->registrypriv;
 	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
@@ -2382,7 +2382,7 @@ void rtw_dynamic_chk_wk_hw_hdl(_adapter *padapter)
 }
 
 /* add for CONFIG_IEEE80211W, none 11w can use it */
-void reset_securitypriv_hdl(_adapter *padapter)
+static void reset_securitypriv_hdl(_adapter *padapter)
 {
 	rtw_reset_securitypriv(padapter);
 }
@@ -4265,7 +4265,7 @@ inline u8 rtw_customer_str_write_cmd(_adapter *adapter, const u8 *cstr)
 }
 #endif /* CONFIG_RTW_CUSTOMER_STR */
 
-u8 rtw_c2h_wk_cmd(_adapter *padapter, u8 *pbuf, u16 length, u8 type)
+static u8 rtw_c2h_wk_cmd(_adapter *padapter, u8 *pbuf, u16 length, u8 type)
 {
 	struct cmd_obj *cmd;
 	struct drvextra_cmd_parm *pdrvextra_cmd_parm;
@@ -4372,7 +4372,7 @@ u8 rtw_run_in_thread_cmd_wait(_adapter *adapter, void (*func)(void *), void *con
 }
 
 
-u8 session_tracker_cmd(_adapter *adapter, u8 cmd, struct sta_info *sta, u8 *local_naddr, u8 *local_port, u8 *remote_naddr, u8 *remote_port)
+static u8 session_tracker_cmd(_adapter *adapter, u8 cmd, struct sta_info *sta, u8 *local_naddr, u8 *local_port, u8 *remote_naddr, u8 *remote_port)
 {
 	struct cmd_priv	*cmdpriv = &adapter_to_dvobj(adapter)->cmdpriv;
 	struct cmd_obj *cmdobj;
@@ -4439,7 +4439,7 @@ inline u8 session_tracker_del_cmd(_adapter *adapter, struct sta_info *sta, u8 *l
 	return session_tracker_cmd(adapter, ST_CMD_DEL, sta, local_naddr, local_port, remote_naddr, remote_port);
 }
 
-void session_tracker_chk_for_sta(_adapter *adapter, struct sta_info *sta)
+static void session_tracker_chk_for_sta(_adapter *adapter, struct sta_info *sta)
 {
 	struct st_ctl_t *st_ctl = &sta->st_ctl;
 	int i;
@@ -4520,7 +4520,7 @@ exit:
 	return;
 }
 
-void session_tracker_chk_for_adapter(_adapter *adapter)
+static void session_tracker_chk_for_adapter(_adapter *adapter)
 {
 	struct sta_priv *stapriv = &adapter->stapriv;
 	struct sta_info *sta;
@@ -4551,7 +4551,7 @@ void session_tracker_chk_for_adapter(_adapter *adapter)
 #endif
 }
 
-void session_tracker_cmd_hdl(_adapter *adapter, struct st_cmd_parm *parm)
+static void session_tracker_cmd_hdl(_adapter *adapter, struct st_cmd_parm *parm)
 {
 	u8 cmd = parm->cmd;
 	struct sta_info *sta = parm->sta;
@@ -4713,7 +4713,7 @@ exit:
 #endif
 
 
-void rtw_ac_parm_cmd_hdl(_adapter *padapter, struct _ADAPTER_LINK *padapter_link, u8 *_ac_parm_buf, int ac_type)
+static void rtw_ac_parm_cmd_hdl(_adapter *padapter, struct _ADAPTER_LINK *padapter_link, u8 *_ac_parm_buf, int ac_type)
 {
 
 	u32 ac_parm_buf;
@@ -4974,7 +4974,7 @@ exit:
 
 }
 
-void rtw_getrttbl_cmd_cmdrsp_callback(_adapter *padapter,  struct cmd_obj *pcmd)
+static void rtw_getrttbl_cmd_cmdrsp_callback(_adapter *padapter,  struct cmd_obj *pcmd)
 {
 
 	rtw_free_cmd_obj(pcmd);
@@ -5035,7 +5035,7 @@ exit:
 }
 
 char UNKNOWN_CID[16] = "UNKNOWN_EXTRA";
-char *rtw_extra_name(struct drvextra_cmd_parm *pdrvextra_cmd)
+static char *rtw_extra_name(struct drvextra_cmd_parm *pdrvextra_cmd)
 {
 	switch(pdrvextra_cmd->ec_id) {
 	case NONE_WK_CID:

--- a/core/rtw_cmd.c
+++ b/core/rtw_cmd.c
@@ -15,6 +15,7 @@
 #define _RTW_CMD_C_
 
 #include <drv_types.h>
+#include "rtw_cmd.h"
 
 #ifndef DBG_CMD_EXECUTE
 	#define DBG_CMD_EXECUTE 0

--- a/core/rtw_csa.c
+++ b/core/rtw_csa.c
@@ -52,7 +52,7 @@ bool rtw_mr_is_ecsa_running(struct _ADAPTER *a)
 	return _FALSE;
 }
 
-void rtw_build_csa_ie(struct _ADAPTER *a, struct rtw_phl_ecsa_param *ecsa_param)
+static void rtw_build_csa_ie(struct _ADAPTER *a, struct rtw_phl_ecsa_param *ecsa_param)
 {
 	/* ToDo CONFIG_RTW_MLD: [currently primary link only] */
 	struct _ADAPTER_LINK *alink = GET_PRIMARY_LINK(a);
@@ -73,7 +73,7 @@ void rtw_build_csa_ie(struct _ADAPTER *a, struct rtw_phl_ecsa_param *ecsa_param)
 			csa_data[0], csa_data[1], csa_data[2]);
 }
 
-void rtw_build_ecsa_ie(struct _ADAPTER *a, struct rtw_phl_ecsa_param *ecsa_param)
+static void rtw_build_ecsa_ie(struct _ADAPTER *a, struct rtw_phl_ecsa_param *ecsa_param)
 {
 	/* ToDo CONFIG_RTW_MLD: [currently primary link only] */
 	struct _ADAPTER_LINK *alink = GET_PRIMARY_LINK(a);
@@ -266,7 +266,7 @@ static void rtw_ecsa_update_sta_chan_info(struct _ADAPTER *a,
 	#endif
 }
 
-void rtw_ap_update_beacon_by_role(void *priv, struct rtw_wifi_role_t *role , struct rtw_wifi_role_link_t *rlink)
+static void rtw_ap_update_beacon_by_role(void *priv, struct rtw_wifi_role_t *role , struct rtw_wifi_role_link_t *rlink)
 {
 	/* TODO */
 }

--- a/core/rtw_debug.c
+++ b/core/rtw_debug.c
@@ -34,6 +34,7 @@ const char *rtw_log_level_str[] = {
 #endif /* CONFIG_DEBUG_RTL871X */
 
 #include <rtw_version.h>
+#include "rtw_debug.h"
 
 #ifdef CONFIG_TDLS
 	#define TDLS_DBG_INFO_SPACE_BTWN_ITEM_AND_VALUE	41

--- a/core/rtw_debug.c
+++ b/core/rtw_debug.c
@@ -3731,7 +3731,7 @@ ssize_t proc_set_txbf_cap(struct file *file, const char __user *buffer, size_t c
 */
 #ifdef CONFIG_AP_MODE
 
-void dump_phl_tring_status(struct seq_file *m, _adapter *padapter, struct sta_info *psta)
+static void dump_phl_tring_status(struct seq_file *m, _adapter *padapter, struct sta_info *psta)
 {
 	int i = 0;
 	u16 tring_len = 0;

--- a/core/rtw_he.c
+++ b/core/rtw_he.c
@@ -1424,7 +1424,7 @@ u32 rtw_build_he_6g_band_cap_ie_by_proto(_adapter *padapter, enum role_type role
 	return HE_6G_BAND_CAP_MAX_LEN + 2;
 }
 
-u32 rtw_build_he_6g_band_cap_ie(_adapter *padapter,
+static u32 rtw_build_he_6g_band_cap_ie(_adapter *padapter,
 					struct _ADAPTER_LINK *padapter_link,
 					u8 *pbuf)
 {

--- a/core/rtw_he.c
+++ b/core/rtw_he.c
@@ -1424,7 +1424,8 @@ u32 rtw_build_he_6g_band_cap_ie_by_proto(_adapter *padapter, enum role_type role
 	return HE_6G_BAND_CAP_MAX_LEN + 2;
 }
 
-u32 rtw_build_he_6g_band_cap_ie(_adapter *padapter,
+#if CONFIG_IEEE80211_BAND_6GHZ
+static u32 rtw_build_he_6g_band_cap_ie(_adapter *padapter,
 					struct _ADAPTER_LINK *padapter_link,
 					u8 *pbuf)
 {
@@ -1436,6 +1437,7 @@ u32 rtw_build_he_6g_band_cap_ie(_adapter *padapter,
 
 	return rtw_build_he_6g_band_cap_ie_by_proto(padapter, role_type, proto_cap, pbuf);
 }
+#endif /* CONFIG_IEEE80211_BAND_6GHZ */
 
 u32 rtw_restructure_he_ie(_adapter *padapter,
                                         struct _ADAPTER_LINK *padapter_link,

--- a/core/rtw_ieee80211.c
+++ b/core/rtw_ieee80211.c
@@ -684,7 +684,7 @@ void rtw_set_supported_rate(u8 *SupportedRates, uint mode, u8 ch, enum band_type
 	}
 }
 
-void rtw_filter_suppport_rateie(WLAN_BSSID_EX *pbss_network, u8 keep)
+static void rtw_filter_suppport_rateie(WLAN_BSSID_EX *pbss_network, u8 keep)
 {
 	u8 i, idx = 0, new_rate[NDIS_802_11_LENGTH_RATES_EX], *p;
 	uint iscck, isofdm, ie_orilen = 0, remain_len;
@@ -965,7 +965,7 @@ int rtw_get_rsn_cipher_suite(u8 *s)
 	return 0;
 }
 
-u32 rtw_get_akm_suite_bitmap(u8 *s)
+static u32 rtw_get_akm_suite_bitmap(u8 *s)
 {
 	if (_rtw_memcmp(s, WLAN_AKM_8021X, RSN_SELECTOR_LEN) == _TRUE)
 		return WLAN_AKM_TYPE_8021X;
@@ -2167,7 +2167,7 @@ void dump_ht_cap_ie_content(void *sel, const u8 *buf, u32 buf_len)
 		      , HT_SUP_MCS_SET_ARG(HT_CAP_ELE_SUP_MCS_SET(buf)));
 }
 
-void dump_ht_cap_ie(void *sel, const u8 *ie, u32 ie_len)
+static void dump_ht_cap_ie(void *sel, const u8 *ie, u32 ie_len)
 {
 	const u8 *ht_cap_ie;
 	sint ht_cap_ielen;
@@ -2186,7 +2186,7 @@ const char *const _ht_sc_offset_str[] = {
 	"SCB",
 };
 
-void dump_ht_op_ie_content(void *sel, const u8 *buf, u32 buf_len)
+static void dump_ht_op_ie_content(void *sel, const u8 *buf, u32 buf_len)
 {
 	if (buf_len != HT_OP_IE_LEN) {
 		RTW_PRINT_SEL(sel, "Invalid HT operation IE len:%d != %d\n", buf_len, HT_OP_IE_LEN);
@@ -2200,7 +2200,7 @@ void dump_ht_op_ie_content(void *sel, const u8 *buf, u32 buf_len)
 	);
 }
 
-void dump_ht_op_ie(void *sel, const u8 *ie, u32 ie_len)
+static void dump_ht_op_ie(void *sel, const u8 *ie, u32 ie_len)
 {
 	const u8 *ht_op_ie;
 	sint ht_op_ielen;

--- a/core/rtw_ioctl_set.c
+++ b/core/rtw_ioctl_set.c
@@ -17,8 +17,6 @@
 #include <drv_types.h>
 
 
-extern void indicate_wx_scan_complete_event(_adapter *padapter);
-
 #define IS_MAC_ADDRESS_BROADCAST(addr) \
 	(\
 	 ((addr[0] == 0xff) && (addr[1] == 0xff) && \

--- a/core/rtw_mi.c
+++ b/core/rtw_mi.c
@@ -863,7 +863,7 @@ void rtw_mi_buddy_beacon_update(_adapter *padapter)
 	_rtw_mi_process(padapter, _TRUE, NULL, _rtw_mi_beacon_update);
 }
 
-u8 _rtw_mi_busy_traffic_check(_adapter *padapter, void *data)
+static u8 _rtw_mi_busy_traffic_check(_adapter *padapter, void *data)
 {
 	return padapter->mlmepriv.LinkDetectInfo.bBusyTraffic;
 }
@@ -1283,7 +1283,7 @@ _adapter *rtw_get_iface_by_macddr(_adapter *padapter, const u8 *mac_addr)
 /*#define CONFIG_SKB_ALLOCATED*/
 #define DBG_SKB_PROCESS
 #ifdef DBG_SKB_PROCESS
-void rtw_dbg_skb_process(_adapter *padapter, union recv_frame *precvframe, union recv_frame *pcloneframe)
+static void rtw_dbg_skb_process(_adapter *padapter, union recv_frame *precvframe, union recv_frame *pcloneframe)
 {
 	struct sk_buff *pkt_copy, *pkt_org;
 

--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -26,7 +26,7 @@ static void rtw_update_link_he_6ghz_cap(_adapter *padapter,
 extern u8 rtw_do_join(_adapter *padapter);
 
 
-void rtw_init_mlme_timer(_adapter *padapter)
+static void rtw_init_mlme_timer(_adapter *padapter)
 {
 	struct	mlme_priv *pmlmepriv = &padapter->mlmepriv;
 
@@ -42,7 +42,7 @@ void rtw_init_mlme_timer(_adapter *padapter)
 #endif
 }
 
-sint	_rtw_init_mlme_priv(_adapter *padapter)
+static sint	_rtw_init_mlme_priv(_adapter *padapter)
 {
 	sint	i;
 	u8	*pbuf;
@@ -213,7 +213,7 @@ exit:
 	return res;
 }
 
-void rtw_mfree_mlme_priv_lock(struct mlme_priv *pmlmepriv)
+static void rtw_mfree_mlme_priv_lock(struct mlme_priv *pmlmepriv)
 {
 	_rtw_spinlock_free(&pmlmepriv->lock);
 	_rtw_spinlock_free(&(pmlmepriv->free_bss_pool.lock));
@@ -372,7 +372,7 @@ exit:
 }
 #endif /* defined(CONFIG_WFD) && defined(CONFIG_IOCTL_CFG80211) */
 
-void _rtw_free_mlme_priv(struct mlme_priv *pmlmepriv)
+static void _rtw_free_mlme_priv(struct mlme_priv *pmlmepriv)
 {
 	_adapter *adapter = mlme_to_adapter(pmlmepriv);
 	if (NULL == pmlmepriv) {
@@ -409,7 +409,7 @@ int rtw_init_link_mlme_priv(struct _ADAPTER_LINK *padapter_link)
 	return _SUCCESS;
 }
 
-sint	_rtw_enqueue_network(_queue *queue, struct wlan_network *pnetwork)
+static sint	_rtw_enqueue_network(_queue *queue, struct wlan_network *pnetwork)
 {
 
 	if (pnetwork == NULL)
@@ -662,19 +662,19 @@ void rtw_free_mlme_priv(struct mlme_priv *pmlmepriv)
 	_rtw_free_mlme_priv(pmlmepriv);
 }
 
-int rtw_enqueue_network(_queue *queue, struct wlan_network *pnetwork)
+static int rtw_enqueue_network(_queue *queue, struct wlan_network *pnetwork)
 {
 	int	res;
 	res = _rtw_enqueue_network(queue, pnetwork);
 	return res;
 }
 
-void rtw_free_network(struct mlme_priv *pmlmepriv, struct	wlan_network *pnetwork, u8 is_freeall)/* (struct	wlan_network *pnetwork, _queue	*free_queue) */
+static void rtw_free_network(struct mlme_priv *pmlmepriv, struct	wlan_network *pnetwork, u8 is_freeall)/* (struct	wlan_network *pnetwork, _queue	*free_queue) */
 {
 	_rtw_free_network(pmlmepriv, pnetwork, is_freeall);
 }
 
-void rtw_free_network_nolock(_adapter *padapter, struct wlan_network *pnetwork)
+static void rtw_free_network_nolock(_adapter *padapter, struct wlan_network *pnetwork)
 {
 	_rtw_free_network_nolock(&(padapter->mlmepriv), pnetwork);
 #ifdef CONFIG_IOCTL_CFG80211
@@ -835,7 +835,7 @@ void rtw_free_cloned_mld_network(struct wlan_mld_network *mld_network)
 }
 #endif
 
-struct wlan_mld_network *_rtw_alloc_mld_network(struct mlme_priv *pmlmepriv, const u8 *mac_addr)
+static struct wlan_mld_network *_rtw_alloc_mld_network(struct mlme_priv *pmlmepriv, const u8 *mac_addr)
 {
 	struct	wlan_mld_network	*pmld_network;
 	_queue *free_queue = &pmlmepriv->free_mld_bss_pool;
@@ -895,7 +895,7 @@ struct wlan_mld_network *rtw_alloc_mld_network(_adapter *adapter, const u8 *mac_
 	return pmld_network;
 }
 
-void _rtw_free_mld_network(struct mlme_priv *pmlmepriv, struct wlan_mld_network *pmld_network, u8 isfreeall)
+static void _rtw_free_mld_network(struct mlme_priv *pmlmepriv, struct wlan_mld_network *pmld_network, u8 isfreeall)
 {
 	u32 delta_time;
 	u32 lifetime = SCANQUEUE_LIFETIME;
@@ -936,7 +936,8 @@ exit:
 	return;
 }
 
-void _rtw_free_mld_network_nolock(struct mlme_priv *pmlmepriv, struct wlan_mld_network *pmld_network)
+#ifdef CONFIG_80211BE_EHT
+static void _rtw_free_mld_network_nolock(struct mlme_priv *pmlmepriv, struct wlan_mld_network *pmld_network)
 {
 
 	_queue *free_queue = &(pmlmepriv->free_mld_bss_pool);
@@ -957,8 +958,9 @@ void _rtw_free_mld_network_nolock(struct mlme_priv *pmlmepriv, struct wlan_mld_n
 exit:
 	return;
 }
+#endif /* CONFIG_80211BE_EHT */
 
-void _rtw_free_mld_network_queue(_adapter *padapter, u8 isfreeall)
+static void _rtw_free_mld_network_queue(_adapter *padapter, u8 isfreeall)
 {
 
 	_list *phead, *plist;
@@ -991,15 +993,17 @@ void _rtw_free_mld_network_queue(_adapter *padapter, u8 isfreeall)
 
 }
 
-void rtw_free_mld_network(struct mlme_priv *pmlmepriv, struct wlan_mld_network *pmld_network, u8 is_freeall)
+static void rtw_free_mld_network(struct mlme_priv *pmlmepriv, struct wlan_mld_network *pmld_network, u8 is_freeall)
 {
 	_rtw_free_mld_network(pmlmepriv, pmld_network, is_freeall);
 }
 
-void rtw_free_mld_network_nolock(_adapter *padapter, struct wlan_mld_network *pmld_network)
+#ifdef CONFIG_80211BE_EHT
+static void rtw_free_mld_network_nolock(_adapter *padapter, struct wlan_mld_network *pmld_network)
 {
 	_rtw_free_mld_network_nolock(&(padapter->mlmepriv), pmld_network);
 }
+#endif /* CONFIG_80211BE_EHT */
 
 void rtw_free_mld_network_queue(_adapter *dev, u8 isfreeall)
 {
@@ -1810,7 +1814,7 @@ unlock_unassoc_sta_queue:
  *			   (3) WMM
  *			   (4) HT
  * (5) others */
-int rtw_is_desired_network(_adapter *adapter, struct wlan_network *pnetwork)
+static int rtw_is_desired_network(_adapter *adapter, struct wlan_network *pnetwork)
 {
 	struct security_priv *psecuritypriv = &adapter->securitypriv;
 	struct mlme_priv *pmlmepriv = &adapter->mlmepriv;
@@ -1918,7 +1922,7 @@ static void free_scanqueue(struct	mlme_priv *pmlmepriv)
 
 }
 
-void rtw_reset_rx_info(_adapter *adapter)
+static void rtw_reset_rx_info(_adapter *adapter)
 {
 	struct recv_info *precvinfo = &adapter->recvinfo;
 

--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -26,7 +26,7 @@ static void rtw_update_link_he_6ghz_cap(_adapter *padapter,
 extern u8 rtw_do_join(_adapter *padapter);
 
 
-void rtw_init_mlme_timer(_adapter *padapter)
+static void rtw_init_mlme_timer(_adapter *padapter)
 {
 	struct	mlme_priv *pmlmepriv = &padapter->mlmepriv;
 
@@ -42,7 +42,7 @@ void rtw_init_mlme_timer(_adapter *padapter)
 #endif
 }
 
-sint	_rtw_init_mlme_priv(_adapter *padapter)
+static sint	_rtw_init_mlme_priv(_adapter *padapter)
 {
 	sint	i;
 	u8	*pbuf;
@@ -213,7 +213,7 @@ exit:
 	return res;
 }
 
-void rtw_mfree_mlme_priv_lock(struct mlme_priv *pmlmepriv)
+static void rtw_mfree_mlme_priv_lock(struct mlme_priv *pmlmepriv)
 {
 	_rtw_spinlock_free(&pmlmepriv->lock);
 	_rtw_spinlock_free(&(pmlmepriv->free_bss_pool.lock));
@@ -372,7 +372,7 @@ exit:
 }
 #endif /* defined(CONFIG_WFD) && defined(CONFIG_IOCTL_CFG80211) */
 
-void _rtw_free_mlme_priv(struct mlme_priv *pmlmepriv)
+static void _rtw_free_mlme_priv(struct mlme_priv *pmlmepriv)
 {
 	_adapter *adapter = mlme_to_adapter(pmlmepriv);
 	if (NULL == pmlmepriv) {
@@ -409,7 +409,7 @@ int rtw_init_link_mlme_priv(struct _ADAPTER_LINK *padapter_link)
 	return _SUCCESS;
 }
 
-sint	_rtw_enqueue_network(_queue *queue, struct wlan_network *pnetwork)
+static sint	_rtw_enqueue_network(_queue *queue, struct wlan_network *pnetwork)
 {
 
 	if (pnetwork == NULL)
@@ -662,19 +662,19 @@ void rtw_free_mlme_priv(struct mlme_priv *pmlmepriv)
 	_rtw_free_mlme_priv(pmlmepriv);
 }
 
-int rtw_enqueue_network(_queue *queue, struct wlan_network *pnetwork)
+static int rtw_enqueue_network(_queue *queue, struct wlan_network *pnetwork)
 {
 	int	res;
 	res = _rtw_enqueue_network(queue, pnetwork);
 	return res;
 }
 
-void rtw_free_network(struct mlme_priv *pmlmepriv, struct	wlan_network *pnetwork, u8 is_freeall)/* (struct	wlan_network *pnetwork, _queue	*free_queue) */
+static void rtw_free_network(struct mlme_priv *pmlmepriv, struct	wlan_network *pnetwork, u8 is_freeall)/* (struct	wlan_network *pnetwork, _queue	*free_queue) */
 {
 	_rtw_free_network(pmlmepriv, pnetwork, is_freeall);
 }
 
-void rtw_free_network_nolock(_adapter *padapter, struct wlan_network *pnetwork)
+static void rtw_free_network_nolock(_adapter *padapter, struct wlan_network *pnetwork)
 {
 	_rtw_free_network_nolock(&(padapter->mlmepriv), pnetwork);
 #ifdef CONFIG_IOCTL_CFG80211
@@ -835,7 +835,7 @@ void rtw_free_cloned_mld_network(struct wlan_mld_network *mld_network)
 }
 #endif
 
-struct wlan_mld_network *_rtw_alloc_mld_network(struct mlme_priv *pmlmepriv, const u8 *mac_addr)
+static struct wlan_mld_network *_rtw_alloc_mld_network(struct mlme_priv *pmlmepriv, const u8 *mac_addr)
 {
 	struct	wlan_mld_network	*pmld_network;
 	_queue *free_queue = &pmlmepriv->free_mld_bss_pool;
@@ -895,7 +895,7 @@ struct wlan_mld_network *rtw_alloc_mld_network(_adapter *adapter, const u8 *mac_
 	return pmld_network;
 }
 
-void _rtw_free_mld_network(struct mlme_priv *pmlmepriv, struct wlan_mld_network *pmld_network, u8 isfreeall)
+static void _rtw_free_mld_network(struct mlme_priv *pmlmepriv, struct wlan_mld_network *pmld_network, u8 isfreeall)
 {
 	u32 delta_time;
 	u32 lifetime = SCANQUEUE_LIFETIME;
@@ -936,7 +936,7 @@ exit:
 	return;
 }
 
-void _rtw_free_mld_network_nolock(struct mlme_priv *pmlmepriv, struct wlan_mld_network *pmld_network)
+static void _rtw_free_mld_network_nolock(struct mlme_priv *pmlmepriv, struct wlan_mld_network *pmld_network)
 {
 
 	_queue *free_queue = &(pmlmepriv->free_mld_bss_pool);
@@ -958,7 +958,7 @@ exit:
 	return;
 }
 
-void _rtw_free_mld_network_queue(_adapter *padapter, u8 isfreeall)
+static void _rtw_free_mld_network_queue(_adapter *padapter, u8 isfreeall)
 {
 
 	_list *phead, *plist;
@@ -991,12 +991,12 @@ void _rtw_free_mld_network_queue(_adapter *padapter, u8 isfreeall)
 
 }
 
-void rtw_free_mld_network(struct mlme_priv *pmlmepriv, struct wlan_mld_network *pmld_network, u8 is_freeall)
+static void rtw_free_mld_network(struct mlme_priv *pmlmepriv, struct wlan_mld_network *pmld_network, u8 is_freeall)
 {
 	_rtw_free_mld_network(pmlmepriv, pmld_network, is_freeall);
 }
 
-void rtw_free_mld_network_nolock(_adapter *padapter, struct wlan_mld_network *pmld_network)
+static void rtw_free_mld_network_nolock(_adapter *padapter, struct wlan_mld_network *pmld_network)
 {
 	_rtw_free_mld_network_nolock(&(padapter->mlmepriv), pmld_network);
 }
@@ -1810,7 +1810,7 @@ unlock_unassoc_sta_queue:
  *			   (3) WMM
  *			   (4) HT
  * (5) others */
-int rtw_is_desired_network(_adapter *adapter, struct wlan_network *pnetwork)
+static int rtw_is_desired_network(_adapter *adapter, struct wlan_network *pnetwork)
 {
 	struct security_priv *psecuritypriv = &adapter->securitypriv;
 	struct mlme_priv *pmlmepriv = &adapter->mlmepriv;
@@ -1918,7 +1918,7 @@ static void free_scanqueue(struct	mlme_priv *pmlmepriv)
 
 }
 
-void rtw_reset_rx_info(_adapter *adapter)
+static void rtw_reset_rx_info(_adapter *adapter)
 {
 	struct recv_info *precvinfo = &adapter->recvinfo;
 

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -519,7 +519,7 @@ static void init_mlme_ext_priv_value(_adapter *padapter)
 	pmlmeext->action_public_dialog_token = 0xff;
 }
 
-void init_mlme_ext_timer(_adapter *padapter)
+static void init_mlme_ext_timer(_adapter *padapter)
 {
 	struct mlme_ext_priv *pmlmeext = &padapter->mlmeextpriv;
 
@@ -626,7 +626,7 @@ void free_mlme_ext_priv(struct mlme_ext_priv *pmlmeext)
 	}
 }
 
-void init_link_mlme_default_rate_set(struct _ADAPTER_LINK *padapter_link)
+static void init_link_mlme_default_rate_set(struct _ADAPTER_LINK *padapter_link)
 {
 	_adapter *padapter = padapter_link->adapter;
 	struct	link_mlme_ext_priv	*pmlmeext = &padapter_link->mlmeextpriv;
@@ -941,7 +941,7 @@ void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 }
 
 #ifdef CONFIG_P2P
-u32 p2p_listen_state_process(_adapter *padapter, unsigned char *da)
+static u32 p2p_listen_state_process(_adapter *padapter, unsigned char *da)
 {
 	bool response = _TRUE;
 	/* ToDo CONFIG_RTW_MLD: [currently primary link only] */
@@ -3857,7 +3857,7 @@ u32 rtw_build_vendor_ie(_adapter *padapter , unsigned char **pframe , u8 mgmt_fr
 #endif
 
 #ifdef CONFIG_ECSA_PHL
-u8 *build_supported_op_class_ie(_adapter *padapter, u8 *pbuf, int *pktlen)
+static u8 *build_supported_op_class_ie(_adapter *padapter, u8 *pbuf, int *pktlen)
 {
 	u8 buf[32];
 	int ie_len = 0;
@@ -3996,7 +3996,7 @@ void issue_probersp_p2p(_adapter *padapter, unsigned char *da)
 
 }
 
-int _issue_probereq_p2p(_adapter *padapter, u8 *da, int wait_ack)
+static int _issue_probereq_p2p(_adapter *padapter, u8 *da, int wait_ack)
 {
 	int ret = _FAIL;
 	struct xmit_frame		*pmgntframe;
@@ -4113,7 +4113,7 @@ inline void issue_probereq_p2p(_adapter *adapter, u8 *da)
 
 #endif /* CONFIG_P2P */
 
-s32 rtw_action_public_decache(union recv_frame *rframe, u8 token_offset)
+static s32 rtw_action_public_decache(union recv_frame *rframe, u8 token_offset)
 {
 	_adapter *adapter = rframe->u.hdr.adapter;
 	struct mlme_ext_priv *mlmeext = &(adapter->mlmeextpriv);
@@ -4138,7 +4138,7 @@ s32 rtw_action_public_decache(union recv_frame *rframe, u8 token_offset)
 	return _SUCCESS;
 }
 
-unsigned int on_action_public_p2p(union recv_frame *precv_frame)
+static unsigned int on_action_public_p2p(union recv_frame *precv_frame)
 {
 	_adapter *padapter = precv_frame->u.hdr.adapter;
 
@@ -4158,7 +4158,7 @@ unsigned int on_action_public_p2p(union recv_frame *precv_frame)
 	return _SUCCESS;
 }
 
-unsigned int on_action_public_vendor(union recv_frame *precv_frame)
+static unsigned int on_action_public_vendor(union recv_frame *precv_frame)
 {
 	unsigned int ret = _FAIL;
 	u8 *pframe = precv_frame->u.hdr.rx_data;
@@ -4190,7 +4190,7 @@ exit:
 	return ret;
 }
 
-unsigned int on_action_public_default(union recv_frame *precv_frame, u8 action)
+static unsigned int on_action_public_default(union recv_frame *precv_frame, u8 action)
 {
 	unsigned int ret = _FAIL;
 	u8 *pframe = precv_frame->u.hdr.rx_data;
@@ -4719,7 +4719,7 @@ unsigned int DoReserved(_adapter *padapter, union recv_frame *precv_frame)
 	return _SUCCESS;
 }
 
-struct xmit_frame *_alloc_mgtxmitframe(struct xmit_priv *pxmitpriv, bool once)
+static struct xmit_frame *_alloc_mgtxmitframe(struct xmit_priv *pxmitpriv, bool once)
 {
 	struct xmit_frame *pmgntframe;
 
@@ -5036,7 +5036,7 @@ s32 dump_mgntframe_and_wait_ack(_adapter *padapter, struct xmit_frame *pmgntfram
 }
 
 #ifdef RTW_PHL_BCN //core ops
-s32 rtw_core_issue_beacon(_adapter *padapter, struct xmit_frame *pmgntframe)
+static s32 rtw_core_issue_beacon(_adapter *padapter, struct xmit_frame *pmgntframe)
 {
 	struct rtw_wifi_role_t *wrole = padapter->phl_role;
 	struct rtw_bcn_info_cmn *bcn_cmn = NULL;
@@ -5107,7 +5107,7 @@ s32 rtw_core_issue_beacon(_adapter *padapter, struct xmit_frame *pmgntframe)
 }
 #endif
 
-int update_hidden_ssid(u8 *ies, u32 ies_len, u8 hidden_ssid_mode)
+static int update_hidden_ssid(u8 *ies, u32 ies_len, u8 hidden_ssid_mode)
 {
 	u8 *ssid_ie;
 	sint ssid_len_ori;
@@ -5142,7 +5142,8 @@ int update_hidden_ssid(u8 *ies, u32 ies_len, u8 hidden_ssid_mode)
 	return len_diff;
 }
 
-u8 *rtw_build_reduced_nb_rpt(_adapter *padapter, struct pkt_attrib *pattrib, u8 *pframe)
+#ifdef CONFIG_80211BE_EHT
+static u8 *rtw_build_reduced_nb_rpt(_adapter *padapter, struct pkt_attrib *pattrib, u8 *pframe)
 {
 	u32 len = 0;
 	len = rtw_phl_build_reduced_nb_rpt(padapter->phl_role, pattrib->adapter_link->wrlink, pframe);
@@ -5150,6 +5151,7 @@ u8 *rtw_build_reduced_nb_rpt(_adapter *padapter, struct pkt_attrib *pattrib, u8 
 
 	return pframe + len;
 }
+#endif /* CONFIG_80211BE_EHT */
 
 void issue_beacon(_adapter *padapter, int timeout_ms)
 {
@@ -5807,7 +5809,7 @@ void issue_ml_probersp(_adapter *padapter, struct _ADAPTER_LINK *padapter_link, 
 }
 #endif
 
-int _issue_probereq(_adapter *padapter, struct _ADAPTER_LINK *padapter_link,
+static int _issue_probereq(_adapter *padapter, struct _ADAPTER_LINK *padapter_link,
 		const NDIS_802_11_SSID *pssid, const u8 *da, u8 ch, bool append_wps, int wait_ack)
 {
 	int ret = _FAIL;
@@ -8130,7 +8132,7 @@ void issue_action_BSSCoexistPacket(_adapter *padapter)
 }
 
 /* Spatial Multiplexing Powersave (SMPS) action frame */
-int _issue_action_SM_PS(_adapter *padapter, unsigned char *raddr, u8 NewMimoPsMode, u8 wait_ack)
+static int _issue_action_SM_PS(_adapter *padapter, unsigned char *raddr, u8 NewMimoPsMode, u8 wait_ack)
 {
 
 	int ret = _FAIL;
@@ -9757,7 +9759,7 @@ void update_sta_info(_adapter *padapter, struct sta_info *psta) {
 
 }
 
-void update_sta_trx_nss(_adapter *adapter, struct sta_info *psta)
+static void update_sta_trx_nss(_adapter *adapter, struct sta_info *psta)
 {
 	s8 tx_nss, rx_nss;
 	struct mlme_ext_priv *mlmeext = &adapter->mlmeextpriv;
@@ -9787,7 +9789,7 @@ void update_sta_trx_nss(_adapter *adapter, struct sta_info *psta)
 			psta->phl_sta->macid, tx_nss, rx_nss);
 }
 
-void update_sta_smps_cap(_adapter *adapter, struct sta_info *psta)
+static void update_sta_smps_cap(_adapter *adapter, struct sta_info *psta)
 {
 	struct _ADAPTER_LINK	*adapter_link = psta->padapter_link;
 	struct mlme_ext_priv	*pmlmeext = &adapter->mlmeextpriv;
@@ -9817,7 +9819,7 @@ void update_sta_smps_cap(_adapter *adapter, struct sta_info *psta)
 			psta->phl_sta->asoc_cap.nss_rx);
 }
 
-void update_sta_rate_mask(_adapter *padapter, struct sta_info *psta)
+static void update_sta_rate_mask(_adapter *padapter, struct sta_info *psta)
 {
 	struct registry_priv *registrypriv = &padapter->registrypriv;
 	struct _ADAPTER_LINK *padapter_link = psta->padapter_link;
@@ -10091,7 +10093,8 @@ When station does not receive any packet in MAX_CONTINUAL_NORXPACKET_COUNT*2 sec
 recipient station will teardown the block ack by issuing DELBA frame.
 
 *********************************************************************/
-void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_timer)
+#ifdef CONFIG_ISSUE_DELBA_WHEN_NO_TRAFFIC
+static void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_timer)
 {
 	int	i = 0;
 	int ret = _SUCCESS;
@@ -10128,8 +10131,9 @@ void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_timer)
 		}
 	}
 }
+#endif /* CONFIG_ISSUE_DELBA_WHEN_NO_TRAFFIC */
 
-u8 chk_ap_is_alive(_adapter *padapter, struct sta_info *psta)
+static u8 chk_ap_is_alive(_adapter *padapter, struct sta_info *psta)
 {
 	u8 ret = _FALSE;
 #ifdef DBG_EXPIRATION_CHK
@@ -10169,7 +10173,7 @@ u8 chk_ap_is_alive(_adapter *padapter, struct sta_info *psta)
 	return ret;
 }
 
-u8 chk_adhoc_peer_is_alive(struct sta_info *psta)
+static u8 chk_adhoc_peer_is_alive(struct sta_info *psta)
 {
 	u8 ret = _TRUE;
 
@@ -10764,7 +10768,7 @@ void addba_timer_hdl(void *ctx)
 }
 
 #ifdef CONFIG_IEEE80211W
-void report_sta_timeout_event(_adapter *padapter, u8 *MacAddr, unsigned short reason)
+static void report_sta_timeout_event(_adapter *padapter, u8 *MacAddr, unsigned short reason)
 {
 	struct cmd_obj *pcmd_obj;
 	u8 *pevtcmd;
@@ -10823,7 +10827,7 @@ void report_sta_timeout_event(_adapter *padapter, u8 *MacAddr, unsigned short re
 	return;
 }
 
-void clnt_sa_query_timeout(_adapter *padapter)
+static void clnt_sa_query_timeout(_adapter *padapter)
 {
 	struct mlme_ext_priv *mlmeext = &(padapter->mlmeextpriv);
 	struct mlme_ext_info *mlmeinfo = &(mlmeext->mlmext_info);
@@ -11959,7 +11963,7 @@ exit:
  *
  * Returns: 0: no ps announcement is doing. 1: ps announcement is doing
  */
-u8 rtw_ps_annc(_adapter *adapter, bool ps)
+static u8 rtw_ps_annc(_adapter *adapter, bool ps)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	_adapter *iface;

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -519,7 +519,7 @@ static void init_mlme_ext_priv_value(_adapter *padapter)
 	pmlmeext->action_public_dialog_token = 0xff;
 }
 
-void init_mlme_ext_timer(_adapter *padapter)
+static void init_mlme_ext_timer(_adapter *padapter)
 {
 	struct mlme_ext_priv *pmlmeext = &padapter->mlmeextpriv;
 
@@ -626,7 +626,7 @@ void free_mlme_ext_priv(struct mlme_ext_priv *pmlmeext)
 	}
 }
 
-void init_link_mlme_default_rate_set(struct _ADAPTER_LINK *padapter_link)
+static void init_link_mlme_default_rate_set(struct _ADAPTER_LINK *padapter_link)
 {
 	_adapter *padapter = padapter_link->adapter;
 	struct	link_mlme_ext_priv	*pmlmeext = &padapter_link->mlmeextpriv;
@@ -941,7 +941,7 @@ void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 }
 
 #ifdef CONFIG_P2P
-u32 p2p_listen_state_process(_adapter *padapter, unsigned char *da)
+static u32 p2p_listen_state_process(_adapter *padapter, unsigned char *da)
 {
 	bool response = _TRUE;
 	/* ToDo CONFIG_RTW_MLD: [currently primary link only] */
@@ -3857,7 +3857,7 @@ u32 rtw_build_vendor_ie(_adapter *padapter , unsigned char **pframe , u8 mgmt_fr
 #endif
 
 #ifdef CONFIG_ECSA_PHL
-u8 *build_supported_op_class_ie(_adapter *padapter, u8 *pbuf, int *pktlen)
+static u8 *build_supported_op_class_ie(_adapter *padapter, u8 *pbuf, int *pktlen)
 {
 	u8 buf[32];
 	int ie_len = 0;
@@ -3996,7 +3996,7 @@ void issue_probersp_p2p(_adapter *padapter, unsigned char *da)
 
 }
 
-int _issue_probereq_p2p(_adapter *padapter, u8 *da, int wait_ack)
+static int _issue_probereq_p2p(_adapter *padapter, u8 *da, int wait_ack)
 {
 	int ret = _FAIL;
 	struct xmit_frame		*pmgntframe;
@@ -4113,7 +4113,7 @@ inline void issue_probereq_p2p(_adapter *adapter, u8 *da)
 
 #endif /* CONFIG_P2P */
 
-s32 rtw_action_public_decache(union recv_frame *rframe, u8 token_offset)
+static s32 rtw_action_public_decache(union recv_frame *rframe, u8 token_offset)
 {
 	_adapter *adapter = rframe->u.hdr.adapter;
 	struct mlme_ext_priv *mlmeext = &(adapter->mlmeextpriv);
@@ -4138,7 +4138,7 @@ s32 rtw_action_public_decache(union recv_frame *rframe, u8 token_offset)
 	return _SUCCESS;
 }
 
-unsigned int on_action_public_p2p(union recv_frame *precv_frame)
+static unsigned int on_action_public_p2p(union recv_frame *precv_frame)
 {
 	_adapter *padapter = precv_frame->u.hdr.adapter;
 
@@ -4158,7 +4158,7 @@ unsigned int on_action_public_p2p(union recv_frame *precv_frame)
 	return _SUCCESS;
 }
 
-unsigned int on_action_public_vendor(union recv_frame *precv_frame)
+static unsigned int on_action_public_vendor(union recv_frame *precv_frame)
 {
 	unsigned int ret = _FAIL;
 	u8 *pframe = precv_frame->u.hdr.rx_data;
@@ -4190,7 +4190,7 @@ exit:
 	return ret;
 }
 
-unsigned int on_action_public_default(union recv_frame *precv_frame, u8 action)
+static unsigned int on_action_public_default(union recv_frame *precv_frame, u8 action)
 {
 	unsigned int ret = _FAIL;
 	u8 *pframe = precv_frame->u.hdr.rx_data;
@@ -4719,7 +4719,7 @@ unsigned int DoReserved(_adapter *padapter, union recv_frame *precv_frame)
 	return _SUCCESS;
 }
 
-struct xmit_frame *_alloc_mgtxmitframe(struct xmit_priv *pxmitpriv, bool once)
+static struct xmit_frame *_alloc_mgtxmitframe(struct xmit_priv *pxmitpriv, bool once)
 {
 	struct xmit_frame *pmgntframe;
 
@@ -5036,7 +5036,7 @@ s32 dump_mgntframe_and_wait_ack(_adapter *padapter, struct xmit_frame *pmgntfram
 }
 
 #ifdef RTW_PHL_BCN //core ops
-s32 rtw_core_issue_beacon(_adapter *padapter, struct xmit_frame *pmgntframe)
+static s32 rtw_core_issue_beacon(_adapter *padapter, struct xmit_frame *pmgntframe)
 {
 	struct rtw_wifi_role_t *wrole = padapter->phl_role;
 	struct rtw_bcn_info_cmn *bcn_cmn = NULL;
@@ -5107,7 +5107,7 @@ s32 rtw_core_issue_beacon(_adapter *padapter, struct xmit_frame *pmgntframe)
 }
 #endif
 
-int update_hidden_ssid(u8 *ies, u32 ies_len, u8 hidden_ssid_mode)
+static int update_hidden_ssid(u8 *ies, u32 ies_len, u8 hidden_ssid_mode)
 {
 	u8 *ssid_ie;
 	sint ssid_len_ori;
@@ -5142,7 +5142,7 @@ int update_hidden_ssid(u8 *ies, u32 ies_len, u8 hidden_ssid_mode)
 	return len_diff;
 }
 
-u8 *rtw_build_reduced_nb_rpt(_adapter *padapter, struct pkt_attrib *pattrib, u8 *pframe)
+static u8 *rtw_build_reduced_nb_rpt(_adapter *padapter, struct pkt_attrib *pattrib, u8 *pframe)
 {
 	u32 len = 0;
 	len = rtw_phl_build_reduced_nb_rpt(padapter->phl_role, pattrib->adapter_link->wrlink, pframe);
@@ -5807,7 +5807,7 @@ void issue_ml_probersp(_adapter *padapter, struct _ADAPTER_LINK *padapter_link, 
 }
 #endif
 
-int _issue_probereq(_adapter *padapter, struct _ADAPTER_LINK *padapter_link,
+static int _issue_probereq(_adapter *padapter, struct _ADAPTER_LINK *padapter_link,
 		const NDIS_802_11_SSID *pssid, const u8 *da, u8 ch, bool append_wps, int wait_ack)
 {
 	int ret = _FAIL;
@@ -8130,7 +8130,7 @@ void issue_action_BSSCoexistPacket(_adapter *padapter)
 }
 
 /* Spatial Multiplexing Powersave (SMPS) action frame */
-int _issue_action_SM_PS(_adapter *padapter, unsigned char *raddr, u8 NewMimoPsMode, u8 wait_ack)
+static int _issue_action_SM_PS(_adapter *padapter, unsigned char *raddr, u8 NewMimoPsMode, u8 wait_ack)
 {
 
 	int ret = _FAIL;
@@ -9757,7 +9757,7 @@ void update_sta_info(_adapter *padapter, struct sta_info *psta) {
 
 }
 
-void update_sta_trx_nss(_adapter *adapter, struct sta_info *psta)
+static void update_sta_trx_nss(_adapter *adapter, struct sta_info *psta)
 {
 	s8 tx_nss, rx_nss;
 	struct mlme_ext_priv *mlmeext = &adapter->mlmeextpriv;
@@ -9787,7 +9787,7 @@ void update_sta_trx_nss(_adapter *adapter, struct sta_info *psta)
 			psta->phl_sta->macid, tx_nss, rx_nss);
 }
 
-void update_sta_smps_cap(_adapter *adapter, struct sta_info *psta)
+static void update_sta_smps_cap(_adapter *adapter, struct sta_info *psta)
 {
 	struct _ADAPTER_LINK	*adapter_link = psta->padapter_link;
 	struct mlme_ext_priv	*pmlmeext = &adapter->mlmeextpriv;
@@ -9817,7 +9817,7 @@ void update_sta_smps_cap(_adapter *adapter, struct sta_info *psta)
 			psta->phl_sta->asoc_cap.nss_rx);
 }
 
-void update_sta_rate_mask(_adapter *padapter, struct sta_info *psta)
+static void update_sta_rate_mask(_adapter *padapter, struct sta_info *psta)
 {
 	struct registry_priv *registrypriv = &padapter->registrypriv;
 	struct _ADAPTER_LINK *padapter_link = psta->padapter_link;
@@ -10091,7 +10091,7 @@ When station does not receive any packet in MAX_CONTINUAL_NORXPACKET_COUNT*2 sec
 recipient station will teardown the block ack by issuing DELBA frame.
 
 *********************************************************************/
-void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_timer)
+static void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_timer)
 {
 	int	i = 0;
 	int ret = _SUCCESS;
@@ -10129,7 +10129,7 @@ void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_timer)
 	}
 }
 
-u8 chk_ap_is_alive(_adapter *padapter, struct sta_info *psta)
+static u8 chk_ap_is_alive(_adapter *padapter, struct sta_info *psta)
 {
 	u8 ret = _FALSE;
 #ifdef DBG_EXPIRATION_CHK
@@ -10169,7 +10169,7 @@ u8 chk_ap_is_alive(_adapter *padapter, struct sta_info *psta)
 	return ret;
 }
 
-u8 chk_adhoc_peer_is_alive(struct sta_info *psta)
+static u8 chk_adhoc_peer_is_alive(struct sta_info *psta)
 {
 	u8 ret = _TRUE;
 
@@ -10764,7 +10764,7 @@ void addba_timer_hdl(void *ctx)
 }
 
 #ifdef CONFIG_IEEE80211W
-void report_sta_timeout_event(_adapter *padapter, u8 *MacAddr, unsigned short reason)
+static void report_sta_timeout_event(_adapter *padapter, u8 *MacAddr, unsigned short reason)
 {
 	struct cmd_obj *pcmd_obj;
 	u8 *pevtcmd;
@@ -10823,7 +10823,7 @@ void report_sta_timeout_event(_adapter *padapter, u8 *MacAddr, unsigned short re
 	return;
 }
 
-void clnt_sa_query_timeout(_adapter *padapter)
+static void clnt_sa_query_timeout(_adapter *padapter)
 {
 	struct mlme_ext_priv *mlmeext = &(padapter->mlmeextpriv);
 	struct mlme_ext_info *mlmeinfo = &(mlmeext->mlmext_info);
@@ -11959,7 +11959,7 @@ exit:
  *
  * Returns: 0: no ps announcement is doing. 1: ps announcement is doing
  */
-u8 rtw_ps_annc(_adapter *adapter, bool ps)
+static u8 rtw_ps_annc(_adapter *adapter, bool ps)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	_adapter *iface;

--- a/core/rtw_mp.c
+++ b/core/rtw_mp.c
@@ -248,7 +248,7 @@ static void PHY_SetRFPathSwitch_default(
 }
 #endif
 
-void mpt_InitHWConfig(_adapter *adapter)
+static void mpt_InitHWConfig(_adapter *adapter)
 {
 #ifdef CONFIG_RTL8822B
 	if (IS_HARDWARE_TYPE_8822B(adapter)) {
@@ -515,17 +515,17 @@ void rtw_mp_trigger_dpk(_adapter *padapter)
 	rtw_mp_cal_trigger(padapter, RTW_MP_CAL_DPK);
 }
 
-void rtw_mp_trigger_tssi(_adapter *padapter)
+static void rtw_mp_trigger_tssi(_adapter *padapter)
 {
 	rtw_mp_cal_trigger(padapter, RTW_MP_CAL_TSSI);
 }
 
-void rtw_mp_trigger_ch_rfk(_adapter *padapter)
+static void rtw_mp_trigger_ch_rfk(_adapter *padapter)
 {
 	rtw_mp_cal_trigger(padapter, RTW_MP_CAL_CHL_RFK);
 }
 
-void rtw_mp_trigger_dack(_adapter *padapter)
+static void rtw_mp_trigger_dack(_adapter *padapter)
 {
 	rtw_mp_cal_trigger(padapter, RTW_MP_CAL_DACK);
 }
@@ -878,7 +878,7 @@ int rtw_mp_txpoweridx(_adapter *adapter)
 	return _TRUE;
 }
 
-s16 rtw_mp_get_pwr_refcw(_adapter *adapter, u8 rfpath, u8 is_cck)
+static s16 rtw_mp_get_pwr_refcw(_adapter *adapter, u8 rfpath, u8 is_cck)
 {
 	struct rtw_mp_txpwr_arg	ptxpwr_arg;
 	struct mp_priv *pmppriv = &adapter->mppriv;
@@ -895,7 +895,7 @@ s16 rtw_mp_get_pwr_refcw(_adapter *adapter, u8 rfpath, u8 is_cck)
 	return txpwr_refcw_idx;
 }
 
-u16 rtw_mp_get_pwr_ref(_adapter *adapter, u8 rfpath)
+static u16 rtw_mp_get_pwr_ref(_adapter *adapter, u8 rfpath)
 {
 	struct rtw_mp_txpwr_arg	ptxpwr_arg;
 	struct mp_priv *pmppriv = &adapter->mppriv;
@@ -989,7 +989,7 @@ void SetDataRate(_adapter *padapter)
 	return;
 }
 
-void SetTxAGCOffset(_adapter *adapter, u32 ulTxAGCOffset)
+static void SetTxAGCOffset(_adapter *adapter, u32 ulTxAGCOffset)
 {
 	u32 TxAGCOffset_B, TxAGCOffset_C, TxAGCOffset_D, tmpAGC;
 
@@ -2135,7 +2135,7 @@ static u32 rtw_GetPSDData(_adapter *adapter, u32 point)
 	return psd_val;
 }
 
-u8 rtw_mp_phl_psd_cmd(_adapter *padapter, struct rtw_mp_cal_arg	*psd_arg, u8 cmdid)
+static u8 rtw_mp_phl_psd_cmd(_adapter *padapter, struct rtw_mp_cal_arg	*psd_arg, u8 cmdid)
 {
 	struct mp_priv	*pmppriv = &padapter->mppriv;
 	u16 i = 0;

--- a/core/rtw_p2p.c
+++ b/core/rtw_p2p.c
@@ -25,7 +25,7 @@
 	#error "Enable CONFIG_P2P without CONFIG_IOCTL_CFG80211"
 #endif
 
-int is_any_client_associated(_adapter *padapter)
+static int is_any_client_associated(_adapter *padapter)
 {
 	return padapter->stapriv.asoc_list_cnt ? _TRUE : _FALSE;
 }
@@ -1795,7 +1795,7 @@ static void rtw_cfg80211_adjust_p2pie_channel(_adapter *padapter, const u8 *fram
 #endif
 
 #ifdef CONFIG_WFD
-u32 rtw_xframe_build_wfd_ie(struct xmit_frame *xframe)
+static u32 rtw_xframe_build_wfd_ie(struct xmit_frame *xframe)
 {
 	_adapter *adapter = xframe->padapter;
 	struct wifidirect_info *wdinfo = &adapter->wdinfo;
@@ -1873,7 +1873,7 @@ u32 rtw_xframe_build_wfd_ie(struct xmit_frame *xframe)
 }
 #endif /* CONFIG_WFD */
 
-bool rtw_xframe_del_wfd_ie(struct xmit_frame *xframe)
+static bool rtw_xframe_del_wfd_ie(struct xmit_frame *xframe)
 {
 #define DBG_XFRAME_DEL_WFD_IE 0
 	u8 *frame = xframe->buf_addr + TXDESC_OFFSET;
@@ -1945,7 +1945,7 @@ void rtw_xframe_chk_wfd_ie(struct xmit_frame *xframe)
 #endif
 }
 
-u8 *dump_p2p_attr_ch_list(u8 *p2p_ie, uint p2p_ielen, u8 *buf, u32 buf_len)
+static u8 *dump_p2p_attr_ch_list(u8 *p2p_ie, uint p2p_ielen, u8 *buf, u32 buf_len)
 {
 	uint attr_contentlen = 0;
 	u8 *pattr = NULL;
@@ -1999,7 +1999,7 @@ make_str:
 /*
  * return _TRUE if requester is GO, _FALSE if responder is GO
  */
-bool rtw_p2p_nego_intent_compare(u8 req, u8 resp)
+static bool rtw_p2p_nego_intent_compare(u8 req, u8 resp)
 {
 	if (req >> 1 == resp >> 1)
 		return  req & 0x01 ? _TRUE : _FALSE;

--- a/core/rtw_phl.c
+++ b/core/rtw_phl.c
@@ -269,7 +269,7 @@ u8 rtw_hw_get_mac_addr(struct dvobj_priv *dvobj, u8 *hw_mac_addr)
 	return _SUCCESS;
 }
 
-u8 rtw_core_deregister_phl_msg(struct dvobj_priv *dvobj)
+static u8 rtw_core_deregister_phl_msg(struct dvobj_priv *dvobj)
 {
 	enum rtw_phl_status psts = RTW_PHL_STATUS_FAILURE;
 
@@ -651,7 +651,7 @@ static void phl_radar_detect_msg_hdl(struct dvobj_priv *dvobj, struct phl_msg *m
 }
 #endif /* CONFIG_DFS_MASTER */
 
-void core_handler_phl_msg(void *drv_priv, struct phl_msg *msg)
+static void core_handler_phl_msg(void *drv_priv, struct phl_msg *msg)
 {
 	struct dvobj_priv *dvobj = (struct dvobj_priv *)drv_priv;
 	u8 mdl_id = MSG_MDL_ID_FIELD(msg->msg_id);
@@ -740,7 +740,7 @@ void core_handler_phl_msg(void *drv_priv, struct phl_msg *msg)
 	}
 }
 
-u8 rtw_core_register_phl_msg(struct dvobj_priv *dvobj)
+static u8 rtw_core_register_phl_msg(struct dvobj_priv *dvobj)
 {
 	struct phl_msg_receiver ctx = {0};
 	u8 imr[] = {PHL_MDL_RX, PHL_MDL_SER, PHL_MDL_WOW, PHL_MDL_MRC};
@@ -947,7 +947,7 @@ struct rtw_phl_mr_ops rtw_mr_ops = {
 #endif
 };
 
-void rtw_core_register_mr_config(struct dvobj_priv *dvobj)
+static void rtw_core_register_mr_config(struct dvobj_priv *dvobj)
 {
 #ifdef CONFIG_MCC_MODE
 	rtw_mr_ops.mcc_ops->priv = (void *)dvobj;

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -182,7 +182,7 @@ void rtw_free_recv_priv(struct dvobj_priv *dvobj)
 	rtw_intf_free_recv_priv(dvobj);
 }
 
-union recv_frame *_rtw_alloc_recvframe(_queue *pfree_recv_queue)
+static union recv_frame *_rtw_alloc_recvframe(_queue *pfree_recv_queue)
 {
 	union recv_frame  *precvframe;
 	_list	*plist, *phead;
@@ -351,7 +351,7 @@ using spinlock to protect
 
 */
 
-void rtw_free_recvframe_queue(_queue *pframequeue)
+static void rtw_free_recvframe_queue(_queue *pframequeue)
 {
 	union	recv_frame	*precvframe;
 	_list	*plist, *phead;
@@ -393,7 +393,7 @@ u32 rtw_free_uc_swdec_pending_queue(struct dvobj_priv *dvobj)
 }
 #endif
 
-sint recvframe_chkmic(_adapter *adapter,  union recv_frame *precvframe)
+static sint recvframe_chkmic(_adapter *adapter,  union recv_frame *precvframe)
 {
 
 	sint	i, res = _SUCCESS;
@@ -500,7 +500,7 @@ exit:
 /*#define DBG_RX_SW_DECRYPTOR*/
 
 /* decrypt and set the ivlen,icvlen of the recv_frame */
-union recv_frame *decryptor(_adapter *padapter, union recv_frame *precv_frame)
+static union recv_frame *decryptor(_adapter *padapter, union recv_frame *precv_frame)
 {
 
 	struct rx_pkt_attrib *prxattrib = &precv_frame->u.hdr.attrib;
@@ -660,7 +660,7 @@ union recv_frame *decryptor(_adapter *padapter, union recv_frame *precv_frame)
 }
 
 /* ###set the security information in the recv_frame */
-union recv_frame *portctrl(_adapter *adapter, union recv_frame *precv_frame)
+static union recv_frame *portctrl(_adapter *adapter, union recv_frame *precv_frame)
 {
 	u8 *psta_addr = NULL;
 	u8 *ptr;
@@ -1201,7 +1201,7 @@ void count_rx_stats(_adapter *padapter, union recv_frame *prframe, struct sta_in
 	}
 }
 
-sint sta2sta_data_frame(
+static sint sta2sta_data_frame(
 	_adapter *adapter,
 	union recv_frame *precv_frame,
 	struct sta_info **psta
@@ -1271,7 +1271,7 @@ exit:
 
 }
 
-sint ap2sta_data_frame(
+static sint ap2sta_data_frame(
 	_adapter *adapter,
 	union recv_frame *precv_frame,
 	struct sta_info **psta)
@@ -1336,7 +1336,7 @@ exit:
 
 }
 
-sint sta2ap_data_frame(
+static sint sta2ap_data_frame(
 	_adapter *adapter,
 	union recv_frame *precv_frame,
 	struct sta_info **psta)
@@ -1389,7 +1389,7 @@ exit:
 
 }
 
-int rtw_sta_rx_data_validate_hdr(_adapter *adapter, union recv_frame *rframe, struct sta_info **sta)
+static int rtw_sta_rx_data_validate_hdr(_adapter *adapter, union recv_frame *rframe, struct sta_info **sta)
 {
 	struct sta_priv *stapriv = &adapter->stapriv;
 	u8 *myhwaddr = adapter_mac_addr(adapter);
@@ -1527,7 +1527,7 @@ exit:
 	return ret;
 }
 
-int rtw_sta_rx_amsdu_act_check(union recv_frame *rframe
+static int rtw_sta_rx_amsdu_act_check(union recv_frame *rframe
 	, const u8 *da, const u8 *sa)
 {
 	int act = RTW_RX_MSDU_ACT_INDICATE;
@@ -1547,7 +1547,7 @@ int rtw_sta_rx_amsdu_act_check(union recv_frame *rframe
 }
 
 #ifdef CONFIG_AP_MODE
-sint rtw_proccess_pspoll(_adapter *adapter, union recv_frame *precv_frame, struct sta_info *psta)
+static sint rtw_proccess_pspoll(_adapter *adapter, union recv_frame *precv_frame, struct sta_info *psta)
 {
 	u8 *pframe = precv_frame->u.hdr.rx_data;
 	struct rx_pkt_attrib *pattrib = &precv_frame->u.hdr.attrib;
@@ -1661,7 +1661,7 @@ sint rtw_proccess_pspoll(_adapter *adapter, union recv_frame *precv_frame, struc
 	return _SUCCESS;
 }
 #endif /*CONFIG_AP_MODE*/
-sint validate_recv_ctrl_frame(_adapter *padapter, union recv_frame *precv_frame)
+static sint validate_recv_ctrl_frame(_adapter *padapter, union recv_frame *precv_frame)
 {
 	struct rx_pkt_attrib *pattrib = &precv_frame->u.hdr.attrib;
 	struct sta_priv *pstapriv = &padapter->stapriv;
@@ -1988,9 +1988,9 @@ fail:
 }
 #endif /* defined(CONFIG_IEEE80211W) || defined(CONFIG_RTW_MESH) */
 
-s32 recvframe_chk_defrag(_adapter *padapter, union recv_frame **pprecv_frame);
+static s32 recvframe_chk_defrag(_adapter *padapter, union recv_frame **pprecv_frame);
 
-sint validate_recv_mgnt_frame(_adapter *padapter, union recv_frame *precv_frame)
+static sint validate_recv_mgnt_frame(_adapter *padapter, union recv_frame *precv_frame)
 {
 	struct rx_pkt_attrib *pattrib = &precv_frame->u.hdr.attrib;
 	struct sta_info *psta;
@@ -2039,7 +2039,7 @@ exit:
 
 }
 
-sint validate_recv_data_frame(_adapter *adapter, union recv_frame *precv_frame)
+static sint validate_recv_data_frame(_adapter *adapter, union recv_frame *precv_frame)
 {
 	u8 bretry, a4_shift;
 	struct sta_info *psta = NULL;
@@ -2613,7 +2613,7 @@ exit:
 }
 
 #ifdef CONFIG_MP_INCLUDED
-int validate_mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
+static int validate_mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
 {
 	int ret = _SUCCESS;
 	u8 *ptr = precv_frame->u.hdr.rx_data;
@@ -2661,7 +2661,7 @@ int validate_mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
 	return ret;
 }
 
-sint mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
+static sint mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
 {
 	sint ret = _SUCCESS;
 	struct rx_pkt_attrib *pattrib = &precv_frame->u.hdr.attrib;
@@ -2693,7 +2693,7 @@ exit:
 
 #endif
 /* Reture expected handling for LLC */
-enum rtw_rx_llc_hdl rtw_recv_llc_parse(u8 *msdu, u16 msdu_len)
+static enum rtw_rx_llc_hdl rtw_recv_llc_parse(u8 *msdu, u16 msdu_len)
 {
 	u16	eth_type;
 
@@ -2717,7 +2717,7 @@ enum rtw_rx_llc_hdl rtw_recv_llc_parse(u8 *msdu, u16 msdu_len)
 
 
 /* remove the wlanhdr and add the eth_hdr */
-sint wlanhdr_to_ethhdr(union recv_frame *precvframe, enum rtw_rx_llc_hdl llc_hdl)
+static sint wlanhdr_to_ethhdr(union recv_frame *precvframe, enum rtw_rx_llc_hdl llc_hdl)
 {
 	u8 *ptr = get_recvframe_data(precvframe) ; /* point to frame_ctrl field */
 	struct rx_pkt_attrib *pattrib = &precvframe->u.hdr.attrib;
@@ -2858,7 +2858,7 @@ static void recvframe_expand_pkt(
 #endif
 
 /* perform defrag */
-union recv_frame *recvframe_defrag(_adapter *adapter, _queue *defrag_q)
+static union recv_frame *recvframe_defrag(_adapter *adapter, _queue *defrag_q)
 {
 	_list	*plist, *phead;
 	u8	*data, wlanhdr_offset;
@@ -3304,7 +3304,7 @@ static u8 validate_amsdu_content(_adapter *padapter, union recv_frame *prframe,
 
 }
 
-int amsdu_to_msdu(_adapter *padapter, union recv_frame *prframe)
+static int amsdu_to_msdu(_adapter *padapter, union recv_frame *prframe)
 {
 	struct rx_pkt_attrib *rattrib = &prframe->u.hdr.attrib;
 	int	a_len, padding_len;
@@ -3951,7 +3951,7 @@ void rtw_reordering_ctrl_timeout_handler(void *pcontext)
 #endif /* defined(CONFIG_80211N_HT) && defined(CONFIG_RECV_REORDERING_CTRL) */
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24))
-int recv_frame_monitor(_adapter *padapter, union recv_frame *rframe, struct rtw_recv_pkt *rx_req)
+static int recv_frame_monitor(_adapter *padapter, union recv_frame *rframe, struct rtw_recv_pkt *rx_req)
 {
 	int ret = _SUCCESS;
 
@@ -5007,7 +5007,7 @@ void rtw_free_lite_recv_resource(struct dvobj_priv *dvobj)
 #endif
 
 #ifdef RTW_PHL_RX
-void rx_dump_skb(struct sk_buff *skb)
+static void rx_dump_skb(struct sk_buff *skb)
 {
 	int idx=0;
 	u8 *tmp=skb->data;
@@ -5029,7 +5029,7 @@ void rx_dump_skb(struct sk_buff *skb)
 	printk("\n===\n");
 }
 
-void dump_rxreq(_adapter *adapter, union recv_frame *prframe)
+static void dump_rxreq(_adapter *adapter, union recv_frame *prframe)
 {
 
 
@@ -5052,7 +5052,7 @@ void dump_recv_frame(_adapter *adapter, union recv_frame *prframe)
 	printk("bssid=%pM\n", rxattr->bssid);
 }
 
-void core_update_recvframe_pkt( union recv_frame *prframe, struct rtw_recv_pkt *rx_req)
+static void core_update_recvframe_pkt( union recv_frame *prframe, struct rtw_recv_pkt *rx_req)
 {
 	struct rtw_pkt_buf_list *pkt = rx_req->pkt_list;
 	struct sk_buff *skb = prframe->u.hdr.pkt;
@@ -5135,7 +5135,7 @@ static int core_alloc_recvframe_pkt(union recv_frame *prframe,
 	return 0;
 }
 
-void core_update_recvframe_mdata(union recv_frame *prframe, struct rtw_recv_pkt *rx_req)
+static void core_update_recvframe_mdata(union recv_frame *prframe, struct rtw_recv_pkt *rx_req)
 {
 	struct rx_pkt_attrib *prxattrib = &prframe->u.hdr.attrib;
 	struct rtw_r_meta_data *mdata = &rx_req->mdata;
@@ -5341,7 +5341,7 @@ void rx_process_phy_info(union recv_frame *precvframe)
 
 
 /*#define DBG_PHY_INFO*/
-void core_update_recvframe_phyinfo(union recv_frame *prframe, struct rtw_recv_pkt *rx_req)
+static void core_update_recvframe_phyinfo(union recv_frame *prframe, struct rtw_recv_pkt *rx_req)
 {
 	struct rx_pkt_attrib *attrib = &prframe->u.hdr.attrib;
 	struct rtw_phl_ppdu_phy_info *phy_info = &rx_req->phy_info;
@@ -5404,7 +5404,7 @@ void core_update_recvframe_phyinfo(union recv_frame *prframe, struct rtw_recv_pk
 }
 #endif /*RTW_WKARD_CORE_RSSI_V1*/
 
-s32 core_rx_process_amsdu(_adapter *adapter, union recv_frame *prframe)
+static s32 core_rx_process_amsdu(_adapter *adapter, union recv_frame *prframe)
 {
 	if(amsdu_to_msdu(adapter, prframe) != _SUCCESS)
 		return CORE_RX_DROP;
@@ -5412,7 +5412,7 @@ s32 core_rx_process_amsdu(_adapter *adapter, union recv_frame *prframe)
 	return CORE_RX_DONE;
 }
 
-s32 core_rx_process_msdu(_adapter *adapter, union recv_frame *prframe)
+static s32 core_rx_process_msdu(_adapter *adapter, union recv_frame *prframe)
 {
 	struct rx_pkt_attrib *pattrib = &prframe->u.hdr.attrib;
 	u8 *msdu = get_recvframe_data(prframe)
@@ -5554,7 +5554,7 @@ s32 rtw_core_rx_data_pre_process(_adapter *adapter, union recv_frame **prframe)
 	return CORE_RX_CONTINUE;
 }
 
-s32 rtw_core_update_recvframe(struct dvobj_priv *dvobj,
+static s32 rtw_core_update_recvframe(struct dvobj_priv *dvobj,
 	union recv_frame *prframe, struct rtw_recv_pkt *rx_req)
 {
 	u8 *pbuf = NULL;

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -15,6 +15,7 @@
 #define _RTW_RECV_C_
 
 #include <drv_types.h>
+#include "rtw_recv.h"
 
 static void rtw_signal_stat_timer_hdl(void *ctx);
 

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -182,7 +182,7 @@ void rtw_free_recv_priv(struct dvobj_priv *dvobj)
 	rtw_intf_free_recv_priv(dvobj);
 }
 
-union recv_frame *_rtw_alloc_recvframe(_queue *pfree_recv_queue)
+static union recv_frame *_rtw_alloc_recvframe(_queue *pfree_recv_queue)
 {
 	union recv_frame  *precvframe;
 	_list	*plist, *phead;
@@ -351,7 +351,7 @@ using spinlock to protect
 
 */
 
-void rtw_free_recvframe_queue(_queue *pframequeue)
+static void rtw_free_recvframe_queue(_queue *pframequeue)
 {
 	union	recv_frame	*precvframe;
 	_list	*plist, *phead;
@@ -393,7 +393,7 @@ u32 rtw_free_uc_swdec_pending_queue(struct dvobj_priv *dvobj)
 }
 #endif
 
-sint recvframe_chkmic(_adapter *adapter,  union recv_frame *precvframe)
+static sint recvframe_chkmic(_adapter *adapter,  union recv_frame *precvframe)
 {
 
 	sint	i, res = _SUCCESS;
@@ -500,7 +500,7 @@ exit:
 /*#define DBG_RX_SW_DECRYPTOR*/
 
 /* decrypt and set the ivlen,icvlen of the recv_frame */
-union recv_frame *decryptor(_adapter *padapter, union recv_frame *precv_frame)
+static union recv_frame *decryptor(_adapter *padapter, union recv_frame *precv_frame)
 {
 
 	struct rx_pkt_attrib *prxattrib = &precv_frame->u.hdr.attrib;
@@ -660,7 +660,7 @@ union recv_frame *decryptor(_adapter *padapter, union recv_frame *precv_frame)
 }
 
 /* ###set the security information in the recv_frame */
-union recv_frame *portctrl(_adapter *adapter, union recv_frame *precv_frame)
+static union recv_frame *portctrl(_adapter *adapter, union recv_frame *precv_frame)
 {
 	u8 *psta_addr = NULL;
 	u8 *ptr;
@@ -1201,7 +1201,7 @@ void count_rx_stats(_adapter *padapter, union recv_frame *prframe, struct sta_in
 	}
 }
 
-sint sta2sta_data_frame(
+static sint sta2sta_data_frame(
 	_adapter *adapter,
 	union recv_frame *precv_frame,
 	struct sta_info **psta
@@ -1271,7 +1271,7 @@ exit:
 
 }
 
-sint ap2sta_data_frame(
+static sint ap2sta_data_frame(
 	_adapter *adapter,
 	union recv_frame *precv_frame,
 	struct sta_info **psta)
@@ -1336,7 +1336,7 @@ exit:
 
 }
 
-sint sta2ap_data_frame(
+static sint sta2ap_data_frame(
 	_adapter *adapter,
 	union recv_frame *precv_frame,
 	struct sta_info **psta)
@@ -1389,7 +1389,7 @@ exit:
 
 }
 
-int rtw_sta_rx_data_validate_hdr(_adapter *adapter, union recv_frame *rframe, struct sta_info **sta)
+static int rtw_sta_rx_data_validate_hdr(_adapter *adapter, union recv_frame *rframe, struct sta_info **sta)
 {
 	struct sta_priv *stapriv = &adapter->stapriv;
 	u8 *myhwaddr = adapter_mac_addr(adapter);
@@ -1527,7 +1527,7 @@ exit:
 	return ret;
 }
 
-int rtw_sta_rx_amsdu_act_check(union recv_frame *rframe
+static int rtw_sta_rx_amsdu_act_check(union recv_frame *rframe
 	, const u8 *da, const u8 *sa)
 {
 	int act = RTW_RX_MSDU_ACT_INDICATE;
@@ -1547,7 +1547,7 @@ int rtw_sta_rx_amsdu_act_check(union recv_frame *rframe
 }
 
 #ifdef CONFIG_AP_MODE
-sint rtw_proccess_pspoll(_adapter *adapter, union recv_frame *precv_frame, struct sta_info *psta)
+static sint rtw_proccess_pspoll(_adapter *adapter, union recv_frame *precv_frame, struct sta_info *psta)
 {
 	u8 *pframe = precv_frame->u.hdr.rx_data;
 	struct rx_pkt_attrib *pattrib = &precv_frame->u.hdr.attrib;
@@ -1661,7 +1661,7 @@ sint rtw_proccess_pspoll(_adapter *adapter, union recv_frame *precv_frame, struc
 	return _SUCCESS;
 }
 #endif /*CONFIG_AP_MODE*/
-sint validate_recv_ctrl_frame(_adapter *padapter, union recv_frame *precv_frame)
+static sint validate_recv_ctrl_frame(_adapter *padapter, union recv_frame *precv_frame)
 {
 	struct rx_pkt_attrib *pattrib = &precv_frame->u.hdr.attrib;
 	struct sta_priv *pstapriv = &padapter->stapriv;
@@ -1988,9 +1988,9 @@ fail:
 }
 #endif /* defined(CONFIG_IEEE80211W) || defined(CONFIG_RTW_MESH) */
 
-s32 recvframe_chk_defrag(_adapter *padapter, union recv_frame **pprecv_frame);
+static s32 recvframe_chk_defrag(_adapter *padapter, union recv_frame **pprecv_frame);
 
-sint validate_recv_mgnt_frame(_adapter *padapter, union recv_frame *precv_frame)
+static sint validate_recv_mgnt_frame(_adapter *padapter, union recv_frame *precv_frame)
 {
 	struct rx_pkt_attrib *pattrib = &precv_frame->u.hdr.attrib;
 	struct sta_info *psta;
@@ -2039,7 +2039,7 @@ exit:
 
 }
 
-sint validate_recv_data_frame(_adapter *adapter, union recv_frame *precv_frame)
+static sint validate_recv_data_frame(_adapter *adapter, union recv_frame *precv_frame)
 {
 	u8 bretry, a4_shift;
 	struct sta_info *psta = NULL;
@@ -2613,7 +2613,7 @@ exit:
 }
 
 #ifdef CONFIG_MP_INCLUDED
-int validate_mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
+static int validate_mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
 {
 	int ret = _SUCCESS;
 	u8 *ptr = precv_frame->u.hdr.rx_data;
@@ -2661,7 +2661,7 @@ int validate_mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
 	return ret;
 }
 
-sint mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
+static sint mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
 {
 	sint ret = _SUCCESS;
 	struct rx_pkt_attrib *pattrib = &precv_frame->u.hdr.attrib;
@@ -2693,7 +2693,7 @@ exit:
 
 #endif
 /* Reture expected handling for LLC */
-enum rtw_rx_llc_hdl rtw_recv_llc_parse(u8 *msdu, u16 msdu_len)
+static enum rtw_rx_llc_hdl rtw_recv_llc_parse(u8 *msdu, u16 msdu_len)
 {
 	u16	eth_type;
 
@@ -2717,7 +2717,7 @@ enum rtw_rx_llc_hdl rtw_recv_llc_parse(u8 *msdu, u16 msdu_len)
 
 
 /* remove the wlanhdr and add the eth_hdr */
-sint wlanhdr_to_ethhdr(union recv_frame *precvframe, enum rtw_rx_llc_hdl llc_hdl)
+static sint wlanhdr_to_ethhdr(union recv_frame *precvframe, enum rtw_rx_llc_hdl llc_hdl)
 {
 	u8 *ptr = get_recvframe_data(precvframe) ; /* point to frame_ctrl field */
 	struct rx_pkt_attrib *pattrib = &precvframe->u.hdr.attrib;
@@ -2858,7 +2858,7 @@ static void recvframe_expand_pkt(
 #endif
 
 /* perform defrag */
-union recv_frame *recvframe_defrag(_adapter *adapter, _queue *defrag_q)
+static union recv_frame *recvframe_defrag(_adapter *adapter, _queue *defrag_q)
 {
 	_list	*plist, *phead;
 	u8	*data, wlanhdr_offset;
@@ -3304,7 +3304,7 @@ static u8 validate_amsdu_content(_adapter *padapter, union recv_frame *prframe,
 
 }
 
-int amsdu_to_msdu(_adapter *padapter, union recv_frame *prframe)
+static int amsdu_to_msdu(_adapter *padapter, union recv_frame *prframe)
 {
 	struct rx_pkt_attrib *rattrib = &prframe->u.hdr.attrib;
 	int	a_len, padding_len;
@@ -3953,7 +3953,7 @@ void rtw_reordering_ctrl_timeout_handler(void *pcontext)
 #endif /* defined(CONFIG_80211N_HT) && defined(CONFIG_RECV_REORDERING_CTRL) */
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24))
-int recv_frame_monitor(_adapter *padapter, union recv_frame *rframe, struct rtw_recv_pkt *rx_req)
+static int recv_frame_monitor(_adapter *padapter, union recv_frame *rframe, struct rtw_recv_pkt *rx_req)
 {
 	int ret = _SUCCESS;
 
@@ -5009,7 +5009,7 @@ void rtw_free_lite_recv_resource(struct dvobj_priv *dvobj)
 #endif
 
 #ifdef RTW_PHL_RX
-void rx_dump_skb(struct sk_buff *skb)
+static void rx_dump_skb(struct sk_buff *skb)
 {
 	int idx=0;
 	u8 *tmp=skb->data;
@@ -5031,7 +5031,7 @@ void rx_dump_skb(struct sk_buff *skb)
 	printk("\n===\n");
 }
 
-void dump_rxreq(_adapter *adapter, union recv_frame *prframe)
+static void dump_rxreq(_adapter *adapter, union recv_frame *prframe)
 {
 
 
@@ -5054,7 +5054,7 @@ void dump_recv_frame(_adapter *adapter, union recv_frame *prframe)
 	printk("bssid=%pM\n", rxattr->bssid);
 }
 
-void core_update_recvframe_pkt( union recv_frame *prframe, struct rtw_recv_pkt *rx_req)
+static void core_update_recvframe_pkt( union recv_frame *prframe, struct rtw_recv_pkt *rx_req)
 {
 	struct rtw_pkt_buf_list *pkt = rx_req->pkt_list;
 	struct sk_buff *skb = prframe->u.hdr.pkt;
@@ -5137,7 +5137,7 @@ static int core_alloc_recvframe_pkt(union recv_frame *prframe,
 	return 0;
 }
 
-void core_update_recvframe_mdata(union recv_frame *prframe, struct rtw_recv_pkt *rx_req)
+static void core_update_recvframe_mdata(union recv_frame *prframe, struct rtw_recv_pkt *rx_req)
 {
 	struct rx_pkt_attrib *prxattrib = &prframe->u.hdr.attrib;
 	struct rtw_r_meta_data *mdata = &rx_req->mdata;
@@ -5343,7 +5343,7 @@ void rx_process_phy_info(union recv_frame *precvframe)
 
 
 /*#define DBG_PHY_INFO*/
-void core_update_recvframe_phyinfo(union recv_frame *prframe, struct rtw_recv_pkt *rx_req)
+static void core_update_recvframe_phyinfo(union recv_frame *prframe, struct rtw_recv_pkt *rx_req)
 {
 	struct rx_pkt_attrib *attrib = &prframe->u.hdr.attrib;
 	struct rtw_phl_ppdu_phy_info *phy_info = &rx_req->phy_info;
@@ -5406,7 +5406,7 @@ void core_update_recvframe_phyinfo(union recv_frame *prframe, struct rtw_recv_pk
 }
 #endif /*RTW_WKARD_CORE_RSSI_V1*/
 
-s32 core_rx_process_amsdu(_adapter *adapter, union recv_frame *prframe)
+static s32 core_rx_process_amsdu(_adapter *adapter, union recv_frame *prframe)
 {
 	if(amsdu_to_msdu(adapter, prframe) != _SUCCESS)
 		return CORE_RX_DROP;
@@ -5414,7 +5414,7 @@ s32 core_rx_process_amsdu(_adapter *adapter, union recv_frame *prframe)
 	return CORE_RX_DONE;
 }
 
-s32 core_rx_process_msdu(_adapter *adapter, union recv_frame *prframe)
+static s32 core_rx_process_msdu(_adapter *adapter, union recv_frame *prframe)
 {
 	struct rx_pkt_attrib *pattrib = &prframe->u.hdr.attrib;
 	u8 *msdu = get_recvframe_data(prframe)
@@ -5556,7 +5556,7 @@ s32 rtw_core_rx_data_pre_process(_adapter *adapter, union recv_frame **prframe)
 	return CORE_RX_CONTINUE;
 }
 
-s32 rtw_core_update_recvframe(struct dvobj_priv *dvobj,
+static s32 rtw_core_update_recvframe(struct dvobj_priv *dvobj,
 	union recv_frame *prframe, struct rtw_recv_pkt *rx_req)
 {
 	u8 *pbuf = NULL;

--- a/core/rtw_rf.c
+++ b/core/rtw_rf.c
@@ -938,7 +938,7 @@ RTW_FUNC_2G_5G_ONLY u8 rtw_get_center_ch(u8 ch, u8 bw, u8 offset)
  * @bw_b: bw of set b
  * @offset_b: offset of set b
  */
-bool _rtw_is_bchbw_grouped(enum band_type band_a, u8 ch_a, u8 bw_a, u8 offset_a
+static bool _rtw_is_bchbw_grouped(enum band_type band_a, u8 ch_a, u8 bw_a, u8 offset_a
 	, enum band_type band_b, u8 ch_b, u8 bw_b, u8 offset_b)
 {
 	bool is_grouped = _FALSE;
@@ -987,7 +987,7 @@ bool rtw_is_bchbw_grouped(enum band_type band_a, u8 ch_a, u8 bw_a, u8 offset_a
  * @g_bw: pointer of the ongoing group bw, may be modified further
  * @g_offset: pointer of the ongoing group offset, may be modified further
  */
-void _rtw_sync_bchbw(enum band_type *req_band, u8 *req_ch, u8 *req_bw, u8 *req_offset
+static void _rtw_sync_bchbw(enum band_type *req_band, u8 *req_ch, u8 *req_bw, u8 *req_offset
 	, enum band_type *g_band, u8 *g_ch, u8 *g_bw, u8 *g_offset)
 {
 	*req_band = *g_band;
@@ -1540,7 +1540,7 @@ void dump_global_op_class(void *sel)
 		dump_global_op_class_ch_single(sel, i);
 }
 
-u8 _rtw_get_op_class_by_bchbw(enum band_type band, u8 ch, u8 bw, u8 offset)
+static u8 _rtw_get_op_class_by_bchbw(enum band_type band, u8 ch, u8 bw, u8 offset)
 {
 	int i;
 	u8 gid = 0; /* invalid */

--- a/core/rtw_scan.c
+++ b/core/rtw_scan.c
@@ -1192,7 +1192,7 @@ static inline void rtw_gen_new_bssid(const u8 *bssid, u8 max_bssid_ind,
 	/*RTW_INFO("%s, %02x,%02x,%02x,%02x,%02x,%02x \n", __func__, new_bssid[0], new_bssid[1], new_bssid[2], new_bssid[3], new_bssid[4], new_bssid[5]);*/
 }
 
-void add_mbssid_network(_adapter *padapter, WLAN_BSSID_EX *ref_bss)
+static void add_mbssid_network(_adapter *padapter, WLAN_BSSID_EX *ref_bss)
 {
 	WLAN_BSSID_EX *pbss;
 	u32 sub_ies_len;
@@ -1897,7 +1897,7 @@ static int rtw_scan_ch_decision(_adapter *padapter, struct rtw_ieee80211_channel
 	return j;
 }
 #ifdef CONFIG_SCAN_BACKOP
-u8 rtw_scan_backop_decision(_adapter *adapter)
+static u8 rtw_scan_backop_decision(_adapter *adapter)
 {
 	struct mlme_ext_priv *mlmeext = &adapter->mlmeextpriv;
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);

--- a/core/rtw_sdio.c
+++ b/core/rtw_sdio.c
@@ -17,6 +17,7 @@
 /*#include "drv_types_sdio.h"*/	/* RTW_SDIO_ADDR_CMD52_GEN */
 #include "drv_types.h"		/* drv_types_sdio.h, struct dvobj_priv and etc. */
 #include "sdio_ops.h"		/* rtw_sdio_raw_read(), rtw_sdio_raw_write() */
+#include "rtw_sdio.h"
 
 /*
  * Description:

--- a/core/rtw_sec_cam.c
+++ b/core/rtw_sec_cam.c
@@ -288,7 +288,7 @@ inline bool rtw_sec_camid_is_drv_forbid(struct cam_ctl_t *cam_ctl, u8 id)
 	return 1;
 }
 
-bool _rtw_sec_camid_is_used(struct cam_ctl_t *cam_ctl, u8 id)
+static bool _rtw_sec_camid_is_used(struct cam_ctl_t *cam_ctl, u8 id)
 {
 	bool ret = _FALSE;
 
@@ -374,7 +374,7 @@ inline bool rtw_camid_is_gk(_adapter *adapter, u8 cam_id)
 	return ret;
 }
 
-bool cam_cache_chk(_adapter *adapter, u8 id, u8 *addr, s16 kid, s8 gk)
+static bool cam_cache_chk(_adapter *adapter, u8 id, u8 *addr, s16 kid, s8 gk)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	bool ret = _FALSE;
@@ -392,7 +392,7 @@ exit:
 	return ret;
 }
 
-s16 _rtw_camid_search(_adapter *adapter, u8 *addr, s16 kid, s8 gk)
+static s16 _rtw_camid_search(_adapter *adapter, u8 *addr, s16 kid, s8 gk)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	struct cam_ctl_t *cam_ctl = &dvobj->cam_ctl;
@@ -431,7 +431,7 @@ s16 rtw_camid_search(_adapter *adapter, u8 *addr, s16 kid, s8 gk)
 	return cam_id;
 }
 
-s16 rtw_get_camid(_adapter *adapter, u8 *addr, s16 kid, u8 gk, bool ext_sec)
+static s16 rtw_get_camid(_adapter *adapter, u8 *addr, s16 kid, u8 gk, bool ext_sec)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	struct cam_ctl_t *cam_ctl = &dvobj->cam_ctl;
@@ -560,7 +560,7 @@ bitmap_handle:
 	return cam_id;
 }
 
-void rtw_camid_set(_adapter *adapter, u8 cam_id)
+static void rtw_camid_set(_adapter *adapter, u8 cam_id)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	struct cam_ctl_t *cam_ctl = &dvobj->cam_ctl;
@@ -636,7 +636,7 @@ inline void rtw_sec_cam_swap(_adapter *adapter, u8 cam_id_a, u8 cam_id_b)
 	}
 }
 
-s16 rtw_get_empty_cam_entry(_adapter *adapter, u8 start_camid)
+static s16 rtw_get_empty_cam_entry(_adapter *adapter, u8 start_camid)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	struct cam_ctl_t *cam_ctl = &dvobj->cam_ctl;

--- a/core/rtw_sreset.c
+++ b/core/rtw_sreset.c
@@ -110,7 +110,7 @@ bool sreset_inprogress(_adapter *padapter)
 #endif
 }
 
-void sreset_restore_security_station(_adapter *padapter, struct _ADAPTER_LINK *padapter_link)
+static void sreset_restore_security_station(_adapter *padapter, struct _ADAPTER_LINK *padapter_link)
 {
 	struct mlme_priv *mlmepriv = &padapter->mlmepriv;
 	struct sta_priv *pstapriv = &padapter->stapriv;
@@ -133,7 +133,7 @@ void sreset_restore_security_station(_adapter *padapter, struct _ADAPTER_LINK *p
 	}
 }
 
-void sreset_restore_network_station(_adapter *padapter)
+static void sreset_restore_network_station(_adapter *padapter)
 {
 	/* ToDo CONFIG_RTW_MLD: [currently primary link only] */
 	struct _ADAPTER_LINK *padapter_link = GET_PRIMARY_LINK(padapter);
@@ -186,7 +186,7 @@ void sreset_restore_network_station(_adapter *padapter)
 }
 
 
-void sreset_restore_network_status(_adapter *padapter)
+static void sreset_restore_network_status(_adapter *padapter)
 {
 	struct mlme_priv *mlmepriv = &padapter->mlmepriv;
 

--- a/core/rtw_sta_mgt.c
+++ b/core/rtw_sta_mgt.c
@@ -16,7 +16,7 @@
 
 #include <drv_types.h>
 
-bool test_st_match_rule(_adapter *adapter, u8 *local_naddr, u8 *local_port, u8 *remote_naddr, u8 *remote_port)
+static bool test_st_match_rule(_adapter *adapter, u8 *local_naddr, u8 *local_port, u8 *remote_naddr, u8 *remote_port)
 {
 	if (ntohs(*((u16 *)local_port)) == 5001 || ntohs(*((u16 *)remote_port)) == 5001)
 		return _TRUE;
@@ -1459,7 +1459,7 @@ const char *const _acl_mode_str[RTW_ACL_MODE_MAX] = {
 	"DENY_UNLESS_LISTED",
 };
 
-u8 _rtw_access_ctrl(_adapter *adapter, u8 period, const u8 *mac_addr)
+static u8 _rtw_access_ctrl(_adapter *adapter, u8 period, const u8 *mac_addr)
 {
 	u8 res = _TRUE;
 	_list *list, *head;

--- a/core/rtw_swcrypto.c
+++ b/core/rtw_swcrypto.c
@@ -18,6 +18,7 @@
 #include <aes_wrap.h>
 #include <sha256.h>
 #include <wlancrypto_wrap.h>
+#include "rtw_swcrypto.h"
 
 #if 0 //RTW_PHL_TX: mark un-finished codes for reading
 int _rtw_core_ccmp_encrypt(u8 *key, u32 key_len, uint hdrlen, u8 *phdr, uint datalen, u8 *pdata)

--- a/core/rtw_trx.c
+++ b/core/rtw_trx.c
@@ -17,7 +17,7 @@
 
 
 #ifdef RTW_PHL_TX
-s32 rtw_core_tx_mgmt(_adapter *padapter, struct xmit_frame *pxframe)
+static s32 rtw_core_tx_mgmt(_adapter *padapter, struct xmit_frame *pxframe)
 {
 
 	pxframe->xftype = RTW_TX_DRV_MGMT;

--- a/core/rtw_vht.c
+++ b/core/rtw_vht.c
@@ -38,7 +38,7 @@ const char *const _vht_sup_ch_width_set_str[] = {
 	"BW-RSVD",
 };
 
-void dump_vht_cap_ie_content(void *sel, const u8 *buf, u32 buf_len)
+static void dump_vht_cap_ie_content(void *sel, const u8 *buf, u32 buf_len)
 {
 	if (buf_len != VHT_CAP_IE_LEN) {
 		RTW_PRINT_SEL(sel, "Invalid VHT capability IE len:%d != %d\n", buf_len, VHT_CAP_IE_LEN);
@@ -78,7 +78,7 @@ const char *const _vht_op_ch_width_str[] = {
 	"BW-RSVD",
 };
 
-void dump_vht_op_ie_content(void *sel, const u8 *buf, u32 buf_len)
+static void dump_vht_op_ie_content(void *sel, const u8 *buf, u32 buf_len)
 {
 	if (buf_len != VHT_OP_IE_LEN) {
 		RTW_PRINT_SEL(sel, "Invalid VHT operation IE len:%d != %d\n", buf_len, VHT_OP_IE_LEN);
@@ -703,7 +703,7 @@ u64	rtw_vht_mcs_map_to_bitmap(u8 *mcs_map, u8 nss)
 }
 
 #ifdef CONFIG_BEAMFORMING
-void update_sta_vht_info_apmode_bf_cap(_adapter *padapter, struct sta_info *psta)
+static void update_sta_vht_info_apmode_bf_cap(_adapter *padapter, struct sta_info *psta)
 {
 	struct _ADAPTER_LINK *padapter_link = psta->padapter_link;
 	struct link_mlme_priv	*pmlmepriv = &(padapter_link->mlmepriv);
@@ -1671,7 +1671,7 @@ void rtw_reattach_vht_ies(_adapter *padapter, struct _ADAPTER_LINK *padapter_lin
 }
 
 /* rx_nss: number of rx spatial stream to be used  */
-u8 _issue_op_mode_notify_frame(_adapter *a, struct _ADAPTER_LINK *a_link,
+static u8 _issue_op_mode_notify_frame(_adapter *a, struct _ADAPTER_LINK *a_link,
 		u8 *ra, u8 rx_nss, enum channel_width bw, u8 wait_ack)
 {
 	int ret = _FAIL;

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -197,7 +197,7 @@ s8 rtw_get_sta_tx_nss(_adapter *adapter, struct sta_info *psta)
 	return nss;
 }
 
-unsigned char ratetbl_val_2wifirate(unsigned char rate)
+static unsigned char ratetbl_val_2wifirate(unsigned char rate)
 {
 	unsigned char val = 0;
 
@@ -256,7 +256,7 @@ unsigned char ratetbl_val_2wifirate(unsigned char rate)
 
 }
 
-int is_basicrate(_adapter *padapter, struct _ADAPTER_LINK *padapter_link, unsigned char rate)
+static int is_basicrate(_adapter *padapter, struct _ADAPTER_LINK *padapter_link, unsigned char rate)
 {
 	int i;
 	unsigned char val;
@@ -274,7 +274,7 @@ int is_basicrate(_adapter *padapter, struct _ADAPTER_LINK *padapter_link, unsign
 	return _FALSE;
 }
 
-unsigned int ratetbl2rateset(_adapter *padapter, struct _ADAPTER_LINK *padapter_link,
+static unsigned int ratetbl2rateset(_adapter *padapter, struct _ADAPTER_LINK *padapter_link,
 				unsigned char *rateset)
 {
 	int i;
@@ -1380,7 +1380,7 @@ void	update_ldpc_stbc_cap(struct sta_info *psta)
 #endif /* CONFIG_80211N_HT */
 }
 
-int check_ielen(u8 *start, uint len)
+static int check_ielen(u8 *start, uint len)
 {
 	int left = len;
 	u8 *pos = start;
@@ -1620,7 +1620,7 @@ void rtw_debug_rx_bcn(_adapter *adapter, u8 *pframe, u32 packet_len)
  *	WLAN_EID_CHANNEL_SWITCH
  *	WLAN_EID_PWR_CONSTRAINT
  */
-int _rtw_get_bcn_keys(u8 *cap_info, u32 buf_len, u8 def_ch
+static int _rtw_get_bcn_keys(u8 *cap_info, u32 buf_len, u8 def_ch
 	, struct _ADAPTER_LINK *adapter_link
 	, struct beacon_keys *recv_beacon)
 {

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -56,7 +56,7 @@ void rtw_init_xmit_block(_adapter *padapter)
 	dvobj->xmit_block = XMIT_BLOCK_NONE;
 
 }
-void rtw_free_xmit_block(_adapter *padapter)
+static void rtw_free_xmit_block(_adapter *padapter)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
 
@@ -64,7 +64,7 @@ void rtw_free_xmit_block(_adapter *padapter)
 }
 
 #ifdef RTW_PHL_TX
-u8 alloc_txring(_adapter *padapter)
+static u8 alloc_txring(_adapter *padapter)
 {
 	struct xmit_txreq_buf *ptxreq_buf = NULL;
 	u32 idx, alloc_sz = 0, alloc_sz_txreq = 0;
@@ -115,7 +115,7 @@ u8 alloc_txring(_adapter *padapter)
 	return res;
 }
 
-void free_txring(_adapter *padapter)
+static void free_txring(_adapter *padapter)
 {
 	u32 idx, alloc_sz = 0, alloc_sz_txreq = 0;
 #ifdef CONFIG_CORE_TXSC
@@ -521,7 +521,7 @@ exit:
 	return res;
 }
 
-void  rtw_mfree_xmit_priv_lock(struct xmit_priv *pxmitpriv)
+static void  rtw_mfree_xmit_priv_lock(struct xmit_priv *pxmitpriv)
 {
 	_rtw_spinlock_free(&pxmitpriv->lock);
 	#if 0 /*def CONFIG_XMIT_THREAD_MODE*/
@@ -811,7 +811,7 @@ u8 rtw_get_tx_bw_mode(_adapter *adapter, struct sta_info *sta)
 	return bw;
 }
 
-void rtw_get_adapter_tx_rate_bmp_by_bw(_adapter *adapter, u8 bw, u16 *r_bmp_cck_ofdm, u32 *r_bmp_ht, u64 *r_bmp_vht)
+static void rtw_get_adapter_tx_rate_bmp_by_bw(_adapter *adapter, u8 bw, u16 *r_bmp_cck_ofdm, u32 *r_bmp_ht, u64 *r_bmp_vht)
 {
 /* ToDo */
 #if 0
@@ -858,7 +858,7 @@ void rtw_get_adapter_tx_rate_bmp_by_bw(_adapter *adapter, u8 bw, u16 *r_bmp_cck_
 #endif
 }
 
-void rtw_get_shared_macid_tx_rate_bmp_by_bw(struct dvobj_priv *dvobj, u8 bw, u16 *r_bmp_cck_ofdm, u32 *r_bmp_ht, u64 *r_bmp_vht)
+static void rtw_get_shared_macid_tx_rate_bmp_by_bw(struct dvobj_priv *dvobj, u8 bw, u16 *r_bmp_cck_ofdm, u32 *r_bmp_ht, u64 *r_bmp_vht)
 {
 /* ToDo */
 #if 0
@@ -4945,7 +4945,7 @@ s32 rtw_free_xmitbuf(struct xmit_priv *pxmitpriv, struct xmit_buf *pxmitbuf)
 }
 #endif
 
-void rtw_init_xmitframe(struct xmit_frame *pxframe)
+static void rtw_init_xmitframe(struct xmit_frame *pxframe)
 {
 	if (pxframe !=  NULL) { /* default value setting */
 		#if 0 /*CONFIG_CORE_XMITBUF*/
@@ -4992,7 +4992,7 @@ Must be very very cautious...
 */
 
 #ifdef RTW_PHL_TX
-void core_tx_init_xmitframe(struct xmit_frame *pxframe)
+static void core_tx_init_xmitframe(struct xmit_frame *pxframe)
 {
 	if (!pxframe)
 		return;
@@ -5749,7 +5749,7 @@ void rtw_init_hwxmits(struct hw_xmit *phwxmit, sint entry)
 }
 
 #ifdef CONFIG_BR_EXT
-int rtw_br_client_tx(_adapter *padapter, struct sk_buff **pskb)
+static int rtw_br_client_tx(_adapter *padapter, struct sk_buff **pskb)
 {
 	struct sk_buff *skb = *pskb;
 	/* if(MLME_IS_STA(adapter) */
@@ -6319,17 +6319,17 @@ s32 rtw_xmit(_adapter *padapter, struct sk_buff **ppkt, u16 os_qid)
 u32 test_seq;
 #endif
 
-u8 *get_head_from_txreq(_adapter *padapter, struct xmit_frame *pxframe, u8 frag_idx)
+static u8 *get_head_from_txreq(_adapter *padapter, struct xmit_frame *pxframe, u8 frag_idx)
 {
 	return 0;
 }
 
-u8 *get_tail_from_txreq(_adapter *padapter, struct xmit_frame *pxframe, u8 frag_idx)
+static u8 *get_tail_from_txreq(_adapter *padapter, struct xmit_frame *pxframe, u8 frag_idx)
 {
 	return 0;
 }
 
-void dump_pkt(u8 *start, u32 len)
+static void dump_pkt(u8 *start, u32 len)
 {
 	u32 idx = 0;
 	for (idx = 0; idx < len; idx++) {
@@ -6387,7 +6387,7 @@ u8 *get_txreq_buffer(_adapter *padapter, u8 **txreq, u8 **pkt_list, u8 **head, u
 	return (u8 *)ptxreq_buf;
 }
 
-void get_txreq_resources(_adapter *padapter, struct xmit_frame *pxframe,
+static void get_txreq_resources(_adapter *padapter, struct xmit_frame *pxframe,
 	u8 **txreq, u8 **pkt_list, u8 **head, u8 **tail)
 {
 	u32 offset_head = (sizeof(struct rtw_xmit_req) * RTW_MAX_FRAG_NUM);
@@ -6417,7 +6417,7 @@ void get_txreq_resources(_adapter *padapter, struct xmit_frame *pxframe,
 		*pkt_list = pbuf + offset_list;
 }
 
-void dump_xmitframe_txreq(_adapter *padapter, struct xmit_frame *pxframe)
+static void dump_xmitframe_txreq(_adapter *padapter, struct xmit_frame *pxframe)
 {
 	struct rtw_xmit_req *txreq = pxframe->phl_txreq;
 	u32 idx, idx1 = 0;
@@ -6689,7 +6689,7 @@ static void fill_txreq_list_skb(_adapter *padapter,
 		RTW_WARN("remain req_sz=%d should be zero\n", req_sz);
 }
 
-s32 rtw_core_replace_skb(struct sk_buff **pskb, u32 need_head, u32 need_tail)
+static s32 rtw_core_replace_skb(struct sk_buff **pskb, u32 need_head, u32 need_tail)
 {
 	struct sk_buff *newskb;
 	struct sk_buff *skb = *pskb;
@@ -6706,7 +6706,7 @@ s32 rtw_core_replace_skb(struct sk_buff **pskb, u32 need_head, u32 need_tail)
 }
 
 #ifdef CONFIG_BR_EXT
-s32 core_br_client_tx(_adapter *padapter, struct xmit_frame *pxframe, struct sk_buff **pskb)
+static s32 core_br_client_tx(_adapter *padapter, struct xmit_frame *pxframe, struct sk_buff **pskb)
 {
 	struct xmit_priv *pxmitpriv = &padapter->xmitpriv;
 
@@ -6733,7 +6733,7 @@ s32 core_br_client_tx(_adapter *padapter, struct xmit_frame *pxframe, struct sk_
 }
 #endif
 
-s32 core_tx_update_pkt(_adapter *padapter, struct xmit_frame *pxframe, struct sk_buff **pskb)
+static s32 core_tx_update_pkt(_adapter *padapter, struct xmit_frame *pxframe, struct sk_buff **pskb)
 {
 	struct xmit_priv *pxmitpriv = &padapter->xmitpriv;
 	struct sk_buff *skb_orig = *pskb;
@@ -6747,7 +6747,7 @@ s32 core_tx_update_pkt(_adapter *padapter, struct xmit_frame *pxframe, struct sk
 	return SUCCESS;
 }
 
-s32 core_tx_update_xmitframe(_adapter *padapter,
+static s32 core_tx_update_xmitframe(_adapter *padapter,
 	struct xmit_frame *pxframe, struct sk_buff **pskb, struct sta_info *psta, u8 type)
 {
 	pxframe->xftype = type;
@@ -6798,7 +6798,7 @@ s32 core_tx_update_xmitframe(_adapter *padapter,
 
 
 
-void get_wl_frag_paras(_adapter *padapter, struct xmit_frame *pxframe,
+static void get_wl_frag_paras(_adapter *padapter, struct xmit_frame *pxframe,
 	u32 *frag_perfr, u32 *wl_frags)
 {
 	u32 wl_head, wl_tail, payload_totalsz, payload_fragsz, wl_frag_num;
@@ -6835,7 +6835,7 @@ void get_wl_frag_paras(_adapter *padapter, struct xmit_frame *pxframe,
 #endif
 }
 
-u8 fill_txreq_pkt_perfrag_txos(struct _ADAPTER *padapter,
+static u8 fill_txreq_pkt_perfrag_txos(struct _ADAPTER *padapter,
 			       struct xmit_frame *pxframe,
 			       u32 frag_perfr, u32 wl_frags)
 {
@@ -6979,7 +6979,7 @@ fail:
 }
 
 /* TXREQ_QMGT, MGT_TXREQ_QMGT */
-u8 fill_txreq_pkt_mgmt(_adapter *padapter, struct xmit_frame *pxframe)
+static u8 fill_txreq_pkt_mgmt(_adapter *padapter, struct xmit_frame *pxframe)
 {
 	struct rtw_xmit_req *xf_txreq = NULL;
 	struct rtw_pkt_buf_list *pkt_list = NULL;
@@ -7348,7 +7348,7 @@ static enum rtw_data_rate _rate_drv2phl(struct sta_info *sta, u8 rate)
 	return phl;
 }
 
-void fill_txreq_mdata(_adapter *padapter, struct xmit_frame *pxframe)
+static void fill_txreq_mdata(_adapter *padapter, struct xmit_frame *pxframe)
 {
 	struct rtw_xmit_req *txreq = pxframe->phl_txreq;
 	struct sta_info *psta = pxframe->attrib.psta;
@@ -7612,7 +7612,7 @@ void fill_txreq_mdata(_adapter *padapter, struct xmit_frame *pxframe)
 }
 
 
-void fill_txreq_others(_adapter *padapter, struct xmit_frame *pxframe)
+static void fill_txreq_others(_adapter *padapter, struct xmit_frame *pxframe)
 {
 	struct rtw_xmit_req *txreq = pxframe->phl_txreq;
 	u32 idx = 0;
@@ -7625,7 +7625,7 @@ void fill_txreq_others(_adapter *padapter, struct xmit_frame *pxframe)
 	}
 }
 
-u8 core_wlan_fill_txreq_pre(_adapter *padapter, struct xmit_frame *pxframe)
+static u8 core_wlan_fill_txreq_pre(_adapter *padapter, struct xmit_frame *pxframe)
 {
 	u32 frag_perfr, wl_frags = 0;
 
@@ -7641,7 +7641,7 @@ u8 core_wlan_fill_txreq_pre(_adapter *padapter, struct xmit_frame *pxframe)
 	return _SUCCESS;
 }
 
-void core_wlan_fill_txreq_post(_adapter *padapter, struct xmit_frame *pxframe)
+static void core_wlan_fill_txreq_post(_adapter *padapter, struct xmit_frame *pxframe)
 {
 	fill_txreq_mdata(padapter, pxframe);
 	fill_txreq_others(padapter, pxframe);
@@ -7656,7 +7656,7 @@ void core_wlan_fill_txreq_post(_adapter *padapter, struct xmit_frame *pxframe)
 
 }
 
-void core_wlan_fill_head(_adapter *padapter, struct xmit_frame *pxframe)
+static void core_wlan_fill_head(_adapter *padapter, struct xmit_frame *pxframe)
 {
 	u32 idx = 0;
 	if (pxframe->xftype == RTW_TX_OS) {
@@ -7704,14 +7704,14 @@ void core_wlan_fill_head(_adapter *padapter, struct xmit_frame *pxframe)
 }
 
 
-void core_wlan_fill_tail(_adapter *padapter, struct xmit_frame *pxframe)
+static void core_wlan_fill_tail(_adapter *padapter, struct xmit_frame *pxframe)
 {
 	;
 
 }
 
 
-u8 core_wlan_fill_tkip_mic(_adapter *padapter, struct xmit_frame *pxframe)
+static u8 core_wlan_fill_tkip_mic(_adapter *padapter, struct xmit_frame *pxframe)
 {
 	u8 *llc = NULL;
 	u8 *payload = NULL;
@@ -9475,7 +9475,7 @@ int rtw_sctx_wait(struct submit_ctx *sctx, const char *msg)
 	return ret;
 }
 
-bool rtw_sctx_chk_waring_status(int status)
+static bool rtw_sctx_chk_waring_status(int status)
 {
 	switch (status) {
 	case RTW_SCTX_DONE_UNKNOWN:

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -15,6 +15,7 @@
 #define _RTW_XMIT_C_
 
 #include <drv_types.h>
+#include "rtw_xmit.h"
 
 static u8 P802_1H_OUI[P80211_OUI_LEN] = { 0x00, 0x00, 0xf8 };
 static u8 RFC1042_OUI[P80211_OUI_LEN] = { 0x00, 0x00, 0x00 };

--- a/include/custom_gpio.h
+++ b/include/custom_gpio.h
@@ -13,7 +13,7 @@
  *
  *****************************************************************************/
 #ifndef __CUSTOM_GPIO_H__
-#define __CUSTOM_GPIO_H___
+#define __CUSTOM_GPIO_H__
 
 #include <drv_conf.h>
 #include <osdep_service.h>

--- a/include/osdep_intf.h
+++ b/include/osdep_intf.h
@@ -72,6 +72,7 @@ void rtw_inetaddr_notifier_unregister(void);
 
 u8 rtw_rtnl_lock_needed(struct dvobj_priv *dvobj);
 void rtw_set_rtnl_lock_holder(struct dvobj_priv *dvobj, _thread_hdl_ thd_hdl);
+int rtw_change_ifname(_adapter *padapter, const char *ifname);
 
 #endif /* PLATFORM_LINUX */
 

--- a/include/rtw_br_ext.h
+++ b/include/rtw_br_ext.h
@@ -65,5 +65,11 @@ struct br_ext_info {
 };
 
 void nat25_db_cleanup(_adapter *priv);
+void nat25_db_expire(_adapter *priv);
+int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method);
+int nat25_handle_frame(_adapter *priv, struct sk_buff *skb);
+void dhcp_flag_bcast(_adapter *priv, struct sk_buff *skb);
+void *scdb_findEntry(_adapter *priv, unsigned char *macAddr, unsigned char *ipAddr);
+void netdev_br_init(struct net_device *netdev);
 
 #endif /* _RTW_BR_EXT_H_ */

--- a/include/rtw_ioctl.h
+++ b/include/rtw_ioctl.h
@@ -37,6 +37,10 @@ extern struct iw_handler_def  rtw_handlers_def;
 
 extern void rtw_request_wps_pbc_event(_adapter *padapter);
 
+void indicate_wx_scan_complete_event(_adapter *padapter);
+void rtw_indicate_wx_assoc_event(_adapter *padapter);
+void rtw_indicate_wx_disassoc_event(_adapter *padapter);
+
 #ifdef CONFIG_APPEND_VENDOR_IE_ENABLE
 extern int rtw_vendor_ie_get_raw_data(struct net_device *, u32, char *, u32);
 extern int rtw_vendor_ie_get_data(struct net_device*, int , char*);

--- a/os_dep/linux/custom_gpio_linux.c
+++ b/os_dep/linux/custom_gpio_linux.c
@@ -19,6 +19,7 @@
 /* gspi func & GPIO define */
 #include <mach/gpio.h>/* 0915 */
 #include <mach/board.h>
+#include "custom_gpio.h"
 
 #if !(defined ANDROID_2X)
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -217,7 +217,7 @@ static void rtw_get_chdef_from_nl80211_channel_type(struct ieee80211_channel *ch
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29)) */
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0))
-bool rtw_cfg80211_allow_ch_switch_notify(_adapter *adapter)
+static bool rtw_cfg80211_allow_ch_switch_notify(_adapter *adapter)
 {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0))
 	if ((!MLME_IS_AP(adapter))
@@ -327,14 +327,14 @@ static void rtw_6g_channels_init(struct ieee80211_channel *channels)
 }
 #endif
 
-void rtw_2g_rates_init(struct ieee80211_rate *rates)
+static void rtw_2g_rates_init(struct ieee80211_rate *rates)
 {
 	_rtw_memcpy(rates, rtw_g_rates,
 		sizeof(struct ieee80211_rate) * RTW_G_RATES_NUM
 	);
 }
 
-void rtw_5g_rates_init(struct ieee80211_rate *rates)
+static void rtw_5g_rates_init(struct ieee80211_rate *rates)
 {
 	_rtw_memcpy(rates, rtw_a_rates,
 		sizeof(struct ieee80211_rate) * RTW_A_RATES_NUM
@@ -350,7 +350,7 @@ void rtw_6g_rates_init(struct ieee80211_rate *rates)
 }
 #endif
 
-struct ieee80211_supported_band *rtw_spt_band_alloc(enum band_type band)
+static struct ieee80211_supported_band *rtw_spt_band_alloc(enum band_type band)
 {
 	struct ieee80211_supported_band *spt_band = NULL;
 	int n_channels, n_bitrates;
@@ -418,7 +418,7 @@ exit:
 	return spt_band;
 }
 
-void rtw_spt_band_free(struct ieee80211_supported_band *spt_band)
+static void rtw_spt_band_free(struct ieee80211_supported_band *spt_band)
 {
 	u32 size = 0;
 
@@ -517,7 +517,7 @@ static const struct ieee80211_txrx_stypes
 };
 #endif
 
-NDIS_802_11_NETWORK_INFRASTRUCTURE nl80211_iftype_to_rtw_network_type(enum nl80211_iftype type)
+static NDIS_802_11_NETWORK_INFRASTRUCTURE nl80211_iftype_to_rtw_network_type(enum nl80211_iftype type)
 {
 	switch (type) {
 	case NL80211_IFTYPE_ADHOC:
@@ -552,7 +552,7 @@ NDIS_802_11_NETWORK_INFRASTRUCTURE nl80211_iftype_to_rtw_network_type(enum nl802
 	}
 }
 
-u32 nl80211_iftype_to_rtw_mlme_state(enum nl80211_iftype type)
+static u32 nl80211_iftype_to_rtw_mlme_state(enum nl80211_iftype type)
 {
 	switch (type) {
 	case NL80211_IFTYPE_ADHOC:
@@ -2259,7 +2259,7 @@ static int cfg80211_rtw_set_default_key(struct wiphy *wiphy, struct net_device *
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 30))
-int cfg80211_rtw_set_default_mgmt_key(struct wiphy *wiphy,
+static int cfg80211_rtw_set_default_mgmt_key(struct wiphy *wiphy,
 	RTW_CFG80211_DEV_PARAM_TYPE RTW_CFG80211_DEV_PARAM_NAME
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
 	, int link_id
@@ -2911,7 +2911,7 @@ void rtw_cfg80211_unlink_bss(_adapter *padapter, struct wlan_network *pnetwork)
 }
 
 /* if target wps scan ongoing, target_ssid is filled */
-int rtw_cfg80211_is_target_wps_scan(struct cfg80211_scan_request *scan_req, struct cfg80211_ssid *target_ssid)
+static int rtw_cfg80211_is_target_wps_scan(struct cfg80211_scan_request *scan_req, struct cfg80211_ssid *target_ssid)
 {
 	int ret = 0;
 
@@ -5825,7 +5825,7 @@ const char *_nl80211_mesh_power_mode_str[] = {
 #define nl80211_mesh_power_mode_str(_p) ((_p <= NL80211_MESH_POWER_MAX) ? _nl80211_mesh_power_mode_str[_p] : _nl80211_mesh_power_mode_str[0])
 #endif
 
-void dump_station_parameters(void *sel, struct wiphy *wiphy, const struct station_parameters *params)
+static void dump_station_parameters(void *sel, struct wiphy *wiphy, const struct station_parameters *params)
 {
 #if DBG_RTW_CFG80211_STA_PARAM
 	if (params->supported_rates_len) {
@@ -6329,7 +6329,7 @@ exit:
 	return ret;
 }
 
-struct sta_info *rtw_sta_info_get_by_idx(struct sta_priv *pstapriv, const int idx, u8 *asoc_list_num)
+static struct sta_info *rtw_sta_info_get_by_idx(struct sta_priv *pstapriv, const int idx, u8 *asoc_list_num)
 {
 	_list	*phead, *plist;
 	struct sta_info *psta = NULL;
@@ -10290,7 +10290,7 @@ err:
 }
 
 #if !defined(CONFIG_REGD_SRC_FROM_OS) || (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 4, 0))
-void rtw_cfg80211_update_wiphy_max_txpower(_adapter *adapter, struct wiphy *wiphy)
+static void rtw_cfg80211_update_wiphy_max_txpower(_adapter *adapter, struct wiphy *wiphy)
 {
 	struct ieee80211_supported_band *band;
 	struct ieee80211_channel *channel;
@@ -10753,7 +10753,7 @@ int rtw_hostapd_acs_dump_survey(struct wiphy *wiphy, struct net_device *netdev, 
 
 #if defined(CPTCFG_VERSION) || (KERNEL_VERSION(4, 17, 0) <= LINUX_VERSION_CODE) \
     || defined(CONFIG_KERNEL_PATCH_EXTERNAL_AUTH)
-int cfg80211_rtw_external_auth(struct wiphy *wiphy, struct net_device *dev,
+static int cfg80211_rtw_external_auth(struct wiphy *wiphy, struct net_device *dev,
 	struct cfg80211_external_auth_params *params)
 {
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -1274,7 +1274,7 @@ static int rtw_wx_get_freq(struct net_device *dev,
 	return 0;
 }
 
-u32 wext_mode_to_rtw_mlme_state(union iwreq_data *wrqu)
+static u32 wext_mode_to_rtw_mlme_state(union iwreq_data *wrqu)
 {
 	switch (wrqu->mode) {
 	#ifdef CONFIG_WIFI_MONITOR
@@ -3733,7 +3733,6 @@ exit:
 
 }
 
-extern int rtw_change_ifname(_adapter *padapter, const char *ifname);
 static int rtw_rereg_nd_name(struct net_device *dev,
 			     struct iw_request_info *info,
 			     union iwreq_data *wrqu, char *extra)
@@ -6180,7 +6179,7 @@ _clear_path:
 #endif
 
 #if defined(RTW_PHL_TX) || defined(RTW_PHL_RX) || defined(CONFIG_PHL_TEST_SUITE)
-int rtw_phl_test_set(struct net_device *dev,
+static int rtw_phl_test_set(struct net_device *dev,
 	struct iw_request_info *info, union iwreq_data *wrqu, char *extra)
 {
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -16,6 +16,7 @@
 
 #include <drv_types.h>
 #include <rtw_mp.h>
+#include "rtw_ioctl.h"
 
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 27))

--- a/os_dep/linux/ioctl_mp.c
+++ b/os_dep/linux/ioctl_mp.c
@@ -1515,7 +1515,7 @@ int rtw_mp_psd(struct net_device *dev,
 	return 0;
 }
 
-int rtw_mp_uuid(struct net_device *dev,
+static int rtw_mp_uuid(struct net_device *dev,
 		struct iw_request_info *info,
 		struct iw_point *wrqu, char *extra)
 {
@@ -3735,7 +3735,7 @@ exit:
 
 }
 
-int rtw_mp_gpio(struct net_device *dev,
+static int rtw_mp_gpio(struct net_device *dev,
 		struct iw_request_info *info,
 		struct iw_point *wrqu, char *extra)
 {

--- a/os_dep/linux/mlme_linux.c
+++ b/os_dep/linux/mlme_linux.c
@@ -51,9 +51,6 @@ void Linkdown_workitem_callback(struct work_struct *work)
 }
 #endif
 
-extern void rtw_indicate_wx_assoc_event(_adapter *padapter);
-extern void rtw_indicate_wx_disassoc_event(_adapter *padapter);
-
 void rtw_os_indicate_connect(_adapter *adapter)
 {
 	struct mlme_priv *pmlmepriv = &(adapter->mlmepriv);
@@ -85,7 +82,6 @@ void rtw_os_indicate_connect(_adapter *adapter)
 
 }
 
-extern void indicate_wx_scan_complete_event(_adapter *padapter);
 void rtw_os_indicate_scan_done(_adapter *padapter, bool aborted)
 {
 #ifdef CONFIG_IOCTL_CFG80211

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -132,7 +132,7 @@ static struct net_device_stats *rtw_net_get_stats(struct net_device *pnetdev)
 static const u16 rtw_1d_to_queue[8] = { 2, 3, 3, 2, 1, 1, 0, 0 };
 
 /* Given a data frame determine the 802.1p/1d tag to use. */
-unsigned int rtw_classify8021d(struct sk_buff *skb)
+static unsigned int rtw_classify8021d(struct sk_buff *skb)
 {
 	unsigned int dscp;
 
@@ -290,7 +290,7 @@ void rtw_ndev_notifier_unregister(void)
 	unregister_netdevice_notifier(&rtw_ndev_notifier);
 }
 
-int rtw_ndev_init(struct net_device *dev)
+static int rtw_ndev_init(struct net_device *dev)
 {
 	_adapter *adapter = rtw_netdev_priv(dev);
 
@@ -310,7 +310,7 @@ int rtw_ndev_init(struct net_device *dev)
 	return 0;
 }
 
-void rtw_ndev_uninit(struct net_device *dev)
+static void rtw_ndev_uninit(struct net_device *dev)
 {
 	_adapter *adapter = rtw_netdev_priv(dev);
 
@@ -367,7 +367,7 @@ int rtw_init_netdev_name(struct net_device *pnetdev, const char *ifname)
 	return 0;
 }
 
-void rtw_hook_if_ops(struct net_device *ndev)
+static void rtw_hook_if_ops(struct net_device *ndev)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29))
 	ndev->netdev_ops = &rtw_netdev_ops;
@@ -456,7 +456,7 @@ struct net_device *rtw_init_netdev(_adapter *old_padapter)
 #ifdef CONFIG_PCI_HCI
 #include <rtw_trx_pci.h>
 #endif
-int rtw_os_ndev_alloc(_adapter *adapter)
+static int rtw_os_ndev_alloc(_adapter *adapter)
 {
 	int ret = _FAIL;
 	struct net_device *ndev = NULL;
@@ -642,7 +642,7 @@ static const struct ethtool_ops rtw_ethtool_ops = {
 #endif /* CONFIG_IOCTL_CFG80211 */
 /* For ethtool --- */
 
-int rtw_os_ndev_register(_adapter *adapter, const char *name)
+static int rtw_os_ndev_register(_adapter *adapter, const char *name)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	int ret = _SUCCESS;
@@ -759,7 +759,7 @@ void rtw_os_ndev_deinit(_adapter *adapter)
 	rtw_os_ndev_free(adapter);
 }
 
-int rtw_os_ndevs_alloc(struct dvobj_priv *dvobj)
+static int rtw_os_ndevs_alloc(struct dvobj_priv *dvobj)
 {
 	int i, status = _SUCCESS;
 	_adapter *adapter;
@@ -812,7 +812,7 @@ int rtw_os_ndevs_alloc(struct dvobj_priv *dvobj)
 	return status;
 }
 
-void rtw_os_ndevs_free(struct dvobj_priv *dvobj)
+static void rtw_os_ndevs_free(struct dvobj_priv *dvobj)
 {
 	int i;
 	_adapter *adapter = NULL;
@@ -922,7 +922,7 @@ void rtw_stop_drv_threads(_adapter *padapter)
 }
 #endif
 
-u8 rtw_init_default_value(_adapter *padapter)
+static u8 rtw_init_default_value(_adapter *padapter)
 {
 	u8 ret  = _SUCCESS;
 	struct registry_priv *pregistrypriv = &padapter->registrypriv;
@@ -1445,7 +1445,7 @@ exit:
 }
 
 
-u8 rtw_init_link_default_value(struct _ADAPTER_LINK *padapter_link)
+static u8 rtw_init_link_default_value(struct _ADAPTER_LINK *padapter_link)
 {
 	struct link_security_priv *psecuritypriv = &padapter_link->securitypriv;
 	struct link_mlme_priv *pmlmepriv = &padapter_link->mlmepriv;
@@ -1465,7 +1465,7 @@ u8 rtw_init_link_default_value(struct _ADAPTER_LINK *padapter_link)
 	return ret;
 }
 
-u8 init_adapter_link(_adapter *padapter) {
+static u8 init_adapter_link(_adapter *padapter) {
 	struct _ADAPTER_LINK *padapter_link = NULL;
 	u8 lidx;
 
@@ -1542,7 +1542,7 @@ void rtw_adapter_link_deinit(struct dvobj_priv *dvobj)
 	}
 }
 
-int init_link_capab_from_adapter(_adapter *padapter) {
+static int init_link_capab_from_adapter(_adapter *padapter) {
 	struct _ADAPTER_LINK *padapter_link = NULL;
 	u8 lidx;
 
@@ -2118,7 +2118,7 @@ void rtw_inetaddr_notifier_unregister(void)
 #endif
 }
 
-int rtw_os_ndevs_register(struct dvobj_priv *dvobj)
+static int rtw_os_ndevs_register(struct dvobj_priv *dvobj)
 {
 	int i, status = _SUCCESS;
 	struct registry_priv *regsty = dvobj_to_regsty(dvobj);
@@ -2415,7 +2415,7 @@ int netdev_open(struct net_device *pnetdev)
 	return ret;
 }
 
-int _pm_netdev_open(_adapter *padapter)
+static int _pm_netdev_open(_adapter *padapter)
 {
 	uint status;
 	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
@@ -2460,7 +2460,7 @@ netdev_open_error:
 	return -1;
 
 }
-int _mi_pm_netdev_open(struct net_device *pnetdev)
+static int _mi_pm_netdev_open(struct net_device *pnetdev)
 {
 	int i;
 	int status = 0;
@@ -2482,7 +2482,7 @@ int _mi_pm_netdev_open(struct net_device *pnetdev)
 	return status;
 }
 
-int pm_netdev_open(struct net_device *pnetdev, u8 bnormal)
+static int pm_netdev_open(struct net_device *pnetdev, u8 bnormal)
 {
 	int status = 0;
 
@@ -2586,7 +2586,7 @@ static int netdev_close(struct net_device *pnetdev)
 
 }
 
-int pm_netdev_close(struct net_device *pnetdev, u8 bnormal)
+static int pm_netdev_close(struct net_device *pnetdev, u8 bnormal)
 {
 	int status = 0;
 
@@ -3112,7 +3112,7 @@ int rtw_suspend_ap_wow(_adapter *padapter)
 #endif /* #ifdef CONFIG_AP_WOWLAN */
 
 
-int rtw_suspend_normal(_adapter *padapter)
+static int rtw_suspend_normal(_adapter *padapter)
 {
 	int ret = _SUCCESS;
 
@@ -3458,7 +3458,7 @@ exit:
 }
 #endif /* #ifdef CONFIG_APWOWLAN */
 
-void rtw_mi_resume_process_normal(_adapter *padapter)
+static void rtw_mi_resume_process_normal(_adapter *padapter)
 {
 	int i;
 	_adapter *iface;
@@ -3487,7 +3487,7 @@ void rtw_mi_resume_process_normal(_adapter *padapter)
 	}
 }
 
-int rtw_resume_process_normal(_adapter *padapter)
+static int rtw_resume_process_normal(_adapter *padapter)
 {
 	struct net_device *pnetdev;
 	struct pwrctrl_priv *pwrpriv;

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -138,7 +138,7 @@ int rtw_android_cmdstr_to_num(char *cmdstr)
 	return cmd_num;
 }
 
-int rtw_android_get_rssi(struct net_device *net, char *command, int total_len)
+static int rtw_android_get_rssi(struct net_device *net, char *command, int total_len)
 {
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(net);
 	struct	mlme_priv	*pmlmepriv = &(padapter->mlmepriv);
@@ -153,7 +153,7 @@ int rtw_android_get_rssi(struct net_device *net, char *command, int total_len)
 	return bytes_written;
 }
 
-int rtw_android_get_link_speed(struct net_device *net, char *command, int total_len)
+static int rtw_android_get_link_speed(struct net_device *net, char *command, int total_len)
 {
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(net);
 	int bytes_written = 0;
@@ -165,7 +165,7 @@ int rtw_android_get_link_speed(struct net_device *net, char *command, int total_
 	return bytes_written;
 }
 
-int rtw_android_get_macaddr(struct net_device *net, char *command, int total_len)
+static int rtw_android_get_macaddr(struct net_device *net, char *command, int total_len)
 {
 	int bytes_written = 0;
 
@@ -173,7 +173,7 @@ int rtw_android_get_macaddr(struct net_device *net, char *command, int total_len
 	return bytes_written;
 }
 
-int rtw_android_set_country(struct net_device *net, char *command, int total_len)
+static int rtw_android_set_country(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	char *country_code = command + strlen(android_wifi_cmd_str[ANDROID_WIFI_CMD_COUNTRY]) + 1;
@@ -184,7 +184,7 @@ int rtw_android_set_country(struct net_device *net, char *command, int total_len
 	return (ret == _SUCCESS) ? 0 : -1;
 }
 
-int rtw_android_get_p2p_dev_addr(struct net_device *net, char *command, int total_len)
+static int rtw_android_get_p2p_dev_addr(struct net_device *net, char *command, int total_len)
 {
 	int bytes_written = 0;
 
@@ -195,7 +195,7 @@ int rtw_android_get_p2p_dev_addr(struct net_device *net, char *command, int tota
 	return bytes_written;
 }
 
-int rtw_android_set_block_scan(struct net_device *net, char *command, int total_len)
+static int rtw_android_set_block_scan(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	char *block_value = command + strlen(android_wifi_cmd_str[ANDROID_WIFI_CMD_BLOCK_SCAN]) + 1;
@@ -207,7 +207,7 @@ int rtw_android_set_block_scan(struct net_device *net, char *command, int total_
 	return 0;
 }
 
-int rtw_android_set_block(struct net_device *net, char *command, int total_len)
+static int rtw_android_set_block(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	char *block_value = command + strlen(android_wifi_cmd_str[ANDROID_WIFI_CMD_BLOCK]) + 1;
@@ -219,7 +219,7 @@ int rtw_android_set_block(struct net_device *net, char *command, int total_len)
 	return 0;
 }
 
-int rtw_android_setband(struct net_device *net, char *command, int total_len)
+static int rtw_android_setband(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	char *arg = command + strlen(android_wifi_cmd_str[ANDROID_WIFI_CMD_SETBAND]) + 1;
@@ -232,7 +232,7 @@ int rtw_android_setband(struct net_device *net, char *command, int total_len)
 	return (ret == _SUCCESS) ? 0 : -1;
 }
 
-int rtw_android_getband(struct net_device *net, char *command, int total_len)
+static int rtw_android_getband(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	int bytes_written = 0;
@@ -243,7 +243,7 @@ int rtw_android_getband(struct net_device *net, char *command, int total_len)
 }
 
 #ifdef CONFIG_WFD
-int rtw_android_set_miracast_mode(struct net_device *net, char *command, int total_len)
+static int rtw_android_set_miracast_mode(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	struct wifi_display_info *wfd_info = &adapter->wfd_info;
@@ -279,7 +279,7 @@ exit:
 }
 #endif /* CONFIG_WFD */
 
-int get_int_from_command(char *pcmd)
+static int get_int_from_command(char *pcmd)
 {
 	int i = 0;
 

--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -143,7 +143,7 @@ int dbg_rtw_cfg80211_vendor_cmd_reply(struct sk_buff *skb
 	dbg_rtw_cfg80211_vendor_cmd_reply(skb, MSTAT_FUNC_CFG_VENDOR | MSTAT_TYPE_SKB, __FUNCTION__, __LINE__)
 #else
 
-struct sk_buff *rtw_cfg80211_vendor_event_alloc(
+static struct sk_buff *rtw_cfg80211_vendor_event_alloc(
 	struct wiphy *wiphy, struct wireless_dev *wdev, int len, int event_id, gfp_t gfp)
 {
 	struct sk_buff *skb;
@@ -250,7 +250,7 @@ static int rtw_cfgvendor_send_cmd_reply(struct wiphy *wiphy,
 
 #define MAX_FEATURE_SET_CONCURRRENT_GROUPS  3
 
-u64 rtw_dev_get_feature_set(struct net_device *dev)
+static u64 rtw_dev_get_feature_set(struct net_device *dev)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	u64 feature_set = 0;
@@ -287,7 +287,7 @@ u64 rtw_dev_get_feature_set(struct net_device *dev)
 	return feature_set;
 }
 
-int *rtw_dev_get_feature_set_matrix(struct net_device *dev, int *num)
+static int *rtw_dev_get_feature_set_matrix(struct net_device *dev, int *num)
 {
 	int feature_set_full, mem_needed;
 	int *ret;

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -785,7 +785,7 @@ ssize_t proc_set_led_config(struct file *file, const char __user *buffer, size_t
 #endif /* CONFIG_RTW_LED */
 
 #ifdef CONFIG_AP_MODE
-int proc_get_aid_status(struct seq_file *m, void *v)
+static int proc_get_aid_status(struct seq_file *m, void *v)
 {
 	struct net_device *dev = m->private;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -795,7 +795,7 @@ int proc_get_aid_status(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_aid_status(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_aid_status(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -1900,7 +1900,7 @@ static int proc_get_macaddr_acl(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_macaddr_acl(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_macaddr_acl(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -2214,7 +2214,7 @@ static ssize_t proc_set_dfs_test_case(struct file *file, const char __user *buff
 	return count;
 }
 
-ssize_t proc_set_update_non_ocp(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_update_non_ocp(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -2244,7 +2244,7 @@ exit:
 	return count;
 }
 
-ssize_t proc_set_radar_detect(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_radar_detect(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -2409,7 +2409,7 @@ exit:
 #endif /* CONFIG_DFS_MASTER */
 
 #ifdef CONFIG_80211N_HT
-int proc_get_rx_ampdu_size_limit(struct seq_file *m, void *v)
+static int proc_get_rx_ampdu_size_limit(struct seq_file *m, void *v)
 {
 	struct net_device *dev = m->private;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -2419,7 +2419,7 @@ int proc_get_rx_ampdu_size_limit(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_rx_ampdu_size_limit(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_rx_ampdu_size_limit(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -3162,7 +3162,7 @@ static struct seq_operations seq_ops_txpwr_total_dbm = {
 };
 #endif
 
-int proc_get_mac_addr(struct seq_file *m, void *v)
+static int proc_get_mac_addr(struct seq_file *m, void *v)
 {
 	struct net_device *dev = m->private;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -3536,7 +3536,7 @@ static ssize_t proc_set_napi_th(struct file *file, const char __user *buffer, si
 #endif /* CONFIG_RTW_NAPI_DYNAMIC */
 
 
-ssize_t proc_set_dynamic_agg_enable(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_dynamic_agg_enable(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
@@ -4532,7 +4532,7 @@ exit:
 	return count;
 }
 
-int proc_get_cur_beacon_keys(struct seq_file *m, void *v)
+static int proc_get_cur_beacon_keys(struct seq_file *m, void *v)
 {
 	struct net_device *dev = m->private;
 	_adapter *adapter = rtw_netdev_priv(dev);
@@ -5556,7 +5556,7 @@ static const struct rtw_proc_ops rtw_odm_proc_sseq_fops = {
 #endif
 };
 
-struct proc_dir_entry *rtw_odm_proc_init(struct net_device *dev)
+static struct proc_dir_entry *rtw_odm_proc_init(struct net_device *dev)
 {
 	struct proc_dir_entry *dir_odm = NULL;
 	struct proc_dir_entry *entry = NULL;
@@ -5600,7 +5600,7 @@ exit:
 	return dir_odm;
 }
 
-void rtw_odm_proc_deinit(_adapter  *adapter)
+static void rtw_odm_proc_deinit(_adapter  *adapter)
 {
 	struct proc_dir_entry *dir_odm = NULL;
 	int i;

--- a/os_dep/linux/sdio_intf.c
+++ b/os_dep/linux/sdio_intf.c
@@ -600,7 +600,7 @@ static void sdio_dvobj_deinit(struct sdio_func *func)
 _adapter * g_test_adapter = NULL;
 #endif /* RTW_SUPPORT_PLATFORM_SHUTDOWN */
 
-_adapter *rtw_sdio_primary_adapter_init(struct dvobj_priv *dvobj)
+static _adapter *rtw_sdio_primary_adapter_init(struct dvobj_priv *dvobj)
 {
 	int status = _FAIL;
 	_adapter *padapter = NULL;

--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -203,7 +203,7 @@ static void rtw_regd_override_dfs_state(struct wiphy *wiphy, struct get_chplan_r
 #endif /* CONFIG_RTW_CFG80211_CAC_EVENT */
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0))
-bool rtw_regd_is_wiphy_self_managed(struct wiphy *wiphy)
+static bool rtw_regd_is_wiphy_self_managed(struct wiphy *wiphy)
 {
 	return rtw_rfctl_is_disable_sw_channel_plan(wiphy_to_dvobj(wiphy))
 		|| !REGSTY_REGD_SRC_FROM_OS(dvobj_to_regsty(wiphy_to_dvobj(wiphy)));
@@ -373,7 +373,7 @@ static void rtw_regd_disable_no_20mhz_chs(struct wiphy *wiphy)
 	}
 }
 
-void rtw_update_wiphy_regd(struct wiphy *wiphy, struct get_chplan_resp *chplan, bool rtnl_lock_needed)
+static void rtw_update_wiphy_regd(struct wiphy *wiphy, struct get_chplan_resp *chplan, bool rtnl_lock_needed)
 {
 	struct ieee80211_regdomain *regd;
 	int ret;

--- a/os_dep/linux/xmit_linux.c
+++ b/os_dep/linux/xmit_linux.c
@@ -548,7 +548,7 @@ int rtw_xmit_entry(struct sk_buff *pkt, _nic_hdl pnetdev)
 
 
 #ifdef RTW_PHL_TX
-int rtw_os_is_adapter_ready(_adapter *padapter, struct sk_buff *pkt)
+static int rtw_os_is_adapter_ready(_adapter *padapter, struct sk_buff *pkt)
 {
 
 	if (padapter->registrypriv.mp_mode) {

--- a/os_dep/osdep_service_linux.c
+++ b/os_dep/osdep_service_linux.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _OSDEP_SERVICE_LINUX_C_
 #include <drv_types.h>
+#include "osdep_intf.h"
 
 #ifdef DBG_MEMORY_LEAK
 ATOMIC_T _malloc_cnt = ATOMIC_INIT(0);

--- a/phl/hal_g6/btc/btc_8852b/btc_8852b.c
+++ b/phl/hal_g6/btc/btc_8852b/btc_8852b.c
@@ -474,7 +474,7 @@ u8 _8852b_bt_rssi(struct btc_t *btc, u8 val)
 	return (val);
 }
 
-void _8852b_wl_trx_mask(struct btc_t *btc, u32 type, u8 group, u32 val)
+static void _8852b_wl_trx_mask(struct btc_t *btc, u32 type, u8 group, u32 val)
 {
 	if (btc->hal->chip_id == CHIP_WIFI6_8851B) {
 		if (group > BTC_BT_SS_GROUP)
@@ -531,7 +531,7 @@ void _8852b_wl_req_mac(struct btc_t *btc, u8 mac_id)
 	_write_cx_reg(btc, R_BTC_CFG, val1);
 }
 
-void _8852b_wl_pri(struct btc_t *btc, u8 map, bool state)
+static void _8852b_wl_pri(struct btc_t *btc, u8 map, bool state)
 {
 	u32 reg = 0, bitmap = 0;
 

--- a/phl/hal_g6/btc/hal_btc.c
+++ b/phl/hal_g6/btc/hal_btc.c
@@ -626,7 +626,7 @@ void _set_init_info(struct btc_t *btc)
 	hal_btc_fw_set_drv_info(btc, CXDRVINFO_CTRL);
 }
 
-void _update_role_link_mode(struct btc_t *btc, bool client_joined, u32 noa)
+static void _update_role_link_mode(struct btc_t *btc, bool client_joined, u32 noa)
 {
 	struct btc_wl_role_info *wl_rinfo = &btc->cx.wl.role_info;
 	struct btc_wl_role_info_bpos wl_role = wl_rinfo->role_map.role;
@@ -668,7 +668,7 @@ void _update_role_link_mode(struct btc_t *btc, bool client_joined, u32 noa)
 		 wl_rinfo->connect_cnt, type, client_joined, noa);
 }
 
-u8 _get_role_link_mode(struct btc_t *btc, u8 role)
+static u8 _get_role_link_mode(struct btc_t *btc, u8 role)
 {
 	switch(role) {
 	case PHL_RTYPE_STATION:
@@ -702,7 +702,7 @@ u8 _get_wl_role_idx(struct btc_t *btc, u8 role)
 	return rid; /*cation: return BTC_WL_MAX_ROLE_NUMBER if role not found */
 }
 
-void _set_wl_req_mac(struct btc_t *btc, u8 mac_id)
+static void _set_wl_req_mac(struct btc_t *btc, u8 mac_id)
 {
 	struct btc_wl_info *wl = &btc->cx.wl;
 	struct btc_chip_ops *ops = btc->chip->ops;

--- a/phl/hal_g6/btc/halbtc_action.c
+++ b/phl/hal_g6/btc/halbtc_action.c
@@ -1501,7 +1501,7 @@ void _action_freerun(struct btc_t *btc)
 	_set_policy(btc, BTC_CXP_OFF_EQ0, __func__);
 }
 
-void _action_fddtrain(struct btc_t *btc)
+static void _action_fddtrain(struct btc_t *btc)
 {
 	struct btc_dm *dm = &btc->dm;
 	struct btc_bt_info *bt = &btc->cx.bt;

--- a/phl/hal_g6/btc/halbtc_dbg_cmd.c
+++ b/phl/hal_g6/btc/halbtc_dbg_cmd.c
@@ -1862,7 +1862,7 @@ static void _cmd_set_bt_psd(struct btc_t *btc, u32 *used,
 	_bt_psd_setup(btc, (u8)idx, (u8)type);
 }
 
-s8 _get_bw_att_db(struct btc_t *btc)
+static s8 _get_bw_att_db(struct btc_t *btc)
 {
 	struct btc_wl_info *wl = &btc->cx.wl;
 	s8 bw_att_db = 13;
@@ -2706,7 +2706,7 @@ static u16 _bt_psd_get_tx_rate(struct btc_t *btc)
 	return (plink->tx_rate);
 }
 
-u8 _bt_psd_get_tx_ss_num(struct btc_t *btc)
+static u8 _bt_psd_get_tx_ss_num(struct btc_t *btc)
 {
 	struct btc_wl_link_info *plink = NULL;
 	u8 ss = 0, i;
@@ -2735,7 +2735,7 @@ u8 _bt_psd_get_tx_ss_num(struct btc_t *btc)
 	return ss;
 }
 
-s8 _bt_psd_get_tx_pwr_dbm(struct btc_t *btc, u8 rf_path)
+static s8 _bt_psd_get_tx_pwr_dbm(struct btc_t *btc, u8 rf_path)
 {
 	s16 wl_txp_dbm_tssi;
 	u32 reg_add;

--- a/phl/hal_g6/btc/halbtc_def.c
+++ b/phl/hal_g6/btc/halbtc_def.c
@@ -17,6 +17,7 @@
 #include "hal_btc.h"
 #include "halbtc_fw.h"
 #include "halbtc_action.h"
+#include "halbtc_def.h"
 
 #ifdef CONFIG_BTCOEX
 

--- a/phl/hal_g6/efuse/hal_efuse.c
+++ b/phl/hal_g6/efuse/hal_efuse.c
@@ -31,18 +31,18 @@ c. efuse information query, map size/used bytes...
 #define get_a_die_start_offset(limit_log_size, a_die_size) (limit_log_size - a_die_size)
 
 /* WIFI EFUSE API */
-void efuse_shadow_read_one_byte(struct efuse_t *efuse, u16 offset, u8 *value)
+static void efuse_shadow_read_one_byte(struct efuse_t *efuse, u16 offset, u8 *value)
 {
 	*value = efuse->shadow_map[offset];
 }
 
-void efuse_shadow_read_two_byte(struct efuse_t *efuse, u16 offset, u16 *value)
+static void efuse_shadow_read_two_byte(struct efuse_t *efuse, u16 offset, u16 *value)
 {
 	*value = efuse->shadow_map[offset];
 	*value |= efuse->shadow_map[offset+1] << 8;
 }
 
-void efuse_shadow_read_four_byte(struct efuse_t *efuse, u16 offset, u32 *value)
+static void efuse_shadow_read_four_byte(struct efuse_t *efuse, u16 offset, u32 *value)
 {
 	*value = efuse->shadow_map[offset];
 	*value |= efuse->shadow_map[offset+1] << 8;
@@ -50,18 +50,18 @@ void efuse_shadow_read_four_byte(struct efuse_t *efuse, u16 offset, u32 *value)
 	*value |= efuse->shadow_map[offset+3] << 24;
 }
 
-void efuse_shadow_write_one_byte(struct efuse_t *efuse, u16 offset, u16 value)
+static void efuse_shadow_write_one_byte(struct efuse_t *efuse, u16 offset, u16 value)
 {
 	efuse->shadow_map[offset] = (u8)(value&0x00FF);
 }
 
-void efuse_shadow_write_two_byte(struct efuse_t *efuse, u16 offset, u16 value)
+static void efuse_shadow_write_two_byte(struct efuse_t *efuse, u16 offset, u16 value)
 {
 	efuse->shadow_map[offset] = (u8)(value&0x00FF);
 	efuse->shadow_map[offset+1] = (u8)((value&0xFF00) >> 8);
 }
 
-void efuse_shadow_write_four_byte(struct efuse_t *efuse, u16 offset, u32 value)
+static void efuse_shadow_write_four_byte(struct efuse_t *efuse, u16 offset, u32 value)
 {
 	efuse->shadow_map[offset] = (u8)(value&0x000000FF);
 	efuse->shadow_map[offset+1] = (u8)((value&0x0000FF00) >> 8);
@@ -69,7 +69,7 @@ void efuse_shadow_write_four_byte(struct efuse_t *efuse, u16 offset, u32 value)
 	efuse->shadow_map[offset+3] = (u8)((value&0xFF000000) >> 24);
 }
 
-u32 efuse_check_autoload(struct efuse_t *efuse)
+static u32 efuse_check_autoload(struct efuse_t *efuse)
 {
 	enum rtw_hal_status hal_status = RTW_HAL_STATUS_FAILURE;
 
@@ -81,7 +81,7 @@ u32 efuse_check_autoload(struct efuse_t *efuse)
 	return hal_status;
 }
 
-u32 efuse_hidden_handle(struct efuse_t *efuse)
+static u32 efuse_hidden_handle(struct efuse_t *efuse)
 {
 	enum rtw_hal_status hal_status = RTW_HAL_STATUS_FAILURE;
 
@@ -90,7 +90,7 @@ u32 efuse_hidden_handle(struct efuse_t *efuse)
 	return hal_status;
 }
 
-enum rtw_hal_status efuse_set_hw_cap(struct efuse_t *efuse)
+static enum rtw_hal_status efuse_set_hw_cap(struct efuse_t *efuse)
 {
 	enum rtw_hal_status status = RTW_HAL_STATUS_FAILURE;
 	struct rtw_hal_com_t *hal_com = efuse->hal_com;
@@ -161,7 +161,7 @@ enum rtw_hal_status efuse_set_hw_cap(struct efuse_t *efuse)
  *     RFE_41(efuse_x02CA=0x29): 1T1R(Tx/Rx@pathB)
  *
  */
-void efuse_compatible_chk(struct efuse_t *efuse)
+static void efuse_compatible_chk(struct efuse_t *efuse)
 {
 	rtw_hal_rf_rfe_ant_num_chk(efuse->hal_com);
 }
@@ -192,7 +192,7 @@ enum rtw_hal_status rtw_efuse_shadow_load(void *efuse, bool is_limit)
 	return status;
 }
 
-enum rtw_hal_status rtw_efuse_shadow_file_load(void *efuse, char *ic_name, bool is_limit)
+static enum rtw_hal_status rtw_efuse_shadow_file_load(void *efuse, char *ic_name, bool is_limit)
 {
 	enum rtw_hal_status status = RTW_HAL_STATUS_SUCCESS;
 
@@ -421,7 +421,7 @@ enum rtw_hal_status rtw_efuse_shadow2buf(void *efuse, u8 *destbuf, u16 buflen)
 	return status;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 efuse_map_buf2shadow(struct efuse_t *efuse, u8 *srcbuf, u16 buflen)
 {
 	enum rtw_hal_status status = RTW_HAL_STATUS_SUCCESS;
@@ -433,7 +433,7 @@ efuse_map_buf2shadow(struct efuse_t *efuse, u8 *srcbuf, u16 buflen)
 	return status;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 efuse_file_map2version(struct efuse_t *efuse, u8 *srcbuf, u16 buflen)
 {
 	enum rtw_hal_status status = RTW_HAL_STATUS_SUCCESS;
@@ -446,7 +446,7 @@ efuse_file_map2version(struct efuse_t *efuse, u8 *srcbuf, u16 buflen)
 	return status;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 efuse_file_mask2buf(struct efuse_t *efuse, u8 *srcbuf, u16 buflen)
 {
 	enum rtw_hal_status status = RTW_HAL_STATUS_FAILURE;
@@ -461,7 +461,7 @@ efuse_file_mask2buf(struct efuse_t *efuse, u8 *srcbuf, u16 buflen)
 	return status;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 efuse_file_mask2version(struct efuse_t *efuse, u8 *srcbuf, u16 buflen)
 {
 	enum rtw_hal_status status = RTW_HAL_STATUS_FAILURE;
@@ -1050,18 +1050,18 @@ void rtw_efuse_deinit(struct rtw_hal_com_t *hal_com, void *efuse)
 }
 
 /* BT EFUSE API */
-void efuse_bt_shadow_read_one_byte(struct efuse_t *efuse, u16 offset, u8 *value)
+static void efuse_bt_shadow_read_one_byte(struct efuse_t *efuse, u16 offset, u8 *value)
 {
    *value = efuse->bt_shadow_map[offset];
 }
 
-void efuse_bt_shadow_read_two_byte(struct efuse_t *efuse, u16 offset, u16 *value)
+static void efuse_bt_shadow_read_two_byte(struct efuse_t *efuse, u16 offset, u16 *value)
 {
    *value = efuse->bt_shadow_map[offset];
    *value |= efuse->bt_shadow_map[offset+1] << 8;
 }
 
-void efuse_bt_shadow_read_four_byte(struct efuse_t *efuse, u16 offset, u32 *value)
+static void efuse_bt_shadow_read_four_byte(struct efuse_t *efuse, u16 offset, u32 *value)
 {
    *value = efuse->bt_shadow_map[offset];
    *value |= efuse->bt_shadow_map[offset+1] << 8;
@@ -1069,18 +1069,18 @@ void efuse_bt_shadow_read_four_byte(struct efuse_t *efuse, u16 offset, u32 *valu
    *value |= efuse->bt_shadow_map[offset+3] << 24;
 }
 
-void efuse_bt_shadow_write_one_byte(struct efuse_t *efuse, u16 offset, u16 value)
+static void efuse_bt_shadow_write_one_byte(struct efuse_t *efuse, u16 offset, u16 value)
 {
    efuse->bt_shadow_map[offset] = (u8)(value&0x00FF);
 }
 
-void efuse_bt_shadow_write_two_byte(struct efuse_t *efuse, u16 offset, u16 value)
+static void efuse_bt_shadow_write_two_byte(struct efuse_t *efuse, u16 offset, u16 value)
 {
    efuse->bt_shadow_map[offset] = (u8)(value&0x00FF);
    efuse->bt_shadow_map[offset+1] = (u8)((value&0xFF00) >> 8);
 }
 
-void efuse_bt_shadow_write_four_byte(struct efuse_t *efuse, u16 offset, u32 value)
+static void efuse_bt_shadow_write_four_byte(struct efuse_t *efuse, u16 offset, u32 value)
 {
    efuse->bt_shadow_map[offset] = (u8)(value&0x000000FF);
    efuse->bt_shadow_map[offset+1] = (u8)((value&0x0000FF00) >> 8);
@@ -1252,7 +1252,7 @@ enum rtw_hal_status rtw_efuse_bt_shadow2buf(void *efuse, u8 *destbuf, u16 buflen
 	return status;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 efuse_bt_map_buf2shadow(struct efuse_t *efuse, u8 *srcbuf, u16 buflen)
 {
 	enum rtw_hal_status status = RTW_HAL_STATUS_FAILURE;
@@ -1265,7 +1265,7 @@ efuse_bt_map_buf2shadow(struct efuse_t *efuse, u8 *srcbuf, u16 buflen)
 	return status;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 efuse_bt_file_mask2buf(struct efuse_t *efuse, u8 *srcbuf, u16 buflen)
 {
 	enum rtw_hal_status status = RTW_HAL_STATUS_FAILURE;

--- a/phl/hal_g6/hal_api.c
+++ b/phl/hal_g6/hal_api.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_API_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 enum rtw_hal_status rtw_hal_get_tsf(void *hal, enum phl_band_idx band,
 					u8 port, u32 *tsf_h, u32 *tsf_l)

--- a/phl/hal_g6/hal_api.h
+++ b/phl/hal_g6/hal_api.h
@@ -993,7 +993,7 @@ void rtw_hal_final_cap_decision(struct rtw_phl_com_t *phl_com, void *hal);
 /* Power Save APIs */
 enum rtw_hal_status
 rtw_hal_ps_pwr_lvl_cfg(struct rtw_phl_com_t *phl_com, void *hal,
-			u32 req_pwr_lvl);
+			u8 req_pwr_lvl);
 enum rtw_hal_status
 rtw_hal_ps_lps_cfg(void *hal, struct rtw_hal_lps_info *lps_info);
 enum rtw_hal_status

--- a/phl/hal_g6/hal_api_bb.c
+++ b/phl/hal_g6/hal_api_bb.c
@@ -19,6 +19,7 @@
 
 //kevin-cmd
 #include "phy/bb/halbb_hw_cfg_ex.h"
+#include "hal_api.h"
 
 void rtw_hal_bb_bb_reset_cmn(struct hal_info_t *hal_info, bool en, enum phl_phy_idx phy_idx)
 {

--- a/phl/hal_g6/hal_api_bb.c
+++ b/phl/hal_g6/hal_api_bb.c
@@ -548,7 +548,7 @@ rtw_hal_bb_get_efuse_info(struct rtw_hal_com_t *hal_com,
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
-u8 hal_get_primary_channel_idx(u8 pri_ch,
+static u8 hal_get_primary_channel_idx(u8 pri_ch,
 				u8 central_ch, enum channel_width bw,
 				enum chan_offset bw_offset)
 {
@@ -1631,7 +1631,7 @@ u32 rtw_hal_bb_process_c2h(void *hal, struct rtw_c2h_info *c2h, struct c2h_evt_m
 #endif
 }
 
-u16 rtw_hal_bb_get_su_rx_rate(struct rtw_hal_com_t *hal_com,
+static u16 rtw_hal_bb_get_su_rx_rate(struct rtw_hal_com_t *hal_com,
 				enum phl_band_idx band_idx)
 {
 	struct hal_info_t *hal_info = (struct hal_info_t *)(hal_com->hal_priv);

--- a/phl/hal_g6/hal_api_btc.c
+++ b/phl/hal_g6/hal_api_btc.c
@@ -15,6 +15,7 @@
 #define _HAL_API_BTC_C_
 #include "hal_headers.h"
 #include "btc/hal_btc.h"
+#include "hal_api.h"
 
 #ifdef CONFIG_BTCOEX
 /*******************************************

--- a/phl/hal_g6/hal_api_efuse.c
+++ b/phl/hal_g6/hal_api_efuse.c
@@ -15,6 +15,7 @@
 #define _HAL_API_EFUSE_C_
 #include "hal_headers.h"
 #include "efuse/hal_efuse_export.h"
+#include "hal_api.h"
 
 /*WIFI Efuse*/
 enum rtw_hal_status

--- a/phl/hal_g6/hal_api_efuse.c
+++ b/phl/hal_g6/hal_api_efuse.c
@@ -405,7 +405,7 @@ enum rtw_hal_status rtw_hal_efuse_renew(
 	return status;
 }
 
-void hal_efuse_dump_wifi_map(
+static void hal_efuse_dump_wifi_map(
 	struct hal_info_t *hal_info,
 	u32 *used_len,
 	char *output,
@@ -465,7 +465,7 @@ exit:
 	*out_len = _out_len;
 }
 
-void hal_efuse_dump_wifi_logic_map(
+static void hal_efuse_dump_wifi_logic_map(
 	struct hal_info_t *hal_info,
 	u32 *used_len,
 	char *output,
@@ -525,7 +525,7 @@ exit:
 	*out_len = _out_len;
 }
 
-void hal_efuse_cmd_parser(
+static void hal_efuse_cmd_parser(
 	struct hal_info_t *hal_info,
 	char input[][MAX_ARGV],
 	u32 input_num,
@@ -582,7 +582,7 @@ void hal_efuse_cmd_parser(
 	}
 }
 
-s32 hal_efuse_cmd(
+static s32 hal_efuse_cmd(
 	struct hal_info_t *hal_info,
 	char *input,
 	char *output,

--- a/phl/hal_g6/hal_api_mac.c
+++ b/phl/hal_g6/hal_api_mac.c
@@ -116,7 +116,7 @@ rtw_hal_mac_watchdog(struct hal_info_t *hal_info, struct rtw_phl_com_t *phl_com)
 	#endif
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 hal_mac_set_chip_id(struct rtw_hal_com_t *hal_com,
 			struct mac_ax_adapter *mac)
 {
@@ -962,7 +962,7 @@ static void hal_mac_event_notify(void *h,
 
 }
 
-struct rtw_h2c_pkt *hal_query_h2c_pkt(struct rtw_phl_com_t *phl_com,
+static struct rtw_h2c_pkt *hal_query_h2c_pkt(struct rtw_phl_com_t *phl_com,
 									  struct rtw_hal_com_t *hal_com,
 									  enum h2c_buf_class type)
 {
@@ -996,7 +996,7 @@ struct rtw_h2c_pkt *hal_query_h2c_pkt(struct rtw_phl_com_t *phl_com,
 	return h2c_pkt;
 }
 
-enum rtw_hal_status hal_pltfm_tx(struct rtw_phl_com_t *phl_com,
+static enum rtw_hal_status hal_pltfm_tx(struct rtw_phl_com_t *phl_com,
 								 struct rtw_hal_com_t *hal_com,
 								 struct rtw_h2c_pkt *pkt)
 {
@@ -1010,7 +1010,7 @@ enum rtw_hal_status hal_pltfm_tx(struct rtw_phl_com_t *phl_com,
 	return hstatus;
 }
 
-void hal_ser_l2_notify(void *phl, void *hal)
+static void hal_ser_l2_notify(void *phl, void *hal)
 {
 	struct rtw_phl_com_t *phl_com = (struct rtw_phl_com_t *)phl;
 
@@ -1126,7 +1126,7 @@ void hal_mac_msg_print(void *p, u8 dbg_level, s8 *fmt, ...)
 }
 
 struct mac_ax_pltfm_cb rtw_plt_cb = {0};
-void rtw_plt_cb_init(void)
+static void rtw_plt_cb_init(void)
 {
 	/* R/W register */
 #ifdef CONFIG_SDIO_HCI
@@ -1277,7 +1277,7 @@ void rtw_hal_mac_get_fw_ver(struct hal_info_t *hal_info, char *ver_str, u16 len)
 #define _IS_FW_READY(hal_info) \
 		(hal_to_mac(hal_info)->sm.fwdl == MAC_AX_FWDL_INIT_RDY)
 
-void hal_mac_print_fw_version(struct hal_info_t *hal_info)
+static void hal_mac_print_fw_version(struct hal_info_t *hal_info)
 {
 	char ver[20] = {0};
 	rtw_hal_mac_get_fw_ver(hal_info, ver, 20);
@@ -3215,7 +3215,7 @@ rtw_hal_mac_hw_rx_resume(struct hal_info_t *hal_info)
 #define FW_PLE_SIZE 0x800
 #define FW_PLE_SEGMENT_SIZE 512 /*Because PHL_PRINT have prefix 5 bytes "PHL: "*/
 
-void
+static void
 _hal_fw_dbg_dump(struct hal_info_t *hal_info, u8 *buffer, u16 bufsize)
 {
 	char str[FW_PLE_SEGMENT_SIZE + 1] = {0};
@@ -3297,7 +3297,7 @@ rtw_hal_mac_trx_init(void *mac, struct hal_init_info_t *init_info)
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
-void _hal_mac_get_ofld_cap(struct rtw_phl_com_t *phl_com, struct hal_info_t *hal_info)
+static void _hal_mac_get_ofld_cap(struct rtw_phl_com_t *phl_com, struct hal_info_t *hal_info)
 {
 #ifdef CONFIG_FW_IO_OFLD_SUPPORT
 	struct mac_ax_adapter *mac = hal_to_mac(hal_info);
@@ -5279,7 +5279,7 @@ rtw_hal_mac_ax_bfee_set_csi_rrsc(void *mac, u8 band, u32 rrsc)
  * @he_rate:
  */
 
-enum rtw_hal_status
+static enum rtw_hal_status
 rtw_hal_mac_ax_bfee_forced_csi_rate(void *mac, struct rtw_phl_stainfo_t *sta,
 	u8 ht_rate, u8 vht_rate, u8 he_rate)
 {
@@ -5516,7 +5516,7 @@ rtw_hal_mac_ax_set_mu_fix_mode(
 }
 
 
-void
+static void
 _hal_mac_fill_mu_sc_tbl_row(u32 *mac_score, void *hal_score)
 {
 	struct hal_mu_score_tbl_score *h_score =
@@ -5577,7 +5577,7 @@ rtw_hal_mac_parse_c2h(void *hal, u8 *buf, u32 buf_len, void *c2h)
  * Required information in (hal_handle_rx_buffer_XXXXX case RX_DESC_PKT_TYPE_PPDU_STATUS),
  * it cannot be used by core/phl/other hal module
  **/
-void
+static void
 _hal_mac_ax_ppdu_sts_to_hal_ppdu_sts(
 	struct mac_ax_ppdu_rpt *mac_ppdu, void *hal_ppdu_sts)
 {
@@ -5617,7 +5617,7 @@ _hal_mac_ax_ppdu_sts_to_hal_ppdu_sts(
  * if any information is required for other core/phl module,
  * copy to rx meta data or hal_info from halmac ax ppdu status.
  **/
-void
+static void
 _hal_mac_ax_ppdu_sts_to_hal_info(struct hal_info_t *hal_info,
 	struct mac_ax_ppdu_rpt *mac_ppdu, void *rx_mdata)
 {
@@ -5998,7 +5998,7 @@ rtw_hal_mac_parse_dfs(struct hal_info_t *hal_info,
 }
 #endif /*CONFIG_PHL_DFS*/
 
-enum rtw_hal_status
+static enum rtw_hal_status
 _hal_mac_get_pkt_ofld(struct hal_info_t *hal_info, u8 *id)
 {
 	struct rtw_hal_com_t *hal_com = hal_info->hal_com;
@@ -6019,7 +6019,7 @@ _hal_mac_get_pkt_ofld(struct hal_info_t *hal_info, u8 *id)
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 _hal_mac_chk_pkt_ofld(struct hal_info_t *hal_info)
 {
 	struct mac_ax_adapter *mac = (struct mac_ax_adapter *)hal_info->mac;
@@ -6048,7 +6048,7 @@ _hal_mac_chk_pkt_ofld(struct hal_info_t *hal_info)
 	}
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 _hal_mac_add_pkt_ofld(struct hal_info_t *hal_info, u8 *pkt, u16 len, u8 *id)
 {
 	struct mac_ax_adapter *mac = (struct mac_ax_adapter *)hal_info->mac;
@@ -6070,7 +6070,7 @@ _hal_mac_add_pkt_ofld(struct hal_info_t *hal_info, u8 *pkt, u16 len, u8 *id)
 	return status;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 _hal_mac_del_pkt_ofld(struct hal_info_t *hal_info, u8 *id)
 {
 	struct mac_ax_adapter *mac = (struct mac_ax_adapter *)hal_info->mac;
@@ -6091,7 +6091,7 @@ _hal_mac_del_pkt_ofld(struct hal_info_t *hal_info, u8 *id)
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 _hal_mac_read_pkt_ofld(struct hal_info_t *hal_info, u8 *id)
 {
 	struct mac_ax_adapter *mac = (struct mac_ax_adapter *)hal_info->mac;
@@ -7201,7 +7201,7 @@ rtw_hal_mac_set_reset_rx_cnt(struct hal_info_t *hal_info, u8 cur_phy_idx)
 	return ret;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 rtw_hal_mac_tx_idle_poll(struct rtw_hal_com_t *hal_com, u8 band_idx)
 {
 	struct hal_info_t *hal = hal_com->hal_priv;
@@ -7243,7 +7243,7 @@ enum rtw_sch_txen_cfg {
 	RTW_TXEN_ALL = 0xFFFF,
 };
 
-enum rtw_hal_status
+static enum rtw_hal_status
 rtw_hal_mac_set_sch_tx_en(struct rtw_hal_com_t *hal_com, u8 band_idx,
 						u16 tx_en, u16 tx_en_mask)
 {
@@ -8564,7 +8564,7 @@ rtw_hal_mac_is_tx_mgnt_empty(struct hal_info_t *hal_info, u8 band, u8 *st)
 
 /* FW Sounding Command */
 /* 1. NDPA Content */
-void _hal_max_ax_snd_cmd_ndpa(struct mac_ax_ndpa_para *mac_ndpa,
+static void _hal_max_ax_snd_cmd_ndpa(struct mac_ax_ndpa_para *mac_ndpa,
 			      struct hal_ndpa_para *hal_ndpa,
 			      bool he, u8 sta_nr)
 {
@@ -8617,7 +8617,7 @@ void _hal_max_ax_snd_cmd_ndpa(struct mac_ax_ndpa_para *mac_ndpa,
 	}
 }
 /* 2-1. BFRP Content - VHT */
-void _hal_max_ax_snd_cmd_bfrp_vht(struct mac_ax_bfrp_para *mac_bfrp,
+static void _hal_max_ax_snd_cmd_bfrp_vht(struct mac_ax_bfrp_para *mac_bfrp,
 				 struct hal_bfrp_para *hal_bfrp, u8 bfrp_num)
 {
 	struct mac_ax_vht_bfrp_para *mac_vht_bfrp = NULL;
@@ -8636,7 +8636,7 @@ void _hal_max_ax_snd_cmd_bfrp_vht(struct mac_ax_bfrp_para *mac_bfrp,
 	}
 }
 /* 2-2. BFRP Content - HE */
-void _hal_max_ax_snd_cmd_bfrp_he(struct mac_ax_bfrp_para *mac_bfrp,
+static void _hal_max_ax_snd_cmd_bfrp_he(struct mac_ax_bfrp_para *mac_bfrp,
 			      struct hal_bfrp_para *hal_bfrp,
 			      u8 num_1, u8 num_2)
 {
@@ -8741,7 +8741,7 @@ void _hal_max_ax_snd_cmd_bfrp_he(struct mac_ax_bfrp_para *mac_bfrp,
 }
 
 /* 2-3 he bfrp f2p cmd */
-void _hal_max_ax_snd_cmd_bfrp_he_f2p(struct mac_ax_snd_f2P *mac_bfrp_f2p,
+static void _hal_max_ax_snd_cmd_bfrp_he_f2p(struct mac_ax_snd_f2P *mac_bfrp_f2p,
 				     struct hal_bfrp_para *hal_bfrp,
 				     u8 num_1, u8 num_2)
 {
@@ -8820,7 +8820,7 @@ void _hal_max_ax_snd_cmd_bfrp_he_f2p(struct mac_ax_snd_f2P *mac_bfrp_f2p,
 
 
 /* 3. WD Content */
-void _hal_max_ax_snd_cmd_wd(struct mac_ax_snd_wd_para *mac_wd,
+static void _hal_max_ax_snd_cmd_wd(struct mac_ax_snd_wd_para *mac_wd,
 			    struct hal_snd_wd_para *hal_wd)
 {
 	PHL_TRACE(COMP_PHL_SOUND, _PHL_INFO_, "==> _hal_max_ax_snd_cmd_wd \n");
@@ -9957,7 +9957,7 @@ enum rtw_hal_status rtw_hal_mac_cfg_rxhci(struct hal_info_t *hal, u8 en)
 }
 
 #ifdef CONFIG_MCC_SUPPORT
-void _hal_mac_mcc_fill_role_info(struct rtw_phl_mcc_role *mcc_role,
+static void _hal_mac_mcc_fill_role_info(struct rtw_phl_mcc_role *mcc_role,
 				struct mac_ax_mcc_role *info)
 {
 	struct rtw_phl_mcc_policy_info *policy = &mcc_role->policy;
@@ -9999,7 +9999,7 @@ void _hal_mac_mcc_fill_role_info(struct rtw_phl_mcc_role *mcc_role,
 		info->courtesy_en, info->courtesy_num, info->courtesy_target);
 }
 
-void _hal_mac_mcc_fill_duration_info(struct rtw_phl_mcc_en_info *en_info,
+static void _hal_mac_mcc_fill_duration_info(struct rtw_phl_mcc_en_info *en_info,
 					struct rtw_phl_mcc_bt_info *bt_info,
 					struct mac_ax_mcc_duration_info *info)
 {
@@ -10020,7 +10020,7 @@ void _hal_mac_mcc_fill_duration_info(struct rtw_phl_mcc_en_info *en_info,
 		info->start_tsf_low);
 }
 
-void _hal_mac_mcc_fill_start_info(u8 group, u8 macid, u32 tsf_high, u32 tsf_low,
+static void _hal_mac_mcc_fill_start_info(u8 group, u8 macid, u32 tsf_high, u32 tsf_low,
 			u8 btc_in_group, u8 old_group_action, u8 old_group,
 			struct mac_ax_mcc_start *info)
 {
@@ -10516,7 +10516,7 @@ exit:
 #define P2P_TYPE_GO 0
 #define P2P_TYPE_GC 1
 
-void _hal_mac_dump_p2p_act_struct(struct mac_ax_p2p_act_info *mac_p2p_info)
+static void _hal_mac_dump_p2p_act_struct(struct mac_ax_p2p_act_info *mac_p2p_info)
 {
 	PHL_TRACE(COMP_PHL_P2PPS, _PHL_INFO_, "[NoA]_hal_mac_dump_p2p_act_struct(): macid = %d\n",
 		mac_p2p_info->macid);
@@ -10540,7 +10540,7 @@ void _hal_mac_dump_p2p_act_struct(struct mac_ax_p2p_act_info *mac_p2p_info)
 		mac_p2p_info->ctw);
 }
 
-void _hal_mac_noa_fill_info(u8 action,
+static void _hal_mac_noa_fill_info(u8 action,
 	struct rtw_phl_noa_desc *desc,
 	u16 macid,
 	struct mac_ax_p2p_act_info *mac_p2p_info)
@@ -10560,7 +10560,7 @@ void _hal_mac_noa_fill_info(u8 action,
 	mac_p2p_info->cnt = desc->count;
 }
 
-enum rtw_hal_status _hal_mac_get_p2p_stat(struct hal_info_t *hal)
+static enum rtw_hal_status _hal_mac_get_p2p_stat(struct hal_info_t *hal)
 {
 	struct mac_ax_adapter *mac = hal_to_mac(hal);
 	u16 loop_cnt;
@@ -10610,7 +10610,7 @@ enum rtw_hal_status rtw_hal_mac_p2p_macid_ctrl(struct hal_info_t *hal,
 	return h_sts;
 }
 
-enum rtw_hal_status _hal_mac_set_p2p_act(struct hal_info_t *hal,
+static enum rtw_hal_status _hal_mac_set_p2p_act(struct hal_info_t *hal,
 	struct mac_ax_p2p_act_info *mac_p2p_info)
 {
 	enum rtw_hal_status h_stat = RTW_HAL_STATUS_FAILURE;

--- a/phl/hal_g6/hal_api_mac.c
+++ b/phl/hal_g6/hal_api_mac.c
@@ -116,7 +116,7 @@ rtw_hal_mac_watchdog(struct hal_info_t *hal_info, struct rtw_phl_com_t *phl_com)
 	#endif
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 hal_mac_set_chip_id(struct rtw_hal_com_t *hal_com,
 			struct mac_ax_adapter *mac)
 {
@@ -964,7 +964,7 @@ static void hal_mac_event_notify(void *h,
 
 }
 
-struct rtw_h2c_pkt *hal_query_h2c_pkt(struct rtw_phl_com_t *phl_com,
+static struct rtw_h2c_pkt *hal_query_h2c_pkt(struct rtw_phl_com_t *phl_com,
 									  struct rtw_hal_com_t *hal_com,
 									  enum h2c_buf_class type)
 {
@@ -998,7 +998,7 @@ struct rtw_h2c_pkt *hal_query_h2c_pkt(struct rtw_phl_com_t *phl_com,
 	return h2c_pkt;
 }
 
-enum rtw_hal_status hal_pltfm_tx(struct rtw_phl_com_t *phl_com,
+static enum rtw_hal_status hal_pltfm_tx(struct rtw_phl_com_t *phl_com,
 								 struct rtw_hal_com_t *hal_com,
 								 struct rtw_h2c_pkt *pkt)
 {
@@ -1012,7 +1012,7 @@ enum rtw_hal_status hal_pltfm_tx(struct rtw_phl_com_t *phl_com,
 	return hstatus;
 }
 
-void hal_ser_l2_notify(void *phl, void *hal)
+static void hal_ser_l2_notify(void *phl, void *hal)
 {
 	struct rtw_phl_com_t *phl_com = (struct rtw_phl_com_t *)phl;
 
@@ -1128,7 +1128,7 @@ void hal_mac_msg_print(void *p, u8 dbg_level, s8 *fmt, ...)
 }
 
 struct mac_ax_pltfm_cb rtw_plt_cb = {0};
-void rtw_plt_cb_init(void)
+static void rtw_plt_cb_init(void)
 {
 	/* R/W register */
 #ifdef CONFIG_SDIO_HCI
@@ -1279,7 +1279,7 @@ void rtw_hal_mac_get_fw_ver(struct hal_info_t *hal_info, char *ver_str, u16 len)
 #define _IS_FW_READY(hal_info) \
 		(hal_to_mac(hal_info)->sm.fwdl == MAC_AX_FWDL_INIT_RDY)
 
-void hal_mac_print_fw_version(struct hal_info_t *hal_info)
+static void hal_mac_print_fw_version(struct hal_info_t *hal_info)
 {
 	char ver[20] = {0};
 	rtw_hal_mac_get_fw_ver(hal_info, ver, 20);
@@ -3217,7 +3217,7 @@ rtw_hal_mac_hw_rx_resume(struct hal_info_t *hal_info)
 #define FW_PLE_SIZE 0x800
 #define FW_PLE_SEGMENT_SIZE 512 /*Because PHL_PRINT have prefix 5 bytes "PHL: "*/
 
-void
+static void
 _hal_fw_dbg_dump(struct hal_info_t *hal_info, u8 *buffer, u16 bufsize)
 {
 	char str[FW_PLE_SEGMENT_SIZE + 1] = {0};
@@ -3299,7 +3299,7 @@ rtw_hal_mac_trx_init(void *mac, struct hal_init_info_t *init_info)
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
-void _hal_mac_get_ofld_cap(struct rtw_phl_com_t *phl_com, struct hal_info_t *hal_info)
+static void _hal_mac_get_ofld_cap(struct rtw_phl_com_t *phl_com, struct hal_info_t *hal_info)
 {
 #ifdef CONFIG_FW_IO_OFLD_SUPPORT
 	struct mac_ax_adapter *mac = hal_to_mac(hal_info);
@@ -5283,7 +5283,7 @@ rtw_hal_mac_ax_bfee_set_csi_rrsc(void *mac, u8 band, u32 rrsc)
  * @he_rate:
  */
 
-enum rtw_hal_status
+static enum rtw_hal_status
 rtw_hal_mac_ax_bfee_forced_csi_rate(void *mac, struct rtw_phl_stainfo_t *sta,
 	u8 ht_rate, u8 vht_rate, u8 he_rate)
 {
@@ -5520,7 +5520,7 @@ rtw_hal_mac_ax_set_mu_fix_mode(
 }
 
 
-void
+static void
 _hal_mac_fill_mu_sc_tbl_row(u32 *mac_score, void *hal_score)
 {
 	struct hal_mu_score_tbl_score *h_score =
@@ -5581,7 +5581,7 @@ rtw_hal_mac_parse_c2h(void *hal, u8 *buf, u32 buf_len, void *c2h)
  * Required information in (hal_handle_rx_buffer_XXXXX case RX_DESC_PKT_TYPE_PPDU_STATUS),
  * it cannot be used by core/phl/other hal module
  **/
-void
+static void
 _hal_mac_ax_ppdu_sts_to_hal_ppdu_sts(
 	struct mac_ax_ppdu_rpt *mac_ppdu, void *hal_ppdu_sts)
 {
@@ -5621,7 +5621,7 @@ _hal_mac_ax_ppdu_sts_to_hal_ppdu_sts(
  * if any information is required for other core/phl module,
  * copy to rx meta data or hal_info from halmac ax ppdu status.
  **/
-void
+static void
 _hal_mac_ax_ppdu_sts_to_hal_info(struct hal_info_t *hal_info,
 	struct mac_ax_ppdu_rpt *mac_ppdu, void *rx_mdata)
 {
@@ -6002,7 +6002,7 @@ rtw_hal_mac_parse_dfs(struct hal_info_t *hal_info,
 }
 #endif /*CONFIG_PHL_DFS*/
 
-enum rtw_hal_status
+static enum rtw_hal_status
 _hal_mac_get_pkt_ofld(struct hal_info_t *hal_info, u8 *id)
 {
 	struct rtw_hal_com_t *hal_com = hal_info->hal_com;
@@ -6023,7 +6023,7 @@ _hal_mac_get_pkt_ofld(struct hal_info_t *hal_info, u8 *id)
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 _hal_mac_chk_pkt_ofld(struct hal_info_t *hal_info)
 {
 	struct mac_ax_adapter *mac = (struct mac_ax_adapter *)hal_info->mac;
@@ -6052,7 +6052,7 @@ _hal_mac_chk_pkt_ofld(struct hal_info_t *hal_info)
 	}
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 _hal_mac_add_pkt_ofld(struct hal_info_t *hal_info, u8 *pkt, u16 len, u8 *id)
 {
 	struct mac_ax_adapter *mac = (struct mac_ax_adapter *)hal_info->mac;
@@ -6074,7 +6074,7 @@ _hal_mac_add_pkt_ofld(struct hal_info_t *hal_info, u8 *pkt, u16 len, u8 *id)
 	return status;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 _hal_mac_del_pkt_ofld(struct hal_info_t *hal_info, u8 *id)
 {
 	struct mac_ax_adapter *mac = (struct mac_ax_adapter *)hal_info->mac;
@@ -6095,7 +6095,7 @@ _hal_mac_del_pkt_ofld(struct hal_info_t *hal_info, u8 *id)
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 _hal_mac_read_pkt_ofld(struct hal_info_t *hal_info, u8 *id)
 {
 	struct mac_ax_adapter *mac = (struct mac_ax_adapter *)hal_info->mac;
@@ -7205,7 +7205,7 @@ rtw_hal_mac_set_reset_rx_cnt(struct hal_info_t *hal_info, u8 cur_phy_idx)
 	return ret;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 rtw_hal_mac_tx_idle_poll(struct rtw_hal_com_t *hal_com, u8 band_idx)
 {
 	struct hal_info_t *hal = hal_com->hal_priv;
@@ -7247,7 +7247,7 @@ enum rtw_sch_txen_cfg {
 	RTW_TXEN_ALL = 0xFFFF,
 };
 
-enum rtw_hal_status
+static enum rtw_hal_status
 rtw_hal_mac_set_sch_tx_en(struct rtw_hal_com_t *hal_com, u8 band_idx,
 						u16 tx_en, u16 tx_en_mask)
 {
@@ -8568,7 +8568,7 @@ rtw_hal_mac_is_tx_mgnt_empty(struct hal_info_t *hal_info, u8 band, u8 *st)
 
 /* FW Sounding Command */
 /* 1. NDPA Content */
-void _hal_max_ax_snd_cmd_ndpa(struct mac_ax_ndpa_para *mac_ndpa,
+static void _hal_max_ax_snd_cmd_ndpa(struct mac_ax_ndpa_para *mac_ndpa,
 			      struct hal_ndpa_para *hal_ndpa,
 			      bool he, u8 sta_nr)
 {
@@ -8621,7 +8621,7 @@ void _hal_max_ax_snd_cmd_ndpa(struct mac_ax_ndpa_para *mac_ndpa,
 	}
 }
 /* 2-1. BFRP Content - VHT */
-void _hal_max_ax_snd_cmd_bfrp_vht(struct mac_ax_bfrp_para *mac_bfrp,
+static void _hal_max_ax_snd_cmd_bfrp_vht(struct mac_ax_bfrp_para *mac_bfrp,
 				 struct hal_bfrp_para *hal_bfrp, u8 bfrp_num)
 {
 	struct mac_ax_vht_bfrp_para *mac_vht_bfrp = NULL;
@@ -8640,7 +8640,7 @@ void _hal_max_ax_snd_cmd_bfrp_vht(struct mac_ax_bfrp_para *mac_bfrp,
 	}
 }
 /* 2-2. BFRP Content - HE */
-void _hal_max_ax_snd_cmd_bfrp_he(struct mac_ax_bfrp_para *mac_bfrp,
+static void _hal_max_ax_snd_cmd_bfrp_he(struct mac_ax_bfrp_para *mac_bfrp,
 			      struct hal_bfrp_para *hal_bfrp,
 			      u8 num_1, u8 num_2)
 {
@@ -8745,7 +8745,7 @@ void _hal_max_ax_snd_cmd_bfrp_he(struct mac_ax_bfrp_para *mac_bfrp,
 }
 
 /* 2-3 he bfrp f2p cmd */
-void _hal_max_ax_snd_cmd_bfrp_he_f2p(struct mac_ax_snd_f2P *mac_bfrp_f2p,
+static void _hal_max_ax_snd_cmd_bfrp_he_f2p(struct mac_ax_snd_f2P *mac_bfrp_f2p,
 				     struct hal_bfrp_para *hal_bfrp,
 				     u8 num_1, u8 num_2)
 {
@@ -8824,7 +8824,7 @@ void _hal_max_ax_snd_cmd_bfrp_he_f2p(struct mac_ax_snd_f2P *mac_bfrp_f2p,
 
 
 /* 3. WD Content */
-void _hal_max_ax_snd_cmd_wd(struct mac_ax_snd_wd_para *mac_wd,
+static void _hal_max_ax_snd_cmd_wd(struct mac_ax_snd_wd_para *mac_wd,
 			    struct hal_snd_wd_para *hal_wd)
 {
 	PHL_TRACE(COMP_PHL_SOUND, _PHL_INFO_, "==> _hal_max_ax_snd_cmd_wd \n");
@@ -9961,7 +9961,7 @@ enum rtw_hal_status rtw_hal_mac_cfg_rxhci(struct hal_info_t *hal, u8 en)
 }
 
 #ifdef CONFIG_MCC_SUPPORT
-void _hal_mac_mcc_fill_role_info(struct rtw_phl_mcc_role *mcc_role,
+static void _hal_mac_mcc_fill_role_info(struct rtw_phl_mcc_role *mcc_role,
 				struct mac_ax_mcc_role *info)
 {
 	struct rtw_phl_mcc_policy_info *policy = &mcc_role->policy;
@@ -10003,7 +10003,7 @@ void _hal_mac_mcc_fill_role_info(struct rtw_phl_mcc_role *mcc_role,
 		info->courtesy_en, info->courtesy_num, info->courtesy_target);
 }
 
-void _hal_mac_mcc_fill_duration_info(struct rtw_phl_mcc_en_info *en_info,
+static void _hal_mac_mcc_fill_duration_info(struct rtw_phl_mcc_en_info *en_info,
 					struct rtw_phl_mcc_bt_info *bt_info,
 					struct mac_ax_mcc_duration_info *info)
 {
@@ -10024,7 +10024,7 @@ void _hal_mac_mcc_fill_duration_info(struct rtw_phl_mcc_en_info *en_info,
 		info->start_tsf_low);
 }
 
-void _hal_mac_mcc_fill_start_info(u8 group, u8 macid, u32 tsf_high, u32 tsf_low,
+static void _hal_mac_mcc_fill_start_info(u8 group, u8 macid, u32 tsf_high, u32 tsf_low,
 			u8 btc_in_group, u8 old_group_action, u8 old_group,
 			struct mac_ax_mcc_start *info)
 {
@@ -10520,7 +10520,7 @@ exit:
 #define P2P_TYPE_GO 0
 #define P2P_TYPE_GC 1
 
-void _hal_mac_dump_p2p_act_struct(struct mac_ax_p2p_act_info *mac_p2p_info)
+static void _hal_mac_dump_p2p_act_struct(struct mac_ax_p2p_act_info *mac_p2p_info)
 {
 	PHL_TRACE(COMP_PHL_P2PPS, _PHL_INFO_, "[NoA]_hal_mac_dump_p2p_act_struct(): macid = %d\n",
 		mac_p2p_info->macid);
@@ -10544,7 +10544,7 @@ void _hal_mac_dump_p2p_act_struct(struct mac_ax_p2p_act_info *mac_p2p_info)
 		mac_p2p_info->ctw);
 }
 
-void _hal_mac_noa_fill_info(u8 action,
+static void _hal_mac_noa_fill_info(u8 action,
 	struct rtw_phl_noa_desc *desc,
 	u16 macid,
 	struct mac_ax_p2p_act_info *mac_p2p_info)
@@ -10564,7 +10564,7 @@ void _hal_mac_noa_fill_info(u8 action,
 	mac_p2p_info->cnt = desc->count;
 }
 
-enum rtw_hal_status _hal_mac_get_p2p_stat(struct hal_info_t *hal)
+static enum rtw_hal_status _hal_mac_get_p2p_stat(struct hal_info_t *hal)
 {
 	struct mac_ax_adapter *mac = hal_to_mac(hal);
 	u16 loop_cnt;
@@ -10614,7 +10614,7 @@ enum rtw_hal_status rtw_hal_mac_p2p_macid_ctrl(struct hal_info_t *hal,
 	return h_sts;
 }
 
-enum rtw_hal_status _hal_mac_set_p2p_act(struct hal_info_t *hal,
+static enum rtw_hal_status _hal_mac_set_p2p_act(struct hal_info_t *hal,
 	struct mac_ax_p2p_act_info *mac_p2p_info)
 {
 	enum rtw_hal_status h_stat = RTW_HAL_STATUS_FAILURE;

--- a/phl/hal_g6/hal_beamform.c
+++ b/phl/hal_g6/hal_beamform.c
@@ -92,7 +92,7 @@ void rtw_hal_bf_dbg_dump_entry_all(void *hal)
 	}
 }
 
-void _reset_bf_entry(struct hal_bf_entry *bf_entry)
+static void _reset_bf_entry(struct hal_bf_entry *bf_entry)
 {
 	bf_entry->macid = 0;
 	bf_entry->aid12 = 0;
@@ -102,7 +102,7 @@ void _reset_bf_entry(struct hal_bf_entry *bf_entry)
 	bf_entry->couter = 0;
 }
 
-void _reset_sumu_entry(struct hal_sumu_entry *entry)
+static void _reset_sumu_entry(struct hal_sumu_entry *entry)
 {
 	entry->snd_sts = 0;
 	return;
@@ -292,7 +292,7 @@ static enum rtw_hal_status _enqueue_busy_mu_entry(
 }
 
 /* hal bf init */
-enum rtw_hal_status _hal_bf_init_su_entry(
+static enum rtw_hal_status _hal_bf_init_su_entry(
 				struct hal_info_t *hal_info,
 				u8 num)
 {
@@ -330,7 +330,7 @@ enum rtw_hal_status _hal_bf_init_su_entry(
 }
 
 
-enum rtw_hal_status _hal_bf_init_mu_entry(
+static enum rtw_hal_status _hal_bf_init_mu_entry(
 	struct hal_info_t *hal_info,
 	u8 num)
 {
@@ -368,7 +368,7 @@ enum rtw_hal_status _hal_bf_init_mu_entry(
 }
 
 
-enum rtw_hal_status _hal_bf_init_bf_entry(
+static enum rtw_hal_status _hal_bf_init_bf_entry(
 	struct hal_info_t *hal_info,
 	u8 num)
 {
@@ -763,7 +763,7 @@ void hal_bf_update_entry_snd_sts(struct hal_info_t *hal_info, void *entry)
 
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 hal_bf_hw_mac_deinit_bfee(struct hal_info_t *hal_info, u8 band)
 {
 	enum rtw_hal_status status = RTW_HAL_STATUS_SUCCESS;

--- a/phl/hal_g6/hal_beamform.c
+++ b/phl/hal_g6/hal_beamform.c
@@ -92,7 +92,7 @@ void rtw_hal_bf_dbg_dump_entry_all(void *hal)
 	}
 }
 
-void _reset_bf_entry(struct hal_bf_entry *bf_entry)
+static void _reset_bf_entry(struct hal_bf_entry *bf_entry)
 {
 	bf_entry->macid = 0;
 	bf_entry->aid12 = 0;
@@ -102,7 +102,7 @@ void _reset_bf_entry(struct hal_bf_entry *bf_entry)
 	bf_entry->couter = 0;
 }
 
-void _reset_sumu_entry(struct hal_sumu_entry *entry)
+static void _reset_sumu_entry(struct hal_sumu_entry *entry)
 {
 	entry->snd_sts = 0;
 	return;
@@ -292,7 +292,7 @@ static enum rtw_hal_status _enqueue_busy_mu_entry(
 }
 
 /* hal bf init */
-enum rtw_hal_status _hal_bf_init_su_entry(
+static enum rtw_hal_status _hal_bf_init_su_entry(
 				struct hal_info_t *hal_info,
 				u8 num)
 {
@@ -330,7 +330,7 @@ enum rtw_hal_status _hal_bf_init_su_entry(
 }
 
 
-enum rtw_hal_status _hal_bf_init_mu_entry(
+static enum rtw_hal_status _hal_bf_init_mu_entry(
 	struct hal_info_t *hal_info,
 	u8 num)
 {
@@ -368,7 +368,7 @@ enum rtw_hal_status _hal_bf_init_mu_entry(
 }
 
 
-enum rtw_hal_status _hal_bf_init_bf_entry(
+static enum rtw_hal_status _hal_bf_init_bf_entry(
 	struct hal_info_t *hal_info,
 	u8 num)
 {
@@ -763,7 +763,8 @@ void hal_bf_update_entry_snd_sts(struct hal_info_t *hal_info, void *entry)
 
 }
 
-enum rtw_hal_status
+#ifdef RTW_WKARD_DYNAMIC_BFEE_CAP
+static enum rtw_hal_status
 hal_bf_hw_mac_deinit_bfee(struct hal_info_t *hal_info, u8 band)
 {
 	enum rtw_hal_status status = RTW_HAL_STATUS_SUCCESS;
@@ -790,6 +791,7 @@ hal_bf_hw_mac_deinit_bfee(struct hal_info_t *hal_info, u8 band)
 
 	return status;
 }
+#endif /* RTW_WKARD_DYNAMIC_BFEE_CAP */
 
 /**
  * rtw_hal_bf_get_entry_snd_sts

--- a/phl/hal_g6/hal_beamform.c
+++ b/phl/hal_g6/hal_beamform.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 
 #include "hal_headers.h"
+#include "hal_api.h"
 
 /**
  * rtw_hal_bf_dbg_dump_entry

--- a/phl/hal_g6/hal_cam.c
+++ b/phl/hal_g6/hal_cam.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_CAM_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 /**
  * This function calls halmac api to configure security cam

--- a/phl/hal_g6/hal_cap.c
+++ b/phl/hal_g6/hal_cap.c
@@ -13,6 +13,7 @@
  *
  *****************************************************************************/
 #include "hal_headers.h"
+#include "hal_api.h"
 
 static void _hal_bus_cap_pre_decision(struct rtw_phl_com_t *phl_com,
 					 	void *hal)

--- a/phl/hal_g6/hal_chan.c
+++ b/phl/hal_g6/hal_chan.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_CHAN_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 enum rtw_hal_status rtw_hal_set_ch_bw(void *hal, u8 band_idx,
 		struct rtw_chan_def *chdef, enum rfk_tri_type rt_type, bool rd_enabled, bool frc_switch)

--- a/phl/hal_g6/hal_com_i.c
+++ b/phl/hal_g6/hal_com_i.c
@@ -85,7 +85,7 @@ rtw_hal_com_set_power_offset(void *hal, u8 band, s8 ofst_mode, s8 ofst_bw)
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
-enum rtw_hal_status rtw_hal_com_set_gt3(void *hal, u8 en, u8 timeout)
+enum rtw_hal_status rtw_hal_com_set_gt3(void *hal, u8 en, u32 timeout)
 {
 	struct hal_info_t *hal_info = (struct hal_info_t *)hal;
 

--- a/phl/hal_g6/hal_com_i.c
+++ b/phl/hal_g6/hal_com_i.c
@@ -15,6 +15,7 @@
 #ifndef _HAL_COM_I_C_
 #define _HAL_COM_I_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 #define HAL_MAC_TX_LIFETIME_UNIT_US_SHT 8 /* 256 us */
 

--- a/phl/hal_g6/hal_csi_buffer.c
+++ b/phl/hal_g6/hal_csi_buffer.c
@@ -19,7 +19,7 @@
  * 	Dump all of the csi buffer status;
  * @csi_obj: (struct hal_csi_obj *)
  **/
-void _dump_csi_buf_status(struct hal_csi_obj *csi_obj)
+static void _dump_csi_buf_status(struct hal_csi_obj *csi_obj)
 {
 	struct hal_csi_buf *csi_buf = NULL;
 	u8 i = 0;
@@ -48,7 +48,7 @@ void _dump_csi_buf_status(struct hal_csi_obj *csi_obj)
  * return
  * @sub_idx: (u8) csi buffer sub index
  **/
-u8 __query_avl_buf_idx_20(struct hal_csi_buf *csi_buf)
+static u8 __query_avl_buf_idx_20(struct hal_csi_buf *csi_buf)
 {
 	u8 sub_idx = CSI_BUF_SUB_IDX_NON;
 	do {
@@ -84,7 +84,7 @@ u8 __query_avl_buf_idx_20(struct hal_csi_buf *csi_buf)
  * return
  * @sub_idx: (u8) csi buffer sub index
  **/
-u8 __query_avl_buf_idx_40(struct hal_csi_buf *csi_buf)
+static u8 __query_avl_buf_idx_40(struct hal_csi_buf *csi_buf)
 {
 	u8 sub_idx = CSI_BUF_SUB_IDX_NON;
 	do {
@@ -110,7 +110,7 @@ u8 __query_avl_buf_idx_40(struct hal_csi_buf *csi_buf)
  * return
  * @sub_idx: (u8) csi buffer sub index
  **/
-u8 __query_avl_buf_idx_80(struct hal_csi_buf *csi_buf)
+static u8 __query_avl_buf_idx_80(struct hal_csi_buf *csi_buf)
 {
 	u8 sub_idx = CSI_BUF_SUB_IDX_NON;
 
@@ -130,7 +130,7 @@ u8 __query_avl_buf_idx_80(struct hal_csi_buf *csi_buf)
  * return
  * @sub_idx: (u8) csi buffer sub index
  **/
-u8 __query_avl_buf_idx_160(struct hal_csi_buf *csi_buf)
+static u8 __query_avl_buf_idx_160(struct hal_csi_buf *csi_buf)
 {
 	u8 sub_idx = CSI_BUF_SUB_IDX_NON;
 
@@ -152,7 +152,7 @@ u8 __query_avl_buf_idx_160(struct hal_csi_buf *csi_buf)
  * @sub_id: (u8) available csi buffer sub index
  * @csi_buf: (struct hal_csi_buf *) original hal csi buffer
  **/
-struct hal_csi_buf *_query_csi_buf_su(
+static struct hal_csi_buf *_query_csi_buf_su(
 	struct hal_info_t *hal_info,
 	enum hal_csi_buf_size size,
 	u8 *sub_id)
@@ -221,7 +221,7 @@ struct hal_csi_buf *_query_csi_buf_su(
  * @sub_id: (u8) available csi buffer sub index
  * @csi_buf: (struct hal_csi_buf *) original hal csi buffer
  **/
-struct hal_csi_buf *_query_csi_buf_mu(
+static struct hal_csi_buf *_query_csi_buf_mu(
 	struct hal_info_t *hal_info,
 	enum hal_csi_buf_size size,
 	u8 *sub_id)
@@ -290,7 +290,7 @@ struct hal_csi_buf *_query_csi_buf_mu(
  * return
  * @ret: enum hal_csi_buf_size
  **/
-enum hal_csi_buf_size
+static enum hal_csi_buf_size
 _bw2csi(enum channel_width bw)
 {
 	enum hal_csi_buf_size ret = HAL_CSI_BUF_SIZE_NONE;
@@ -313,7 +313,7 @@ _bw2csi(enum channel_width bw)
 	return ret;
 }
 
-enum rtw_hal_status _hal_csi_init_buf(struct hal_info_t *hal_info, u8 num)
+static enum rtw_hal_status _hal_csi_init_buf(struct hal_info_t *hal_info, u8 num)
 {
 	enum rtw_hal_status status = RTW_HAL_STATUS_SUCCESS;
 	void *drv_priv = hal_to_drvpriv(hal_info);

--- a/phl/hal_g6/hal_dfs.c
+++ b/phl/hal_g6/hal_dfs.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_DFS_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 #ifdef CONFIG_PHL_DFS
 

--- a/phl/hal_g6/hal_ext_tx_pwr_lmt.c
+++ b/phl/hal_g6/hal_ext_tx_pwr_lmt.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_EXT_TX_PWR_LMT_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 enum rtw_hal_status
 rtw_hal_set_power_limit(void *hal, u8 band_idx)

--- a/phl/hal_g6/hal_fw.c
+++ b/phl/hal_g6/hal_fw.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_FW_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 static void _hal_send_fwdl_hub_msg(struct rtw_phl_com_t *phl_com, u8 dl_ok)
 {

--- a/phl/hal_g6/hal_init.c
+++ b/phl/hal_g6/hal_init.c
@@ -21,6 +21,7 @@
 #include "hal_usb.h"
 #elif defined(CONFIG_SDIO_HCI)
 #include "hal_sdio.h"
+#include "hal_api.h"
 #endif
 
 

--- a/phl/hal_g6/hal_init.c
+++ b/phl/hal_g6/hal_init.c
@@ -733,7 +733,7 @@ static enum rtw_hal_status hal_set_ops(struct rtw_phl_com_t *phl_com,
 }
 
 #ifdef RTW_PHL_BCN
-enum rtw_hal_status hal_bcn_init(struct hal_info_t *hal_info)
+static enum rtw_hal_status hal_bcn_init(struct hal_info_t *hal_info)
 {
 	struct bcn_entry_pool *bcn_pool = &hal_info->hal_com->bcn_pool;
 
@@ -744,7 +744,7 @@ enum rtw_hal_status hal_bcn_init(struct hal_info_t *hal_info)
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
-enum rtw_hal_status hal_bcn_deinit(struct hal_info_t *hal_info)
+static enum rtw_hal_status hal_bcn_deinit(struct hal_info_t *hal_info)
 {
 	void *drv_priv = hal_to_drvpriv(hal_info);
 	struct bcn_entry_pool *bcn_pool = &hal_info->hal_com->bcn_pool;
@@ -764,7 +764,7 @@ enum rtw_hal_status hal_bcn_deinit(struct hal_info_t *hal_info)
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
-enum rtw_hal_status hal_alloc_bcn_entry(struct rtw_phl_com_t *phl_com, struct hal_info_t *hal_info,
+static enum rtw_hal_status hal_alloc_bcn_entry(struct rtw_phl_com_t *phl_com, struct hal_info_t *hal_info,
 		struct rtw_bcn_entry **bcn_entry, struct rtw_bcn_info_cmn *bcn_cmn)
 {
 	void *drv_priv = hal_to_drvpriv(hal_info);
@@ -786,7 +786,7 @@ enum rtw_hal_status hal_alloc_bcn_entry(struct rtw_phl_com_t *phl_com, struct ha
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
-enum rtw_hal_status hal_free_bcn_entry(struct rtw_phl_com_t *phl_com, struct hal_info_t *hal_info,
+static enum rtw_hal_status hal_free_bcn_entry(struct rtw_phl_com_t *phl_com, struct hal_info_t *hal_info,
 		u8 bcn_id)
 {
 	void *drv_priv = hal_to_drvpriv(hal_info);
@@ -817,7 +817,7 @@ enum rtw_hal_status hal_free_bcn_entry(struct rtw_phl_com_t *phl_com, struct hal
 		return RTW_HAL_STATUS_FAILURE;
 }
 
-enum rtw_hal_status hal_get_bcn_entry(struct rtw_phl_com_t *phl_com, struct hal_info_t *hal_info,
+static enum rtw_hal_status hal_get_bcn_entry(struct rtw_phl_com_t *phl_com, struct hal_info_t *hal_info,
 		struct rtw_bcn_entry **bcn_entry, u8 bcn_id)
 {
 	void *drv_priv = hal_to_drvpriv(hal_info);
@@ -846,7 +846,7 @@ enum rtw_hal_status hal_get_bcn_entry(struct rtw_phl_com_t *phl_com, struct hal_
 		return RTW_HAL_STATUS_FAILURE;
 }
 
-enum rtw_hal_status hal_update_bcn_entry(struct rtw_phl_com_t *phl_com,
+static enum rtw_hal_status hal_update_bcn_entry(struct rtw_phl_com_t *phl_com,
                                          struct hal_info_t *hal_info,
                                          struct rtw_bcn_entry *bcn_entry,
                                          struct rtw_bcn_info_cmn *bcn_cmn)
@@ -1349,7 +1349,7 @@ enum rtw_hal_status rtw_hal_preload(struct rtw_phl_com_t *phl_com, void *hal)
 	return hal_status;
 }
 
-enum rtw_hal_status hal_rfe_type_chk(struct rtw_phl_com_t *phl_com,
+static enum rtw_hal_status hal_rfe_type_chk(struct rtw_phl_com_t *phl_com,
 				     struct hal_info_t *hal_info)
 {
 	enum rtw_hal_status hal_status = RTW_HAL_STATUS_UNKNOWN_RFE_TYPE;
@@ -1559,7 +1559,7 @@ rtw_hal_beacon_stop(void *hal,
 	return hsts;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 hal_ver_check(struct rtw_hal_com_t *hal_com)
 {
 	if ((hal_com->mac_vc.mac_ver < hal_com->bb_vc.mac_ver) ||

--- a/phl/hal_g6/hal_ld_file.c
+++ b/phl/hal_g6/hal_ld_file.c
@@ -1780,7 +1780,7 @@ _hal_parse_txpwrtrack(void *drv_priv, void *para_info_t, u8 *psrc_buf, u32 bufle
 	return 1;
 }
 
-void
+static void
 _hal_decrypt_para_file(
 	char *paraFile,
 	u32  buflen
@@ -1824,7 +1824,7 @@ _hal_decrypt_para_file(
 	PHL_TRACE(COMP_PHL_DBG, _PHL_DEBUG_, "<===== %s(): countLines:%u, curPos:%u\n", __func__, i, currentPos);
 }
 
-void
+static void
 _hal_dl_para_file(struct rtw_phl_com_t *phl_com,
 	void *para_info_t, char *ic_name,
 	int (*parser_fun)(void *drv_priv, void *para_info_t, u8 *psrc_buf, u32 buflen),
@@ -1981,7 +1981,7 @@ _hal_dl_para_file(struct rtw_phl_com_t *phl_com,
 #endif
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 _phl_pwrlmt_para_alloc(struct rtw_phl_com_t* phl_com,
 				struct rtw_para_pwrlmt_info_t *para_info)
 {
@@ -2036,7 +2036,7 @@ _phl_pwrlmt_para_alloc(struct rtw_phl_com_t* phl_com,
 #endif
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 phl_load_file_data_alloc(struct rtw_phl_com_t* phl_com, struct rtw_para_info_t *para_info)
 {
 #ifdef CONFIG_LOAD_PHY_PARA_FROM_FILE

--- a/phl/hal_g6/hal_led.c
+++ b/phl/hal_g6/hal_led.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_LED_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 #define HAL_LED_GET_CTRL_MODE(m)                                               \
 	((m) == RTW_LED_CTRL_SW_PP_MODE                                        \

--- a/phl/hal_g6/hal_mcc.c
+++ b/phl/hal_g6/hal_mcc.c
@@ -15,6 +15,7 @@
 #define _HAL_MCC_C_
 #include "hal_headers.h"
 #include "hal_mcc.h"
+#include "hal_api.h"
 
 #ifdef CONFIG_MCC_SUPPORT
 #define _mcc_fill_slot_bt_coex(_dbg_hal_i, _en) ((struct rtw_phl_mcc_dbg_hal_info *)_dbg_hal_i)->btc_in_group = _en;

--- a/phl/hal_g6/hal_mcc.c
+++ b/phl/hal_g6/hal_mcc.c
@@ -19,7 +19,7 @@
 #ifdef CONFIG_MCC_SUPPORT
 #define _mcc_fill_slot_bt_coex(_dbg_hal_i, _en) ((struct rtw_phl_mcc_dbg_hal_info *)_dbg_hal_i)->btc_in_group = _en;
 
-void _mcc_update_slot_dbg_info(struct rtw_phl_mcc_dbg_hal_info *dbg_hal_i,
+static void _mcc_update_slot_dbg_info(struct rtw_phl_mcc_dbg_hal_info *dbg_hal_i,
 				bool bt_role, u16 macid, u16 dur)
 {
 	struct rtw_phl_mcc_dbg_slot_info *dbg_slot_i = NULL;
@@ -39,7 +39,7 @@ void _mcc_update_slot_dbg_info(struct rtw_phl_mcc_dbg_hal_info *dbg_hal_i,
 	}
 }
 
-void _mcc_update_dbg_info(struct rtw_phl_mcc_en_info *info,
+static void _mcc_update_dbg_info(struct rtw_phl_mcc_en_info *info,
 			struct rtw_phl_mcc_bt_info *bt_info)
 {
 	u8 idx = 0;
@@ -56,7 +56,7 @@ void _mcc_update_dbg_info(struct rtw_phl_mcc_en_info *info,
 	}
 }
 
-void _mcc_fill_slot_dbg_info(struct rtw_phl_mcc_dbg_hal_info *dbg_hal_i,
+static void _mcc_fill_slot_dbg_info(struct rtw_phl_mcc_dbg_hal_info *dbg_hal_i,
 				struct rtw_phl_mcc_role *mrole)
 {
 	struct rtw_phl_mcc_dbg_slot_info *dbg_slot_i = NULL;
@@ -77,7 +77,7 @@ exit:
 	return;
 }
 
-enum rtw_hal_status _mcc_add_bt_role(struct hal_info_t *hal, u8 group,
+static enum rtw_hal_status _mcc_add_bt_role(struct hal_info_t *hal, u8 group,
 			struct rtw_phl_mcc_slot_info *slot_i,
 			struct rtw_phl_mcc_dbg_hal_info *dbg_hal_i)
 {
@@ -93,7 +93,7 @@ enum rtw_hal_status _mcc_add_bt_role(struct hal_info_t *hal, u8 group,
 	return status;
 }
 
-enum rtw_hal_status _mcc_add_wifi_role(struct hal_info_t *hal,
+static enum rtw_hal_status _mcc_add_wifi_role(struct hal_info_t *hal,
 				u8 group, struct rtw_phl_mcc_slot_info *slot_i,
 				struct rtw_phl_mcc_dbg_hal_info *dbg_hal_i)
 {
@@ -123,7 +123,7 @@ exit:
 	return status;
 }
 
-enum rtw_hal_status _mcc_fill_role_setting(struct hal_info_t *hal,
+static enum rtw_hal_status _mcc_fill_role_setting(struct hal_info_t *hal,
 			struct rtw_phl_mcc_en_info *info)
 {
 	enum rtw_hal_status status = RTW_HAL_STATUS_FAILURE;
@@ -159,7 +159,7 @@ exit:
 	return status;
 }
 
-enum rtw_hal_status _mcc_replace_pattern(struct hal_info_t *hal,
+static enum rtw_hal_status _mcc_replace_pattern(struct hal_info_t *hal,
 				struct rtw_phl_mcc_en_info *ori_info,
 				struct rtw_phl_mcc_en_info *new_info,
 				struct rtw_phl_mcc_bt_info *new_bt_info)
@@ -208,7 +208,7 @@ exit:
 	return status;
 }
 
-void
+static void
 _mcc_check_start_t(struct rtw_phl_mcc_en_info *ori_info,
 			struct rtw_phl_mcc_en_info *new_info)
 {
@@ -318,7 +318,7 @@ exit:
 	return status;
 }
 
-enum rtw_hal_status _mcc_set_duration(void *hal,
+static enum rtw_hal_status _mcc_set_duration(void *hal,
 					struct rtw_phl_mcc_en_info *info,
 					struct rtw_phl_mcc_bt_info *bt_info)
 {

--- a/phl/hal_g6/hal_p2pps.c
+++ b/phl/hal_g6/hal_p2pps.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_P2PPS_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 #ifdef CONFIG_PHL_P2PPS
 #define TSF32_TOG_EARLY_T 2000 /*2ms*/

--- a/phl/hal_g6/hal_ps.c
+++ b/phl/hal_g6/hal_ps.c
@@ -17,7 +17,7 @@
 #ifdef CONFIG_POWER_SAVE
 #define case_pwr_state(src) \
 	case PS_PWR_STATE_##src: return #src
-const char *hal_ps_pwr_state_to_str(u8 pwr_state)
+static const char *hal_ps_pwr_state_to_str(u8 pwr_state)
 {
 	switch (pwr_state) {
 	case_pwr_state(ACTIVE);
@@ -248,7 +248,7 @@ _hal_ps_pwr_lvl_cfg(struct rtw_phl_com_t *phl_com, struct hal_info_t *hal_info,
 	return status;
 }
 
-void _hal_ps_proc_hw_rf_state_done(void* priv, struct phl_msg* msg)
+static void _hal_ps_proc_hw_rf_state_done(void* priv, struct phl_msg* msg)
 {
 	struct rtw_phl_com_t *phl_com = (struct rtw_phl_com_t *)priv;
 

--- a/phl/hal_g6/hal_ps.c
+++ b/phl/hal_g6/hal_ps.c
@@ -17,7 +17,7 @@
 #ifdef CONFIG_POWER_SAVE
 #define case_pwr_state(src) \
 	case PS_PWR_STATE_##src: return #src
-const char *hal_ps_pwr_state_to_str(u8 pwr_state)
+static const char *hal_ps_pwr_state_to_str(u8 pwr_state)
 {
 	switch (pwr_state) {
 	case_pwr_state(ACTIVE);
@@ -248,7 +248,8 @@ _hal_ps_pwr_lvl_cfg(struct rtw_phl_com_t *phl_com, struct hal_info_t *hal_info,
 	return status;
 }
 
-void _hal_ps_proc_hw_rf_state_done(void* priv, struct phl_msg* msg)
+#ifdef CONFIG_HW_RADIO_ONOFF_DETECT
+static void _hal_ps_proc_hw_rf_state_done(void* priv, struct phl_msg* msg)
 {
 	struct rtw_phl_com_t *phl_com = (struct rtw_phl_com_t *)priv;
 
@@ -256,6 +257,7 @@ void _hal_ps_proc_hw_rf_state_done(void* priv, struct phl_msg* msg)
 		_os_kmem_free(phlcom_to_drvpriv(phl_com), msg->inbuf, msg->inlen);
 	}
 }
+#endif /* CONFIG_HW_RADIO_ONOFF_DETECT */
 
 /**
  * configured requested power level

--- a/phl/hal_g6/hal_ps.c
+++ b/phl/hal_g6/hal_ps.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_PS_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 #ifdef CONFIG_POWER_SAVE
 #define case_pwr_state(src) \
 	case PS_PWR_STATE_##src: return #src

--- a/phl/hal_g6/hal_rx.c
+++ b/phl/hal_g6/hal_rx.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_RX_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 void rtw_hal_cfg_rxhci(void *hal, u8 en)
 {

--- a/phl/hal_g6/hal_scanofld.c
+++ b/phl/hal_g6/hal_scanofld.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_SCANOFLD_C_
 #include "hal_headers.h"
+#include "hal_scanofld.h"
 
 #ifdef CONFIG_PHL_SCANOFLD
 void

--- a/phl/hal_g6/hal_sdio.c
+++ b/phl/hal_g6/hal_sdio.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_SDIO_C_
 #include "hal_headers.h"
+#include "hal_sdio.h"
 
 #ifdef CONFIG_SDIO_HCI
 static u8 hal_sdio_f0_read8(struct rtw_hal_com_t *hal, u32 addr)

--- a/phl/hal_g6/hal_ser.c
+++ b/phl/hal_g6/hal_ser.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_SER_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 enum rtw_hal_status rtw_hal_ser_ctrl(void *hal, enum rtw_hal_ser_rsn rsn, bool en)
 {

--- a/phl/hal_g6/hal_sound.c
+++ b/phl/hal_g6/hal_sound.c
@@ -15,6 +15,7 @@
 #define _HAL_SOUND_C_
 
 #include "hal_headers.h"
+#include "hal_api.h"
 
 #ifdef CONFIG_PHL_CMD_BF
 struct csi_rpt_na {

--- a/phl/hal_g6/hal_sound.c
+++ b/phl/hal_g6/hal_sound.c
@@ -39,7 +39,7 @@ static const struct csi_rpt_na csi_na[CSI_NA_MATRIX_SIZE] =
 };
 
 
-u32 _cal_he_csi_size(u8 mu, enum channel_width bw, u8 nr, u8 nc, u8 ng, u8 cb)
+static u32 _cal_he_csi_size(u8 mu, enum channel_width bw, u8 nr, u8 nc, u8 ng, u8 cb)
 {
 	u8 na = 0;
 	u8 ns = 0;
@@ -97,7 +97,7 @@ u32 _cal_he_csi_size(u8 mu, enum channel_width bw, u8 nr, u8 nc, u8 ng, u8 cb)
 	return csi_size;
 }
 
-u32 _cal_he_cqi_only_rpt_size(enum channel_width bw, u8 nc)
+static u32 _cal_he_cqi_only_rpt_size(enum channel_width bw, u8 nc)
 {
 	u32 ret = 0;
 	if (CHANNEL_WIDTH_80 == bw)
@@ -111,7 +111,7 @@ u32 _cal_he_cqi_only_rpt_size(enum channel_width bw, u8 nc)
 }
 
 /*1. BF Resource Related*/
-u8 _get_bw_ru_end_idx(enum channel_width bw) {
+static u8 _get_bw_ru_end_idx(enum channel_width bw) {
 	u8 ru_end_idx = 0;
 
 	switch (bw) {
@@ -133,7 +133,7 @@ u8 _get_bw_ru_end_idx(enum channel_width bw) {
 	return ru_end_idx;
 }
 
-void _hal_snd_set_default_var(struct hal_snd_obj *snd_obj)
+static void _hal_snd_set_default_var(struct hal_snd_obj *snd_obj)
 {
 	snd_obj->ndpa_xpara.bw = CHANNEL_WIDTH_20;
 	snd_obj->ndpa_xpara.rate = RTW_DATA_RATE_OFDM6;

--- a/phl/hal_g6/hal_sta.c
+++ b/phl/hal_g6/hal_sta.c
@@ -15,7 +15,7 @@
 #define _HAL_STA_C_
 #include "hal_headers.h"
 
-void
+static void
 _hal_sta_rssi_init(struct rtw_phl_stainfo_t *sta)
 {
 	sta->hal_sta->rssi_stat.assoc_rssi = 0;
@@ -480,7 +480,7 @@ out:
 	return sts;
 }
 
-enum rtw_hal_status
+static enum rtw_hal_status
 _hal_update_ba_cam(struct hal_info_t *hal_info, u8 valid, u16 macid,
                    u8 dialog_token, u16 timeout, u16 start_seq_num, u16 ba_policy,
                    u16 tid, u16 buf_size, u8 camid, u8 band_idx, u8 uid, bool is_std)

--- a/phl/hal_g6/hal_sta.c
+++ b/phl/hal_g6/hal_sta.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_STA_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 static void
 _hal_sta_rssi_init(struct rtw_phl_stainfo_t *sta)

--- a/phl/hal_g6/hal_thermal.c
+++ b/phl/hal_g6/hal_thermal.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_THERMAL_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 #ifdef CONFIG_PHL_THERMAL_PROTECT
 

--- a/phl/hal_g6/hal_trx_mit.c
+++ b/phl/hal_g6/hal_trx_mit.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_TRX_MIT_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 static void
 _hal_trx_mit_timer_convert(u32 timer, u8 *mul_ptr,

--- a/phl/hal_g6/hal_tx.c
+++ b/phl/hal_g6/hal_tx.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_TX_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 /**
  * this function will be used in read / write pointer mechanism and
  * return the number of available read pointer

--- a/phl/hal_g6/hal_txpwr.c
+++ b/phl/hal_g6/hal_txpwr.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _HAL_TXPWR_C_
 #include "hal_headers.h"
+#include "hal_api.h"
 
 int rtw_hal_get_pw_lmt_regu_type_from_str(void *hal, const char *str)
 {

--- a/phl/hal_g6/mac/mac_ax/_sdio.c
+++ b/phl/hal_g6/mac/mac_ax/_sdio.c
@@ -22,7 +22,7 @@ static u8 _patch_reg_sdio(struct mac_ax_adapter *adapter, u32 adr);
 static u16 _patch_fs_enuf(struct mac_ax_adapter *adapter,
 			  struct mac_ax_sdio_tx_info *tx_info);
 
-u8 _pltfm_sdio_cmd53_r8(struct mac_ax_adapter *adapter, u32 adr)
+static u8 _pltfm_sdio_cmd53_r8(struct mac_ax_adapter *adapter, u32 adr)
 {
 	u32 dw_adr = adr & 0xFFFFFFFC;
 	u8 dw_sh = adr - dw_adr;
@@ -55,7 +55,7 @@ u8 _pltfm_sdio_cmd53_r8(struct mac_ax_adapter *adapter, u32 adr)
 	return val32.byte[dw_sh];
 }
 
-u16 _pltfm_sdio_cmd53_r16(struct mac_ax_adapter *adapter, u32 adr)
+static u16 _pltfm_sdio_cmd53_r16(struct mac_ax_adapter *adapter, u32 adr)
 {
 	u32 dw_adr = adr & 0xFFFFFFFD;
 	u8 dw_sh = (adr - dw_adr) ? 1 : 0;
@@ -88,7 +88,7 @@ u16 _pltfm_sdio_cmd53_r16(struct mac_ax_adapter *adapter, u32 adr)
 	return val32.word[dw_sh];
 }
 
-u32 _pltfm_sdio_cmd53_r32(struct mac_ax_adapter *adapter, u32 adr)
+static u32 _pltfm_sdio_cmd53_r32(struct mac_ax_adapter *adapter, u32 adr)
 {
 	u8 cnt = 0;
 	__le32 dword = 0x00000000;

--- a/phl/hal_g6/mac/mac_ax/addr_cam.c
+++ b/phl/hal_g6/mac/mac_ax/addr_cam.c
@@ -38,7 +38,7 @@ static u8 get_set_bits_of_msk(u8 msk)
 	return get_set_bits_of_msk(set_bits) + 1;
 }
 
-u32 find_avail_addr_cam_entry(struct mac_ax_adapter *adapter,
+static u32 find_avail_addr_cam_entry(struct mac_ax_adapter *adapter,
 			      struct mac_ax_role_info *info)
 {
 	u16 i;
@@ -54,7 +54,7 @@ u32 find_avail_addr_cam_entry(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 find_avail_bssid_cam_entry(struct mac_ax_adapter *adapter,
+static u32 find_avail_bssid_cam_entry(struct mac_ax_adapter *adapter,
 			       struct mac_ax_role_info *info)
 {
 	u8 i;

--- a/phl/hal_g6/mac/mac_ax/beacon.c
+++ b/phl/hal_g6/mac/mac_ax/beacon.c
@@ -15,7 +15,7 @@
 
 #include "beacon.h"
 
-u8 _byte_rev(u8 in)
+static u8 _byte_rev(u8 in)
 {
 	u8 data = 0;
 	u8 i;
@@ -25,7 +25,7 @@ u8 _byte_rev(u8 in)
 	return data;
 }
 
-u8 _crc8_htsig(u8 *mem, u32 len)
+static u8 _crc8_htsig(u8 *mem, u32 len)
 {
 	u8 crc = 0xFF;
 	u8 key = 0x07;

--- a/phl/hal_g6/mac/mac_ax/cmac_tx.c
+++ b/phl/hal_g6/mac/mac_ax/cmac_tx.c
@@ -628,7 +628,7 @@ u32 set_hw_sch_tx_en(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 hw_sch_tx_en_h2c_pkt(struct mac_ax_adapter *adapter, u8 band,
+static u32 hw_sch_tx_en_h2c_pkt(struct mac_ax_adapter *adapter, u8 band,
 			 u16 tx_en_u16, u16 mask_u16)
 {
 	u32 ret = MACSUCCESS;

--- a/phl/hal_g6/mac/mac_ax/dbcc.c
+++ b/phl/hal_g6/mac/mac_ax/dbcc.c
@@ -330,7 +330,7 @@ static u32 dbcc_chk_notify_done(struct mac_ax_adapter *adapter)
 	return MACSUCCESS;
 }
 
-u32 dbcc_trx_ctrl_bkp(struct mac_ax_adapter *adapter, enum mac_ax_band band)
+static u32 dbcc_trx_ctrl_bkp(struct mac_ax_adapter *adapter, enum mac_ax_band band)
 {
 	struct mac_ax_ops *mops = adapter_to_mac_ops(adapter);
 	struct mac_ax_dbcc_info *dbcc_info = adapter->dbcc_info;

--- a/phl/hal_g6/mac/mac_ax/dbg_cmd.c
+++ b/phl/hal_g6/mac/mac_ax/dbg_cmd.c
@@ -259,14 +259,14 @@ u32 cmd_mac_error_dump(struct mac_ax_adapter *adapter, char input[][MAC_MAX_ARGV
 	return ret;
 }
 
-void cmd_mac_get_version(struct mac_ax_adapter *adapter, char *ver_str, u16 len)
+static void cmd_mac_get_version(struct mac_ax_adapter *adapter, char *ver_str, u16 len)
 {
 	PLTFM_SNPRINTF(ver_str, len, "V%u.%u.%u.%u",
 		       MAC_AX_MAJOR_VER, MAC_AX_PROTOTYPE_VER,
 		       MAC_AX_SUB_VER, MAC_AX_SUB_INDEX);
 }
 
-void cmd_mac_get_fw_ver(struct mac_ax_adapter *adapter, char *ver_str, u16 len)
+static void cmd_mac_get_fw_ver(struct mac_ax_adapter *adapter, char *ver_str, u16 len)
 {
 	PLTFM_SNPRINTF(ver_str, len, "V%u.%u.%u.%u",
 		       adapter->fw_info.major_ver, adapter->fw_info.minor_ver,
@@ -644,7 +644,7 @@ u32 cmd_mac_ser_level_dump(struct mac_ax_adapter *adapter,  char input[][MAC_MAX
 	return MACSUCCESS;
 }
 
-u32 cmd_mac_fw_log_cfg_set(struct mac_ax_adapter *adapter,
+static u32 cmd_mac_fw_log_cfg_set(struct mac_ax_adapter *adapter,
 			   struct mac_ax_fw_log *log_cfg, char *output, u32 out_len, u32 *used)
 {
 	//struct hal_info_t *hal = hal_com->hal_priv;

--- a/phl/hal_g6/mac/mac_ax/dbgpkg.c
+++ b/phl/hal_g6/mac/mac_ax/dbgpkg.c
@@ -1553,7 +1553,7 @@ static void ps_dbg_dump(struct mac_ax_adapter *adapter)
 	}
 }
 
-u32 fw_backtrace_dump(struct mac_ax_adapter *adapter)
+static u32 fw_backtrace_dump(struct mac_ax_adapter *adapter)
 {
 	u32 addr = 0;
 	u32 str_addr = 0;
@@ -1646,7 +1646,7 @@ u32 fw_backtrace_dump(struct mac_ax_adapter *adapter)
 	return MACSUCCESS;
 }
 
-u32 fw_ple_fwerror_dump(struct mac_ax_adapter *adapter)
+static u32 fw_ple_fwerror_dump(struct mac_ax_adapter *adapter)
 {
 	u32 addr = 0;
 	u32 val = 0;

--- a/phl/hal_g6/mac/mac_ax/fwcmd.c
+++ b/phl/hal_g6/mac/mac_ax/fwcmd.c
@@ -1506,7 +1506,7 @@ static struct c2h_proc_func c2h_proc_fw_info_cmd[] = {
 	{FWCMD_C2H_FUNC_NULL, NULL},
 };
 
-u32 c2h_fw_info(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_fw_info(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 		struct rtw_c2h_info *info)
 {
 	struct c2h_proc_func *proc = c2h_proc_fw_info_cmd;
@@ -1947,7 +1947,7 @@ static struct c2h_proc_func c2h_proc_fw_ofld_cmd[] = {
 	{FWCMD_C2H_FUNC_NULL, NULL},
 };
 
-u32 c2h_fw_ofld(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_fw_ofld(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 		struct rtw_c2h_info *info)
 {
 	struct c2h_proc_func *proc = c2h_proc_fw_ofld_cmd;
@@ -2031,7 +2031,7 @@ static struct c2h_proc_func c2h_proc_twt_cmd[] = {
 	{FWCMD_C2H_FUNC_NULL, NULL}
 };
 
-u32 c2h_twt(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_twt(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	    struct rtw_c2h_info *info)
 {
 	struct c2h_proc_func *proc = c2h_proc_twt_cmd;
@@ -2061,7 +2061,7 @@ u32 c2h_twt(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	return handler(adapter, buf, len, info);
 }
 
-u32 c2h_wow_aoac_report_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_wow_aoac_report_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 			    struct rtw_c2h_info *info)
 {
 	struct mac_ax_wowlan_info *wowlan_info = &adapter->wowlan_info;
@@ -2085,7 +2085,7 @@ static struct c2h_proc_func c2h_proc_wow_cmd[] = {
 	{FWCMD_C2H_FUNC_NULL, NULL},
 };
 
-u32 c2h_wow(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_wow(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	    struct rtw_c2h_info *info)
 {
 	struct c2h_proc_func *proc = c2h_proc_wow_cmd;
@@ -2115,7 +2115,7 @@ u32 c2h_wow(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	return handler(adapter, buf, len, info);
 }
 
-u32 c2h_mcc_rcv_ack_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_mcc_rcv_ack_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 			struct rtw_c2h_info *info)
 {
 	struct mac_ax_state_mach *sm = &adapter->sm;
@@ -2157,7 +2157,7 @@ u32 c2h_mcc_rcv_ack_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	return MACSUCCESS;
 }
 
-u32 c2h_mcc_req_ack_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_mcc_req_ack_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 			struct rtw_c2h_info *info)
 {
 	struct mac_ax_state_mach *sm = &adapter->sm;
@@ -2199,7 +2199,7 @@ u32 c2h_mcc_req_ack_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	return MACSUCCESS;
 }
 
-u32 c2h_mcc_tsf_rpt_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_mcc_tsf_rpt_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 			struct rtw_c2h_info *info)
 {
 	struct mac_ax_mcc_group_info *mcc_info = &adapter->mcc_group_info;
@@ -2251,7 +2251,7 @@ u32 c2h_mcc_tsf_rpt_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	return MACSUCCESS;
 }
 
-u32 c2h_mcc_status_rpt_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_mcc_status_rpt_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 			   struct rtw_c2h_info *info)
 {
 	struct mac_ax_mcc_group_info *mcc_info = &adapter->mcc_group_info;
@@ -2359,7 +2359,7 @@ static struct c2h_proc_func c2h_proc_mcc_cmd[] = {
 	{FWCMD_C2H_FUNC_NULL, NULL},
 };
 
-u32 c2h_mcc(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_mcc(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	    struct rtw_c2h_info *info)
 {
 	struct c2h_proc_func *proc = c2h_proc_mcc_cmd;
@@ -2392,7 +2392,7 @@ u32 c2h_mcc(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	return handler(adapter, buf, len, info);
 }
 
-u32 c2h_rx_dbg_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_rx_dbg_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 		   struct rtw_c2h_info *info)
 {
 	PLTFM_MSG_ERR("[ERR]%s: FW encounter Rx problem!\n", __func__);
@@ -2405,7 +2405,7 @@ static struct c2h_proc_func c2h_proc_fw_dbg_cmd[] = {
 	{FWCMD_C2H_FUNC_NULL, NULL},
 };
 
-u32 c2h_fw_dbg(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_fw_dbg(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	       struct rtw_c2h_info *info)
 {
 	struct c2h_proc_func *proc = c2h_proc_fw_dbg_cmd;
@@ -2438,7 +2438,7 @@ u32 c2h_fw_dbg(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	return handler(adapter, buf, len, info);
 }
 
-u32 c2h_wps_rpt(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_wps_rpt(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 		struct rtw_c2h_info *info)
 {
 	PLTFM_MSG_TRACE("recevied wps report\n");
@@ -2487,7 +2487,7 @@ static u32 c2h_cl_misc(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	return handler(adapter, buf, len, info);
 }
 
-u32 c2h_fast_ch_sw_rpt_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_fast_ch_sw_rpt_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 			   struct rtw_c2h_info *info)
 {
 	u32 *c2h_content;
@@ -2508,7 +2508,7 @@ static struct c2h_proc_func c2h_proc_fast_ch_sw_cmd[] = {
 	{FWCMD_C2H_FUNC_NULL, NULL},
 };
 
-u32 c2h_fast_ch_sw(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_fast_ch_sw(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 		   struct rtw_c2h_info *info)
 {
 	u32 hdr0;
@@ -2540,7 +2540,7 @@ u32 c2h_fast_ch_sw(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	return  handler(adapter, buf, len, info);
 }
 
-u32 c2h_port_init_stat(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_port_init_stat(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 		       struct rtw_c2h_info *info)
 {
 	struct fwcmd_port_init_stat stat;
@@ -2590,7 +2590,7 @@ u32 c2h_port_init_stat(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	return MACSUCCESS;
 }
 
-u32 c2h_port_cfg_stat(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_port_cfg_stat(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 		      struct rtw_c2h_info *info)
 {
 	struct fwcmd_port_cfg_stat stat;
@@ -2671,7 +2671,7 @@ static u32 c2h_cl_mport(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	return handler(adapter, buf, len, info);
 }
 
-u32 c2h_nan_act_req_ack_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_nan_act_req_ack_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 			    struct rtw_c2h_info *info)
 {
 	struct fwcmd_act_schedule_req_ack act_schedule;
@@ -2691,7 +2691,7 @@ u32 c2h_nan_act_req_ack_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 	return MACSUCCESS;
 }
 
-u32 c2h_nan_cluster_info_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
+static u32 c2h_nan_cluster_info_hdl(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
 			     struct rtw_c2h_info *info)
 {
 	struct fwcmd_nan_info_notify_cluster_info cluster_info;
@@ -2750,7 +2750,7 @@ static struct c2h_proc_func c2h_proc_nan_cmd[] = {
 	{FWCMD_C2H_FUNC_NULL, NULL},
 };
 
-u32 c2h_nan(struct mac_ax_adapter *adapter, u8 *buf, u32 len, struct rtw_c2h_info *info)
+static u32 c2h_nan(struct mac_ax_adapter *adapter, u8 *buf, u32 len, struct rtw_c2h_info *info)
 {
 	struct c2h_proc_func *proc = c2h_proc_nan_cmd;
 	u32(*handler)(struct mac_ax_adapter *adapter, u8 *buf, u32 len,
@@ -3170,7 +3170,7 @@ u32 mac_host_getpkt_h2c(struct mac_ax_adapter *adapter, u8 macid, u8 pkttype)
 }
 
 #if MAC_AX_PHL_H2C
-u32 __ie_cam_set_cmd(struct mac_ax_adapter *adapter, struct rtw_h2c_pkt *h2cb,
+static u32 __ie_cam_set_cmd(struct mac_ax_adapter *adapter, struct rtw_h2c_pkt *h2cb,
 		     struct mac_ax_ie_cam_cmd_info *info)
 {
 	struct fwcmd_ie_cam *cmd;
@@ -3302,7 +3302,7 @@ fail:
 	return ret;
 }
 
-u32 _mac_send_h2creg(struct mac_ax_adapter *adapter,
+static u32 _mac_send_h2creg(struct mac_ax_adapter *adapter,
 		     struct mac_ax_h2creg_info *h2c)
 {
 #define MAC_AX_H2CREG_CNT 100
@@ -3379,7 +3379,7 @@ u32 _mac_send_h2creg(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 __recv_c2hreg(struct mac_ax_adapter *adapter, struct fwcmd_c2hreg *c2h)
+static u32 __recv_c2hreg(struct mac_ax_adapter *adapter, struct fwcmd_c2hreg *c2h)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 	struct mac_ax_priv_ops *p_ops = adapter_to_priv_ops(adapter);
@@ -3405,7 +3405,7 @@ u32 __recv_c2hreg(struct mac_ax_adapter *adapter, struct fwcmd_c2hreg *c2h)
 	return MACSUCCESS;
 }
 
-u32 mac_recv_c2hreg(struct mac_ax_adapter *adapter,
+static u32 mac_recv_c2hreg(struct mac_ax_adapter *adapter,
 		    struct mac_ax_c2hreg_cont *cont)
 {
 	u32 ret;
@@ -3498,7 +3498,7 @@ fail:
 	return ret;
 }
 
-u32 poll_c2hreg(struct mac_ax_adapter *adapter,
+static u32 poll_c2hreg(struct mac_ax_adapter *adapter,
 		struct mac_ax_c2hreg_poll *c2h)
 {
 	u32 cnt, poll_us, ret;

--- a/phl/hal_g6/mac/mac_ax/gpio.c
+++ b/phl/hal_g6/mac/mac_ax/gpio.c
@@ -353,7 +353,7 @@ u32 mac_pinmux_free_func(struct mac_ax_adapter *adapter,
 	return mac_pinmux_record(adapter, func, 0);
 }
 
-u8 get_led_gpio(u8 led_id)
+static u8 get_led_gpio(u8 led_id)
 {
 /* LED 0 -> GPIO8 */
 	switch (led_id) {
@@ -454,7 +454,7 @@ END:
 	return ret;
 }
 
-u32 _mac_set_sw_gpio_mode(struct mac_ax_adapter *adapter,
+static u32 _mac_set_sw_gpio_mode(struct mac_ax_adapter *adapter,
 			  u8 output, u8 gpio)
 {
 	struct mac_ax_intf_ops *ops = adapter->ops->intf_ops;
@@ -707,7 +707,7 @@ u32 mac_get_gpio_val(struct mac_ax_adapter *adapter, u8 gpio, u8 *val)
 	return MACSUCCESS;
 }
 
-u32 mac_get_wl_dis_gpio(struct mac_ax_adapter *adapter, u8 *gpio)
+static u32 mac_get_wl_dis_gpio(struct mac_ax_adapter *adapter, u8 *gpio)
 {
 #define MAC_AX_HCI_SEL_SDIO_UART 0
 #define MAC_AX_HCI_SEL_USB_MULT 1

--- a/phl/hal_g6/mac/mac_ax/hci_fc.c
+++ b/phl/hal_g6/mac/mac_ax/hci_fc.c
@@ -1611,7 +1611,7 @@ static struct mac_ax_hfc_prec_cfg hfc_preccfg_sdio = {
 };
 #endif
 
-u32 hfc_reset_param(struct mac_ax_adapter *adapter)
+static u32 hfc_reset_param(struct mac_ax_adapter *adapter)
 {
 	struct mac_ax_hfc_param *param;
 	struct mac_ax_hfc_ch_cfg *ch_cfg, *ch_cfg_ini;

--- a/phl/hal_g6/mac/mac_ax/hw.c
+++ b/phl/hal_g6/mac/mac_ax/hw.c
@@ -60,7 +60,7 @@ struct mac_ax_hw_info *mac_get_hw_info(struct mac_ax_adapter *adapter)
 	return adapter->hw_info->done ? adapter->hw_info : NULL;
 }
 
-u32 get_block_tx_sel_msk(enum mac_ax_block_tx_sel src, u32 *msk)
+static u32 get_block_tx_sel_msk(enum mac_ax_block_tx_sel src, u32 *msk)
 {
 	switch (src) {
 	case MAC_AX_CCA:
@@ -91,7 +91,7 @@ u32 get_block_tx_sel_msk(enum mac_ax_block_tx_sel src, u32 *msk)
 	return MACSUCCESS;
 }
 
-u32 cfg_block_tx(struct mac_ax_adapter *adapter,
+static u32 cfg_block_tx(struct mac_ax_adapter *adapter,
 		 enum mac_ax_block_tx_sel src, u8 band, u8 en)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -132,7 +132,7 @@ u32 cfg_block_tx(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 get_block_tx(struct mac_ax_adapter *adapter,
+static u32 get_block_tx(struct mac_ax_adapter *adapter,
 		 enum mac_ax_block_tx_sel src, u8 band, u8 *en)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -605,7 +605,7 @@ static u32 set_accept_icverr(struct mac_ax_adapter *adapter, u8 enable)
 	return MACSUCCESS;
 }
 
-u32 set_gt3_timer(struct mac_ax_adapter *adapter,
+static u32 set_gt3_timer(struct mac_ax_adapter *adapter,
 		  struct mac_ax_gt3_cfg *cfg)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -663,7 +663,7 @@ u32 set_cctl_rty_limit(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 set_data_rty_limit(struct mac_ax_adapter *adapter,
+static u32 set_data_rty_limit(struct mac_ax_adapter *adapter,
 		       struct mac_ax_rty_lmt *rty)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -704,7 +704,7 @@ u32 set_data_rty_limit(struct mac_ax_adapter *adapter,
 	return ret;
 }
 
-u32 get_data_rty_limit(struct mac_ax_adapter *adapter,
+static u32 get_data_rty_limit(struct mac_ax_adapter *adapter,
 		       struct mac_ax_rty_lmt *rty)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -754,7 +754,7 @@ u32 set_bacam_mode(struct mac_ax_adapter *adapter, u8 mode_sel)
 #endif
 }
 
-u32 set_xtal_aac(struct mac_ax_adapter *adapter, u8 aac_mode)
+static u32 set_xtal_aac(struct mac_ax_adapter *adapter, u8 aac_mode)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 
@@ -772,7 +772,7 @@ u32 set_xtal_aac(struct mac_ax_adapter *adapter, u8 aac_mode)
 	return MACSUCCESS;
 }
 
-u32 set_rxd_zld_en(struct mac_ax_adapter *adapter, u8 enable)
+static u32 set_rxd_zld_en(struct mac_ax_adapter *adapter, u8 enable)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 	u32 val32;
@@ -795,7 +795,7 @@ u32 set_rxd_zld_en(struct mac_ax_adapter *adapter, u8 enable)
 	return MACSUCCESS;
 }
 
-u32 set_partial_pld_mode(struct mac_ax_adapter *adapter, u8 enable)
+static u32 set_partial_pld_mode(struct mac_ax_adapter *adapter, u8 enable)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 	u32 val32;
@@ -813,7 +813,7 @@ u32 set_partial_pld_mode(struct mac_ax_adapter *adapter, u8 enable)
 	return MACSUCCESS;
 }
 
-u32 set_nav_padding(struct mac_ax_adapter *adapter,
+static u32 set_nav_padding(struct mac_ax_adapter *adapter,
 		    struct mac_ax_nav_padding *nav)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -898,7 +898,7 @@ static void set_delay_tx_cfg(struct mac_ax_adapter *adapter,
 	MAC_REG_W32(R_AX_SS_DELAYTX_LEN_THR, val32);
 }
 
-u32 set_core_swr_volt(struct mac_ax_adapter *adapter,
+static u32 set_core_swr_volt(struct mac_ax_adapter *adapter,
 		      enum mac_ax_core_swr_volt volt_sel)
 {
 	u8 i, j, adjust = 0;
@@ -943,7 +943,8 @@ u32 set_core_swr_volt(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 set_pcie_driving_mponly(struct mac_ax_adapter *adapter,
+#if MAC_AX_PCIE_SUPPORT
+static u32 set_pcie_driving_mponly(struct mac_ax_adapter *adapter,
 			    enum mac_ax_pcie_driving_ctrl drving_ctrl)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -971,6 +972,7 @@ u32 set_pcie_driving_mponly(struct mac_ax_adapter *adapter,
 
 	return MACSUCCESS;
 }
+#endif /* MAC_AX_PCIE_SUPPORT */
 
 u32 set_macid_pause(struct mac_ax_adapter *adapter,
 		    struct mac_ax_macid_pause_cfg *cfg)
@@ -1074,7 +1076,8 @@ u32 set_macid_pause(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 set_cctl_preld(struct mac_ax_adapter *adapter,
+#if MAC_AX_PCIE_SUPPORT
+static u32 set_cctl_preld(struct mac_ax_adapter *adapter,
 		   struct mac_ax_cctl_preld_cfg *cfg)
 {
 #if MAC_AX_PCIE_SUPPORT
@@ -1095,6 +1098,7 @@ u32 set_cctl_preld(struct mac_ax_adapter *adapter,
 	return MACPROCERR;
 #endif
 }
+#endif /* MAC_AX_PCIE_SUPPORT */
 
 u32 macid_pause(struct mac_ax_adapter *adapter,
 		struct mac_ax_macid_pause_grp *grp)
@@ -1591,7 +1595,7 @@ u32 scheduler_set_prebkf(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 mac_get_tx_cnt(struct mac_ax_adapter *adapter,
+static u32 mac_get_tx_cnt(struct mac_ax_adapter *adapter,
 		   struct mac_ax_tx_cnt *cnt)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -1617,7 +1621,7 @@ u32 mac_get_tx_cnt(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 cfg_wdt_isr_rst(struct mac_ax_adapter *adapter)
+static u32 cfg_wdt_isr_rst(struct mac_ax_adapter *adapter)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 	u8 val = MAC_REG_R8(R_AX_PLATFORM_ENABLE);
@@ -1631,7 +1635,7 @@ u32 cfg_wdt_isr_rst(struct mac_ax_adapter *adapter)
 	return MACSUCCESS;
 }
 
-u32 mac_clr_tx_cnt(struct mac_ax_adapter *adapter,
+static u32 mac_clr_tx_cnt(struct mac_ax_adapter *adapter,
 		   struct mac_ax_tx_cnt *cnt)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -1709,7 +1713,7 @@ u32 mac_clr_tx_cnt(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 mac_set_adapter_info(struct mac_ax_adapter *adapter,
+static u32 mac_set_adapter_info(struct mac_ax_adapter *adapter,
 			 struct mac_ax_adapter_info *set)
 {
 #ifdef RTW_WKARD_GET_PROCESSOR_ID
@@ -2118,7 +2122,7 @@ u32 get_bacam_mode(struct mac_ax_adapter *adapter, u8 *mode_sel)
 #endif
 }
 
-u32 get_pwr_state(struct mac_ax_adapter *adapter, enum mac_ax_mac_pwr_st *st)
+static u32 get_pwr_state(struct mac_ax_adapter *adapter, enum mac_ax_mac_pwr_st *st)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 	u32 val;
@@ -2144,7 +2148,7 @@ u32 get_pwr_state(struct mac_ax_adapter *adapter, enum mac_ax_mac_pwr_st *st)
 	return MACSUCCESS;
 }
 
-void get_dflt_nav(struct mac_ax_adapter *adapter, u16 *nav)
+static void get_dflt_nav(struct mac_ax_adapter *adapter, u16 *nav)
 {
 	/* data NAV is consist of SIFS and ACK/BA time */
 	/* currently, we use SIFS + 64-bitmap BA as default NAV */

--- a/phl/hal_g6/mac/mac_ax/hw.c
+++ b/phl/hal_g6/mac/mac_ax/hw.c
@@ -60,7 +60,7 @@ struct mac_ax_hw_info *mac_get_hw_info(struct mac_ax_adapter *adapter)
 	return adapter->hw_info->done ? adapter->hw_info : NULL;
 }
 
-u32 get_block_tx_sel_msk(enum mac_ax_block_tx_sel src, u32 *msk)
+static u32 get_block_tx_sel_msk(enum mac_ax_block_tx_sel src, u32 *msk)
 {
 	switch (src) {
 	case MAC_AX_CCA:
@@ -91,7 +91,7 @@ u32 get_block_tx_sel_msk(enum mac_ax_block_tx_sel src, u32 *msk)
 	return MACSUCCESS;
 }
 
-u32 cfg_block_tx(struct mac_ax_adapter *adapter,
+static u32 cfg_block_tx(struct mac_ax_adapter *adapter,
 		 enum mac_ax_block_tx_sel src, u8 band, u8 en)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -132,7 +132,7 @@ u32 cfg_block_tx(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 get_block_tx(struct mac_ax_adapter *adapter,
+static u32 get_block_tx(struct mac_ax_adapter *adapter,
 		 enum mac_ax_block_tx_sel src, u8 band, u8 *en)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -605,7 +605,7 @@ static u32 set_accept_icverr(struct mac_ax_adapter *adapter, u8 enable)
 	return MACSUCCESS;
 }
 
-u32 set_gt3_timer(struct mac_ax_adapter *adapter,
+static u32 set_gt3_timer(struct mac_ax_adapter *adapter,
 		  struct mac_ax_gt3_cfg *cfg)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -663,7 +663,7 @@ u32 set_cctl_rty_limit(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 set_data_rty_limit(struct mac_ax_adapter *adapter,
+static u32 set_data_rty_limit(struct mac_ax_adapter *adapter,
 		       struct mac_ax_rty_lmt *rty)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -704,7 +704,7 @@ u32 set_data_rty_limit(struct mac_ax_adapter *adapter,
 	return ret;
 }
 
-u32 get_data_rty_limit(struct mac_ax_adapter *adapter,
+static u32 get_data_rty_limit(struct mac_ax_adapter *adapter,
 		       struct mac_ax_rty_lmt *rty)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -754,7 +754,7 @@ u32 set_bacam_mode(struct mac_ax_adapter *adapter, u8 mode_sel)
 #endif
 }
 
-u32 set_xtal_aac(struct mac_ax_adapter *adapter, u8 aac_mode)
+static u32 set_xtal_aac(struct mac_ax_adapter *adapter, u8 aac_mode)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 
@@ -772,7 +772,7 @@ u32 set_xtal_aac(struct mac_ax_adapter *adapter, u8 aac_mode)
 	return MACSUCCESS;
 }
 
-u32 set_rxd_zld_en(struct mac_ax_adapter *adapter, u8 enable)
+static u32 set_rxd_zld_en(struct mac_ax_adapter *adapter, u8 enable)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 	u32 val32;
@@ -795,7 +795,7 @@ u32 set_rxd_zld_en(struct mac_ax_adapter *adapter, u8 enable)
 	return MACSUCCESS;
 }
 
-u32 set_partial_pld_mode(struct mac_ax_adapter *adapter, u8 enable)
+static u32 set_partial_pld_mode(struct mac_ax_adapter *adapter, u8 enable)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 	u32 val32;
@@ -813,7 +813,7 @@ u32 set_partial_pld_mode(struct mac_ax_adapter *adapter, u8 enable)
 	return MACSUCCESS;
 }
 
-u32 set_nav_padding(struct mac_ax_adapter *adapter,
+static u32 set_nav_padding(struct mac_ax_adapter *adapter,
 		    struct mac_ax_nav_padding *nav)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -898,7 +898,7 @@ static void set_delay_tx_cfg(struct mac_ax_adapter *adapter,
 	MAC_REG_W32(R_AX_SS_DELAYTX_LEN_THR, val32);
 }
 
-u32 set_core_swr_volt(struct mac_ax_adapter *adapter,
+static u32 set_core_swr_volt(struct mac_ax_adapter *adapter,
 		      enum mac_ax_core_swr_volt volt_sel)
 {
 	u8 i, j, adjust = 0;
@@ -943,7 +943,7 @@ u32 set_core_swr_volt(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 set_pcie_driving_mponly(struct mac_ax_adapter *adapter,
+static u32 set_pcie_driving_mponly(struct mac_ax_adapter *adapter,
 			    enum mac_ax_pcie_driving_ctrl drving_ctrl)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -1074,7 +1074,7 @@ u32 set_macid_pause(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 set_cctl_preld(struct mac_ax_adapter *adapter,
+static u32 set_cctl_preld(struct mac_ax_adapter *adapter,
 		   struct mac_ax_cctl_preld_cfg *cfg)
 {
 #if MAC_AX_PCIE_SUPPORT
@@ -1591,7 +1591,7 @@ u32 scheduler_set_prebkf(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 mac_get_tx_cnt(struct mac_ax_adapter *adapter,
+static u32 mac_get_tx_cnt(struct mac_ax_adapter *adapter,
 		   struct mac_ax_tx_cnt *cnt)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -1617,7 +1617,7 @@ u32 mac_get_tx_cnt(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 cfg_wdt_isr_rst(struct mac_ax_adapter *adapter)
+static u32 cfg_wdt_isr_rst(struct mac_ax_adapter *adapter)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 	u8 val = MAC_REG_R8(R_AX_PLATFORM_ENABLE);
@@ -1631,7 +1631,7 @@ u32 cfg_wdt_isr_rst(struct mac_ax_adapter *adapter)
 	return MACSUCCESS;
 }
 
-u32 mac_clr_tx_cnt(struct mac_ax_adapter *adapter,
+static u32 mac_clr_tx_cnt(struct mac_ax_adapter *adapter,
 		   struct mac_ax_tx_cnt *cnt)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -1709,7 +1709,7 @@ u32 mac_clr_tx_cnt(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 mac_set_adapter_info(struct mac_ax_adapter *adapter,
+static u32 mac_set_adapter_info(struct mac_ax_adapter *adapter,
 			 struct mac_ax_adapter_info *set)
 {
 #ifdef RTW_WKARD_GET_PROCESSOR_ID
@@ -2118,7 +2118,7 @@ u32 get_bacam_mode(struct mac_ax_adapter *adapter, u8 *mode_sel)
 #endif
 }
 
-u32 get_pwr_state(struct mac_ax_adapter *adapter, enum mac_ax_mac_pwr_st *st)
+static u32 get_pwr_state(struct mac_ax_adapter *adapter, enum mac_ax_mac_pwr_st *st)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 	u32 val;
@@ -2144,7 +2144,7 @@ u32 get_pwr_state(struct mac_ax_adapter *adapter, enum mac_ax_mac_pwr_st *st)
 	return MACSUCCESS;
 }
 
-void get_dflt_nav(struct mac_ax_adapter *adapter, u16 *nav)
+static void get_dflt_nav(struct mac_ax_adapter *adapter, u16 *nav)
 {
 	/* data NAV is consist of SIFS and ACK/BA time */
 	/* currently, we use SIFS + 64-bitmap BA as default NAV */

--- a/phl/hal_g6/mac/mac_ax/init.c
+++ b/phl/hal_g6/mac/mac_ax/init.c
@@ -21,7 +21,7 @@
 #include "_pcie.h"
 #endif
 
-u32 mac_set_dut_env_mode(struct mac_ax_adapter *adapter, enum rtw_mac_env_mode env_mode)
+static u32 mac_set_dut_env_mode(struct mac_ax_adapter *adapter, enum rtw_mac_env_mode env_mode)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 	u32 val32;
@@ -178,7 +178,7 @@ struct mac_ax_adapter *get_mac_ax_adapter(enum mac_ax_intf intf,
 }
 #endif
 
-u32 hci_func_en(struct mac_ax_adapter *adapter)
+static u32 hci_func_en(struct mac_ax_adapter *adapter)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 	u32 val32, reg;
@@ -204,7 +204,7 @@ u32 hci_func_en(struct mac_ax_adapter *adapter)
 	return ret;
 }
 
-u32 dmac_pre_init(struct mac_ax_adapter *adapter, enum mac_ax_qta_mode mode, u8 fwdl)
+static u32 dmac_pre_init(struct mac_ax_adapter *adapter, enum mac_ax_qta_mode mode, u8 fwdl)
 {
 	struct mac_ax_priv_ops *p_ops = adapter_to_priv_ops(adapter);
 	u32 ret;
@@ -302,7 +302,7 @@ u32 cmac_func_en(struct mac_ax_adapter *adapter, u8 band, u8 en)
 	return MACSUCCESS;
 }
 
-u32 chip_func_en(struct mac_ax_adapter *adapter)
+static u32 chip_func_en(struct mac_ax_adapter *adapter)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 

--- a/phl/hal_g6/mac/mac_ax/mac_8852b/coex_8852b.c
+++ b/phl/hal_g6/mac/mac_ax/mac_8852b/coex_8852b.c
@@ -145,7 +145,7 @@ u32 mac_read_lte_8852b(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-void _patch_hi_pri_resp_tx_8852b(struct mac_ax_adapter *adapter)
+static void _patch_hi_pri_resp_tx_8852b(struct mac_ax_adapter *adapter)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 	u8 val;

--- a/phl/hal_g6/mac/mac_ax/mac_8852b/fwcmd_8852b.c
+++ b/phl/hal_g6/mac/mac_ax/mac_8852b/fwcmd_8852b.c
@@ -15,6 +15,7 @@
 
 #include "../../type.h"
 #include "../mac_priv.h"
+#include "fwcmd_8852b.h"
 #if MAC_AX_8852B_SUPPORT
 
 static struct mac_ax_h2creg_offset h2creg_offset = {

--- a/phl/hal_g6/mac/mac_ax/mac_8852b/mac_priv_8852b.c
+++ b/phl/hal_g6/mac/mac_ax/mac_8852b/mac_priv_8852b.c
@@ -35,6 +35,7 @@
 #endif
 #if MAC_AX_SDIO_SUPPORT
 #include "_sdio_8852b.h"
+#include "mac_priv_8852b.h"
 #endif
 
 #if MAC_AX_8852B_SUPPORT

--- a/phl/hal_g6/mac/mac_ax/mac_8852b/pwr_seq_func_8852b.c
+++ b/phl/hal_g6/mac/mac_ax/mac_8852b/pwr_seq_func_8852b.c
@@ -22,7 +22,7 @@
 #define PWR_K_CHK_OFFSET 0x5E9
 #define PWR_K_CHK_VALUE 0xAA
 
-u32 _patch_ck_buf_level(struct mac_ax_adapter *adapter)
+static u32 _patch_ck_buf_level(struct mac_ax_adapter *adapter)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 	u32 val32;

--- a/phl/hal_g6/mac/mac_ax/mac_8852b/pwr_seq_func_8852b.c
+++ b/phl/hal_g6/mac/mac_ax/mac_8852b/pwr_seq_func_8852b.c
@@ -15,6 +15,7 @@
 
 #include "../pwr.h"
 #include "../pwr_seq_func.h"
+#include "pwr_seq_func_8852b.h"
 
 #if MAC_AX_8852B_SUPPORT
 

--- a/phl/hal_g6/mac/mac_ax/mport.c
+++ b/phl/hal_g6/mac/mac_ax/mport.c
@@ -320,7 +320,7 @@ u32 get_bp_idx(u8 band, u8 port)
 	return (band * MAC_AX_BAND_NUM + port);
 }
 
-u32 _get_port_cfg(struct mac_ax_adapter *adapter,
+static u32 _get_port_cfg(struct mac_ax_adapter *adapter,
 		  enum mac_ax_port_cfg_type type,
 		  struct mac_ax_port_cfg_para *para)
 {
@@ -1281,7 +1281,7 @@ static u32 fast_bcn_drop(struct mac_ax_adapter *adapter, u8 band, u8 port,
 	return MACSUCCESS;
 }
 
-u32 _patch_port_dis_flow(struct mac_ax_adapter *adapter, u8 band, u8 port,
+static u32 _patch_port_dis_flow(struct mac_ax_adapter *adapter, u8 band, u8 port,
 			 struct mac_ax_port_info *pinfo)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -1373,7 +1373,7 @@ end:
 	return ret;
 }
 
-u32 _patch_tbtt_shift_setval(struct mac_ax_adapter *adapter, u32 bcnspc,
+static u32 _patch_tbtt_shift_setval(struct mac_ax_adapter *adapter, u32 bcnspc,
 			     u32 *shift_val)
 {
 	if (!chk_patch_tbtt_shift_setval(adapter))

--- a/phl/hal_g6/mac/mac_ax/power_saving.c
+++ b/phl/hal_g6/mac/mac_ax/power_saving.c
@@ -601,7 +601,7 @@ u32 mac_ps_pwr_state(struct mac_ax_adapter *adapter,
 	return ret;
 }
 
-void show_rx_bcn_info(struct mac_ax_adapter *adapter)
+static void show_rx_bcn_info(struct mac_ax_adapter *adapter)
 {
 	u8 role_idx, bcn_rate, hit_rate, no_hit_rate;
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -1067,7 +1067,7 @@ u32 mac_periodic_wake_cfg(struct mac_ax_adapter *adapter,
 	return ret;
 }
 
-u32 send_h2c_req_pwr_state(struct mac_ax_adapter *adapter,
+static u32 send_h2c_req_pwr_state(struct mac_ax_adapter *adapter,
 			   struct req_pwr_state_cfg *parm)
 {
 	u8 *buf;
@@ -1129,7 +1129,7 @@ fail:
 	return ret;
 }
 
-u32 set_pwr_st_cfg(struct mac_ax_adapter *adapter,
+static u32 set_pwr_st_cfg(struct mac_ax_adapter *adapter,
 		   struct req_pwr_state_cfg *parm)
 {
 	u32 ret = MACSUCCESS;
@@ -1266,7 +1266,7 @@ u32 mac_req_pwr_state_cfg(struct mac_ax_adapter *adapter,
 	return ret;
 }
 
-u32 send_h2c_req_pwr_lvl(struct mac_ax_adapter *adapter,
+static u32 send_h2c_req_pwr_lvl(struct mac_ax_adapter *adapter,
 			 struct req_pwr_lvl_cfg *parm)
 {
 	u8 *buf;
@@ -1362,7 +1362,7 @@ u32 mac_req_pwr_lvl_cfg(struct mac_ax_adapter *adapter,
 	return ret;
 }
 
-u32 send_h2c_lps_option_cfg(struct mac_ax_adapter *adapter,
+static u32 send_h2c_lps_option_cfg(struct mac_ax_adapter *adapter,
 			    struct lps_option_cfg *parm)
 {
 	u8 *buf;
@@ -1441,7 +1441,7 @@ u32 mac_lps_option_cfg(struct mac_ax_adapter *adapter,
 	return ret;
 }
 
-u32 send_h2c_tbtt_tuning(struct mac_ax_adapter *adapter,
+static u32 send_h2c_tbtt_tuning(struct mac_ax_adapter *adapter,
 			 struct tbtt_tuning_cfg *parm)
 {
 	u8 *buf;

--- a/phl/hal_g6/mac/mac_ax/power_saving.c
+++ b/phl/hal_g6/mac/mac_ax/power_saving.c
@@ -601,7 +601,7 @@ u32 mac_ps_pwr_state(struct mac_ax_adapter *adapter,
 	return ret;
 }
 
-void show_rx_bcn_info(struct mac_ax_adapter *adapter)
+static void show_rx_bcn_info(struct mac_ax_adapter *adapter)
 {
 	u8 role_idx, bcn_rate, hit_rate, no_hit_rate;
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
@@ -1067,7 +1067,7 @@ u32 mac_periodic_wake_cfg(struct mac_ax_adapter *adapter,
 	return ret;
 }
 
-u32 send_h2c_req_pwr_state(struct mac_ax_adapter *adapter,
+static u32 send_h2c_req_pwr_state(struct mac_ax_adapter *adapter,
 			   struct req_pwr_state_cfg *parm)
 {
 	u8 *buf;
@@ -1129,7 +1129,7 @@ fail:
 	return ret;
 }
 
-u32 set_pwr_st_cfg(struct mac_ax_adapter *adapter,
+static u32 set_pwr_st_cfg(struct mac_ax_adapter *adapter,
 		   struct req_pwr_state_cfg *parm)
 {
 	u32 ret = MACSUCCESS;
@@ -1266,7 +1266,7 @@ u32 mac_req_pwr_state_cfg(struct mac_ax_adapter *adapter,
 	return ret;
 }
 
-u32 send_h2c_req_pwr_lvl(struct mac_ax_adapter *adapter,
+static u32 send_h2c_req_pwr_lvl(struct mac_ax_adapter *adapter,
 			 struct req_pwr_lvl_cfg *parm)
 {
 	u8 *buf;
@@ -1362,7 +1362,8 @@ u32 mac_req_pwr_lvl_cfg(struct mac_ax_adapter *adapter,
 	return ret;
 }
 
-u32 send_h2c_lps_option_cfg(struct mac_ax_adapter *adapter,
+#if MAC_AX_USB_SUPPORT
+static u32 send_h2c_lps_option_cfg(struct mac_ax_adapter *adapter,
 			    struct lps_option_cfg *parm)
 {
 	u8 *buf;
@@ -1423,6 +1424,7 @@ fail:
 
 	return ret;
 }
+#endif /* MAC_AX_USB_SUPPORT */
 
 u32 mac_lps_option_cfg(struct mac_ax_adapter *adapter,
 		       struct mac_lps_option *lps_opt)
@@ -1441,7 +1443,7 @@ u32 mac_lps_option_cfg(struct mac_ax_adapter *adapter,
 	return ret;
 }
 
-u32 send_h2c_tbtt_tuning(struct mac_ax_adapter *adapter,
+static u32 send_h2c_tbtt_tuning(struct mac_ax_adapter *adapter,
 			 struct tbtt_tuning_cfg *parm)
 {
 	u8 *buf;

--- a/phl/hal_g6/mac/mac_ax/role.c
+++ b/phl/hal_g6/mac/mac_ax/role.c
@@ -394,7 +394,7 @@ u32 role_tbl_exit(struct mac_ax_adapter *adapter)
 	return ret;
 }
 
-u32 role_info_init(struct mac_ax_adapter *adapter,
+static u32 role_info_init(struct mac_ax_adapter *adapter,
 		   struct mac_ax_role_info *info)
 {
 	u8 i;
@@ -439,7 +439,7 @@ u32 role_info_init(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 sec_info_init(struct mac_ax_adapter *adapter,
+static u32 sec_info_init(struct mac_ax_adapter *adapter,
 		  struct mac_ax_role_info *info)
 {
 	u8 i;
@@ -453,7 +453,7 @@ u32 sec_info_init(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 sec_info_deinit(struct mac_ax_adapter *adapter,
+static u32 sec_info_deinit(struct mac_ax_adapter *adapter,
 		    struct mac_ax_role_info *info,
 		    struct mac_role_tbl *role)
 {
@@ -487,7 +487,7 @@ u32 sec_info_deinit(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 role_init(struct mac_ax_adapter *adapter,
+static u32 role_init(struct mac_ax_adapter *adapter,
 	      struct mac_role_tbl *role,
 	      struct mac_ax_role_info *info)
 {
@@ -526,7 +526,7 @@ u32 role_init(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 set_role_bss_clr(struct mac_ax_adapter *adapter,
+static u32 set_role_bss_clr(struct mac_ax_adapter *adapter,
 		     struct mac_ax_role_info *info)
 {
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);

--- a/phl/hal_g6/mac/mac_ax/security_cam.c
+++ b/phl/hal_g6/mac/mac_ax/security_cam.c
@@ -152,7 +152,7 @@ u32 fill_sec_cam_info(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 fill_addr_cam_sec_only(struct mac_ax_adapter *adapter,
+static u32 fill_addr_cam_sec_only(struct mac_ax_adapter *adapter,
 			   struct mac_ax_role_info *info,
 			   struct addr_sec_only_info *addr_sec_info)
 {
@@ -208,7 +208,7 @@ u32 fill_addr_cam_sec_only(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 mac_upd_sec_infotbl(struct mac_ax_adapter *adapter,
+static u32 mac_upd_sec_infotbl(struct mac_ax_adapter *adapter,
 			struct fwcmd_seccam_info *info)
 {
 	u32 ret = 0, s_info_tbl[6], cam_address = 0;
@@ -300,7 +300,7 @@ fail:
 	return ret;
 }
 
-u8 check_key_index(u8 addr_cam_sec_mode, u8 key_type, u8 key_index)
+static u8 check_key_index(u8 addr_cam_sec_mode, u8 key_type, u8 key_index)
 {
 	switch (addr_cam_sec_mode) {
 	case ADDR_CAM_SEC_MODE_ZERO:
@@ -361,7 +361,7 @@ u8 check_key_index(u8 addr_cam_sec_mode, u8 key_type, u8 key_index)
 	return 1;
 }
 
-u8 decide_key_index(u8 addr_cam_sec_mode, u8 key_type)
+static u8 decide_key_index(u8 addr_cam_sec_mode, u8 key_type)
 {
 	u8 key_index = 0;
 
@@ -404,7 +404,7 @@ u8 decide_key_index(u8 addr_cam_sec_mode, u8 key_type)
 	return key_index;
 }
 
-u8 decide_sec_cam_index(struct mac_ax_adapter *adapter, u8 *sec_cam_idx)
+static u8 decide_sec_cam_index(struct mac_ax_adapter *adapter, u8 *sec_cam_idx)
 {
 	u8 sec_idx = 0, i = 0;
 	/* call by pointer */
@@ -460,7 +460,7 @@ u8 decide_sec_cam_index(struct mac_ax_adapter *adapter, u8 *sec_cam_idx)
 	return MACSECCAMFL;
 }
 
-u8 delete_key_from_addr_cam(struct mac_ax_adapter *adapter,
+static u8 delete_key_from_addr_cam(struct mac_ax_adapter *adapter,
 			    struct mac_role_tbl *role, u8 key_type,
 			    u8 key_id, u8 *sec_cam_idx)
 {
@@ -516,7 +516,7 @@ u8 delete_key_from_addr_cam(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u8 insert_key_to_addr_cam(struct mac_ax_adapter *adapter,
+static u8 insert_key_to_addr_cam(struct mac_ax_adapter *adapter,
 			  struct mac_role_tbl *role, u8 key_type,
 			  u8 key_id, u8 sec_cam_idx)
 {
@@ -565,7 +565,7 @@ u8 insert_key_to_addr_cam(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u32 m_security_cam_hal(struct mac_ax_adapter *adapter,
+static u32 m_security_cam_hal(struct mac_ax_adapter *adapter,
 		       struct mac_ax_sec_cam_info *sec_cam_info,
 		       u8 mac_id, u8 key_id, u8 key_type,
 		       u8 sec_cam_idx, u8 clear)
@@ -832,7 +832,7 @@ u32 mac_sta_hw_security_support(struct mac_ax_adapter *adapter,
 	return MACSUCCESS;
 }
 
-u8 check_key_type(u8 addr_cam_sec_mode, u8 key_index)
+static u8 check_key_type(u8 addr_cam_sec_mode, u8 key_index)
 {
 	switch (addr_cam_sec_mode) {
 	case ADDR_CAM_SEC_MODE_ZERO:

--- a/phl/hal_g6/mac/mac_ax/ser.c
+++ b/phl/hal_g6/mac/mac_ax/ser.c
@@ -198,7 +198,7 @@ u32 mac_trigger_dmac_err(struct mac_ax_adapter *adapter)
 	return MACSUCCESS;
 }
 
-u32 mac_dump_qta_lost(struct mac_ax_adapter *adapter)
+static u32 mac_dump_qta_lost(struct mac_ax_adapter *adapter)
 {
 	struct dle_dfi_qempty_t qempty;
 	struct dle_dfi_quota_t quota;
@@ -314,7 +314,7 @@ u32 mac_dump_qta_lost(struct mac_ax_adapter *adapter)
 	return MACSUCCESS;
 }
 
-u32 mac_dump_l0_to_l1(struct mac_ax_adapter *adapter,
+static u32 mac_dump_l0_to_l1(struct mac_ax_adapter *adapter,
 		      enum mac_ax_err_info err)
 {
 	u32 dbg, event;

--- a/phl/hal_g6/mac/mac_ax/sta_sch.c
+++ b/phl/hal_g6/mac/mac_ax/sta_sch.c
@@ -360,7 +360,7 @@ u32 sta_link_cfg(struct mac_ax_adapter *adapter,
 	return ret;
 }
 
-void set_ss_wmm_tbl(struct mac_ax_adapter *adapter,
+static void set_ss_wmm_tbl(struct mac_ax_adapter *adapter,
 		    struct mac_ax_ss_wmm_tbl_ctrl *ctrl)
 {
 	u32 val32;
@@ -397,7 +397,7 @@ void ss_wmm_tbl_cfg(struct mac_ax_adapter *adapter,
 	set_ss_wmm_tbl(adapter, ctrl);
 }
 
-u32 switch_wmm_macid(struct mac_ax_adapter *adapter,
+static u32 switch_wmm_macid(struct mac_ax_adapter *adapter,
 		     struct mac_ax_ss_link_info *link,
 		     enum mac_ax_ss_wmm_tbl src_link,
 		     enum mac_ax_ss_wmm_tbl dst_link)

--- a/phl/hal_g6/mac/mac_ax/tblupd.c
+++ b/phl/hal_g6/mac/mac_ax/tblupd.c
@@ -841,7 +841,7 @@ fail:
 	return ret;
 }
 
-void _set_role_cctrl(struct mac_ax_adapter *adapter,
+static void _set_role_cctrl(struct mac_ax_adapter *adapter,
 		     struct rtw_hal_mac_ax_cctl_info *info,
 		     struct rtw_hal_mac_ax_cctl_info *mask,
 		     struct rtw_hal_mac_ax_cctl_info *cctrl)
@@ -1068,7 +1068,7 @@ void _set_role_cctrl(struct mac_ax_adapter *adapter,
 			(mask->csi_bw & info->csi_bw);
 }
 
-void mac_upd_role_cctrl(struct mac_ax_adapter *adapter,
+static void mac_upd_role_cctrl(struct mac_ax_adapter *adapter,
 			struct rtw_hal_mac_ax_cctl_info *info,
 			struct rtw_hal_mac_ax_cctl_info *mask, u8 macid)
 {

--- a/phl/hal_g6/mac/mac_ax/trxcfg.c
+++ b/phl/hal_g6/mac/mac_ax/trxcfg.c
@@ -1924,7 +1924,7 @@ static u32 nav_ctrl_init(struct mac_ax_adapter *adapter, u8 band)
 	return MACSUCCESS;
 }
 
-u32 dmac_init(struct mac_ax_adapter *adapter, struct mac_ax_trx_info *info,
+static u32 dmac_init(struct mac_ax_adapter *adapter, struct mac_ax_trx_info *info,
 	      enum mac_ax_band band)
 {
 	u32 ret = 0;

--- a/phl/hal_g6/mac/mac_ax/wowlan.c
+++ b/phl/hal_g6/mac/mac_ax/wowlan.c
@@ -1611,7 +1611,7 @@ u32 mac_get_wow_fw_status(struct mac_ax_adapter *adapter, u8 *status,
 	return MACSUCCESS;
 }
 
-u32 _mac_request_aoac_report_rx_rdy(struct mac_ax_adapter *adapter)
+static u32 _mac_request_aoac_report_rx_rdy(struct mac_ax_adapter *adapter)
 {
 	u32 ret;
 	#if MAC_AX_PHL_H2C
@@ -1686,7 +1686,7 @@ fail:
 	return ret;
 }
 
-u32 _mac_request_aoac_report_rx_not_rdy(struct mac_ax_adapter *adapter)
+static u32 _mac_request_aoac_report_rx_not_rdy(struct mac_ax_adapter *adapter)
 {
 	struct mac_ax_wowlan_info *wow_info = &adapter->wowlan_info;
 	struct mac_ax_aoac_report *aoac_rpt = (struct mac_ax_aoac_report *)wow_info->aoac_report;

--- a/phl/hal_g6/phy/bb/halbb.c
+++ b/phl/hal_g6/phy/bb/halbb.c
@@ -519,7 +519,7 @@ void halbb_sta_info_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 	}
 }
 
-void halbb_traffic_load_decision(struct bb_info *bb)
+static void halbb_traffic_load_decision(struct bb_info *bb)
 {
 	struct rtw_stats *stat = &bb->phl_com->phl_stats;
 	struct bb_link_info *link = &bb->bb_link_i;
@@ -647,7 +647,7 @@ u8 halbb_get_rssi_min(struct bb_info *bb)
 	return rssi_min;
 }
 
-void halbb_cmn_info_self_update(struct bb_info *bb)
+static void halbb_cmn_info_self_update(struct bb_info *bb)
 {
 	struct rtw_hal_com_t *hal = bb->hal_com;
 	struct bb_link_info *link = &bb->bb_link_i;
@@ -872,7 +872,7 @@ void halbb_watchdog_reset(struct bb_info *bb)
 
 }
 
-void halbb_update_hal_info(struct bb_info *bb)
+static void halbb_update_hal_info(struct bb_info *bb)
 {
 	struct rtw_hal_com_t *hal = bb->hal_com;
 
@@ -884,7 +884,7 @@ void halbb_store_data(struct bb_info *bb)
 	halbb_cmn_info_rpt_store_data(bb);
 }
 
-void halbb_reset(struct bb_info *bb)
+static void halbb_reset(struct bb_info *bb)
 {
 	if (bb->bb_cmn_hooker->bb_cmn_dbg_i.cmn_log_2_cnsl_en)
 		return;
@@ -899,7 +899,7 @@ void halbb_reset(struct bb_info *bb)
 	halbb_cmn_info_rpt_reset(bb);
 }
 
-void halbb_watchdog_normal(struct bb_info *bb, enum phl_phy_idx phy_idx)
+static void halbb_watchdog_normal(struct bb_info *bb, enum phl_phy_idx phy_idx)
 {
 	halbb_cmn_info_self_update(bb);
 	halbb_ic_hw_setting(bb);
@@ -957,7 +957,7 @@ void halbb_watchdog_normal(struct bb_info *bb, enum phl_phy_idx phy_idx)
 	halbb_reset(bb);
 }
 
-void halbb_watchdog_low_io(struct bb_info *bb, enum phl_phy_idx phy_idx)
+static void halbb_watchdog_low_io(struct bb_info *bb, enum phl_phy_idx phy_idx)
 {
 	halbb_cmn_info_self_update(bb);
 	halbb_ic_hw_setting_low_io(bb);
@@ -981,7 +981,7 @@ void halbb_watchdog_low_io(struct bb_info *bb, enum phl_phy_idx phy_idx)
 	halbb_reset(bb);
 }
 
-void halbb_watchdog_non_io(struct bb_info *bb, enum phl_phy_idx phy_idx)
+static void halbb_watchdog_non_io(struct bb_info *bb, enum phl_phy_idx phy_idx)
 {
 	halbb_cmn_info_self_update(bb);
 	halbb_ic_hw_setting_non_io(bb);
@@ -990,7 +990,7 @@ void halbb_watchdog_non_io(struct bb_info *bb, enum phl_phy_idx phy_idx)
 	halbb_reset(bb);
 }
 
-void halbb_watchdog_mp(struct bb_info *bb, enum phl_phy_idx phy_idx)
+static void halbb_watchdog_mp(struct bb_info *bb, enum phl_phy_idx phy_idx)
 {
 	halbb_cmn_info_self_update(bb);
 	halbb_basic_dbg_message(bb);
@@ -999,7 +999,7 @@ void halbb_watchdog_mp(struct bb_info *bb, enum phl_phy_idx phy_idx)
 	halbb_reset(bb);
 }
 
-void halbb_watchdog_dbcc(struct bb_info *bb)
+static void halbb_watchdog_dbcc(struct bb_info *bb)
 {
 #ifdef HALBB_DBCC_SUPPORT
 	BB_DBG(bb, DBG_COMMON_FLOW, "[%s] phy_idx=%d\n", __func__,
@@ -1033,7 +1033,7 @@ void halbb_watchdog_dbcc(struct bb_info *bb)
 #endif
 }
 
-void halbb_watchdog_per_phy(struct bb_info *bb_0, enum bb_watchdog_mode_t mode, enum phl_phy_idx phy_idx)
+static void halbb_watchdog_per_phy(struct bb_info *bb_0, enum bb_watchdog_mode_t mode, enum phl_phy_idx phy_idx)
 {
 	struct bb_info *bb = bb_0;
 	bool is_mp_mode = false;
@@ -1106,7 +1106,7 @@ void halbb_watchdog(struct bb_info *bb_0, enum bb_watchdog_mode_t mode, enum phl
 #endif
 }
 
-void halbb_new_entry_connect(struct bb_info *bb)
+static void halbb_new_entry_connect(struct bb_info *bb)
 {
 	struct bb_dig_info *dig = &bb->bb_dig_i;
 	u8 igi_new;

--- a/phl/hal_g6/phy/bb/halbb.c
+++ b/phl/hal_g6/phy/bb/halbb.c
@@ -519,7 +519,7 @@ void halbb_sta_info_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 	}
 }
 
-void halbb_traffic_load_decision(struct bb_info *bb)
+static void halbb_traffic_load_decision(struct bb_info *bb)
 {
 	struct rtw_stats *stat = &bb->phl_com->phl_stats;
 	struct bb_link_info *link = &bb->bb_link_i;
@@ -647,7 +647,7 @@ u8 halbb_get_rssi_min(struct bb_info *bb)
 	return rssi_min;
 }
 
-void halbb_cmn_info_self_update(struct bb_info *bb)
+static void halbb_cmn_info_self_update(struct bb_info *bb)
 {
 	struct rtw_hal_com_t *hal = bb->hal_com;
 	struct bb_link_info *link = &bb->bb_link_i;
@@ -872,7 +872,7 @@ void halbb_watchdog_reset(struct bb_info *bb)
 
 }
 
-void halbb_update_hal_info(struct bb_info *bb)
+static void halbb_update_hal_info(struct bb_info *bb)
 {
 	struct rtw_hal_com_t *hal = bb->hal_com;
 
@@ -884,7 +884,7 @@ void halbb_store_data(struct bb_info *bb)
 	halbb_cmn_info_rpt_store_data(bb);
 }
 
-void halbb_reset(struct bb_info *bb)
+static void halbb_reset(struct bb_info *bb)
 {
 	if (bb->bb_cmn_hooker->bb_cmn_dbg_i.cmn_log_2_cnsl_en)
 		return;
@@ -899,7 +899,7 @@ void halbb_reset(struct bb_info *bb)
 	halbb_cmn_info_rpt_reset(bb);
 }
 
-void halbb_watchdog_normal(struct bb_info *bb, enum phl_phy_idx phy_idx)
+static void halbb_watchdog_normal(struct bb_info *bb, enum phl_phy_idx phy_idx)
 {
 	halbb_cmn_info_self_update(bb);
 	halbb_ic_hw_setting(bb);
@@ -957,7 +957,7 @@ void halbb_watchdog_normal(struct bb_info *bb, enum phl_phy_idx phy_idx)
 	halbb_reset(bb);
 }
 
-void halbb_watchdog_low_io(struct bb_info *bb, enum phl_phy_idx phy_idx)
+static void halbb_watchdog_low_io(struct bb_info *bb, enum phl_phy_idx phy_idx)
 {
 	halbb_cmn_info_self_update(bb);
 	halbb_ic_hw_setting_low_io(bb);
@@ -981,7 +981,7 @@ void halbb_watchdog_low_io(struct bb_info *bb, enum phl_phy_idx phy_idx)
 	halbb_reset(bb);
 }
 
-void halbb_watchdog_non_io(struct bb_info *bb, enum phl_phy_idx phy_idx)
+static void halbb_watchdog_non_io(struct bb_info *bb, enum phl_phy_idx phy_idx)
 {
 	halbb_cmn_info_self_update(bb);
 	halbb_ic_hw_setting_non_io(bb);
@@ -990,7 +990,7 @@ void halbb_watchdog_non_io(struct bb_info *bb, enum phl_phy_idx phy_idx)
 	halbb_reset(bb);
 }
 
-void halbb_watchdog_mp(struct bb_info *bb, enum phl_phy_idx phy_idx)
+static void halbb_watchdog_mp(struct bb_info *bb, enum phl_phy_idx phy_idx)
 {
 	halbb_cmn_info_self_update(bb);
 	halbb_basic_dbg_message(bb);
@@ -999,7 +999,8 @@ void halbb_watchdog_mp(struct bb_info *bb, enum phl_phy_idx phy_idx)
 	halbb_reset(bb);
 }
 
-void halbb_watchdog_dbcc(struct bb_info *bb)
+#ifdef HALBB_DBCC_SUPPORT
+static void halbb_watchdog_dbcc(struct bb_info *bb)
 {
 #ifdef HALBB_DBCC_SUPPORT
 	BB_DBG(bb, DBG_COMMON_FLOW, "[%s] phy_idx=%d\n", __func__,
@@ -1032,8 +1033,9 @@ void halbb_watchdog_dbcc(struct bb_info *bb)
 	halbb_reset(bb);
 #endif
 }
+#endif /* HALBB_DBCC_SUPPORT */
 
-void halbb_watchdog_per_phy(struct bb_info *bb_0, enum bb_watchdog_mode_t mode, enum phl_phy_idx phy_idx)
+static void halbb_watchdog_per_phy(struct bb_info *bb_0, enum bb_watchdog_mode_t mode, enum phl_phy_idx phy_idx)
 {
 	struct bb_info *bb = bb_0;
 	bool is_mp_mode = false;
@@ -1106,7 +1108,7 @@ void halbb_watchdog(struct bb_info *bb_0, enum bb_watchdog_mode_t mode, enum phl
 #endif
 }
 
-void halbb_new_entry_connect(struct bb_info *bb)
+static void halbb_new_entry_connect(struct bb_info *bb)
 {
 	struct bb_dig_info *dig = &bb->bb_dig_i;
 	u8 igi_new;

--- a/phl/hal_g6/phy/bb/halbb_8852b/halbb_8852b.c
+++ b/phl/hal_g6/phy/bb/halbb_8852b/halbb_8852b.c
@@ -85,7 +85,7 @@ bool halbb_chk_tx_idle_8852b(struct bb_info *bb, enum phl_phy_idx phy_idx)
 	return idle;
 }
 
-void halbb_stop_pmac_tx_8852b(struct bb_info *bb,
+static void halbb_stop_pmac_tx_8852b(struct bb_info *bb,
 			      struct halbb_pmac_info *tx_info,
 			      enum phl_phy_idx phy_idx)
 {
@@ -107,7 +107,7 @@ void halbb_stop_pmac_tx_8852b(struct bb_info *bb,
 }
 
 
-void halbb_start_pmac_tx_8852b(struct bb_info *bb,
+static void halbb_start_pmac_tx_8852b(struct bb_info *bb,
 			       struct halbb_pmac_info *tx_info,
 			       enum halbb_pmac_mode mode, u32 pkt_cnt,u16 period,
 			       enum phl_phy_idx phy_idx)

--- a/phl/hal_g6/phy/bb/halbb_8852b/halbb_8852b_api.c
+++ b/phl/hal_g6/phy/bb/halbb_8852b/halbb_8852b_api.c
@@ -312,7 +312,7 @@ void halbb_tssi_cont_en_8852b(struct bb_info *bb, bool en, enum rf_path path)
 	else
 		halbb_set_reg(bb, tssi_trk_man[path], BIT(30), 0x1);
 }
-void halbb_bb_reset_all_8852b(struct bb_info *bb, enum phl_phy_idx phy_idx)
+static void halbb_bb_reset_all_8852b(struct bb_info *bb, enum phl_phy_idx phy_idx)
 {
 	BB_DBG(bb, DBG_DBG_API, "%s\n", __func__);
 
@@ -476,7 +476,7 @@ u32 halbb_read_rf_reg_8852b(struct bb_info *bb, enum rf_path path, u32 reg_addr,
 	return readback_value;
 }
 
-void halbb_5m_mask_8852b(struct bb_info *bb, u8 pri_ch_idx, enum channel_width bw,
+static void halbb_5m_mask_8852b(struct bb_info *bb, u8 pri_ch_idx, enum channel_width bw,
 			   enum phl_phy_idx phy_idx)
 {
 	bool mask_5m_low = false;
@@ -1973,7 +1973,7 @@ void halbb_pre_agc_en_8852b(struct bb_info *bb, bool enable)
 	       en, en);
 }
 
-s8 halbb_efuse_exchange_8852b(struct bb_info *bb, u8 value,
+static s8 halbb_efuse_exchange_8852b(struct bb_info *bb, u8 value,
 				enum efuse_bit_mask mask)
 {
 	s8 tmp = 0;
@@ -1993,7 +1993,7 @@ s8 halbb_efuse_exchange_8852b(struct bb_info *bb, u8 value,
 	return tmp;
 }
 
-void halbb_ext_loss_avg_update_8852b(struct bb_info *bb)
+static void halbb_ext_loss_avg_update_8852b(struct bb_info *bb)
 {
 	struct bb_ch_info *ch = &bb->bb_ch_i;
 	struct bb_edcca_info *bb_edcca = &bb->bb_edcca_i;

--- a/phl/hal_g6/phy/bb/halbb_8852b/halbb_hwimg_8852b.c
+++ b/phl/hal_g6/phy/bb/halbb_8852b/halbb_hwimg_8852b.c
@@ -30,7 +30,7 @@
 
 #ifdef BB_8852B_SUPPORT
 
-bool halbb_sel_headline_8852b(struct bb_info *bb, u32 *array, u32 array_len,
+static bool halbb_sel_headline_8852b(struct bb_info *bb, u32 *array, u32 array_len,
 			      u8 *headline_size, u8 *headline_idx)
 {
 	bool case_match = false;
@@ -133,7 +133,7 @@ bool halbb_sel_headline_8852b(struct bb_info *bb, u32 *array, u32 array_len,
 	return false;
 }
 
-void halbb_flag_2_default_8852b(bool *is_matched, bool *find_target)
+static void halbb_flag_2_default_8852b(bool *is_matched, bool *find_target)
 {
 	*is_matched = true;
 	*find_target = false;

--- a/phl/hal_g6/phy/bb/halbb_8852b/halbb_reg_cfg_8852b.c
+++ b/phl/hal_g6/phy/bb/halbb_8852b/halbb_reg_cfg_8852b.c
@@ -26,16 +26,16 @@
 #include "../halbb_precomp.h"
 #ifdef BB_8852B_SUPPORT
 
-void halbb_cfg_rf_reg_8852b(struct bb_info *bb, u32 addr, u32 data,
+static void halbb_cfg_rf_reg_8852b(struct bb_info *bb, u32 addr, u32 data,
 			     enum rf_path rf_path, u32 reg_addr)
 {
 }
 
-void halbb_cfg_rf_radio_a_8852b(struct bb_info *bb, u32 addr, u32 data)
+static void halbb_cfg_rf_radio_a_8852b(struct bb_info *bb, u32 addr, u32 data)
 {
 }
 
-void halbb_cfg_rf_radio_b_8852b(struct bb_info *bb, u32 addr, u32 data)
+static void halbb_cfg_rf_radio_b_8852b(struct bb_info *bb, u32 addr, u32 data)
 {
 }
 

--- a/phl/hal_g6/phy/bb/halbb_ant_div.c
+++ b/phl/hal_g6/phy/bb/halbb_ant_div.c
@@ -172,7 +172,7 @@ void halbb_antdiv_init(struct bb_info *bb)
 	BB_DBG(bb, DBG_INIT, "Init ant_diversity timer");
 }
 
-u8 halbb_antdiv_sel_tx_ant_by_ext_pwr_lmt(struct bb_info *bb)
+static u8 halbb_antdiv_sel_tx_ant_by_ext_pwr_lmt(struct bb_info *bb)
 {
 	struct rtw_tpu_info *tpu = &bb->hal_com->band[bb->bb_phy_idx].rtw_tpu_i;
 	struct rtw_phl_ext_pwr_lmt_info *ext_pwr_info = &bb->hal_com->band[bb->bb_phy_idx].rtw_tpu_i.ext_pwr_lmt_i;
@@ -213,7 +213,7 @@ u8 halbb_antdiv_sel_tx_ant_by_ext_pwr_lmt(struct bb_info *bb)
 	return ret;
 }
 
-void halbb_antdiv_set_tx_ant(struct bb_info *bb, u8 ant)
+static void halbb_antdiv_set_tx_ant(struct bb_info *bb, u8 ant)
 {
 	struct bb_antdiv_cr_info *cr = &bb->bb_ant_div_i.bb_antdiv_cr_i;
 	u8 default_ant;
@@ -324,7 +324,7 @@ void halbb_antdiv_set_ant(struct bb_info *bb, u8 ant)
 	}
 }
 
-void halbb_antdiv_get_rssi(struct bb_info *bb)
+static void halbb_antdiv_get_rssi(struct bb_info *bb)
 {
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
 	struct bb_pkt_cnt_su_info *pkt_cnt = &cmn_rpt->bb_pkt_cnt_su_i;
@@ -378,7 +378,7 @@ void halbb_antdiv_get_rssi(struct bb_info *bb)
 		rssi->aux_rssi_final = rssi->aux_rssi_cck_avg; */
 }
 
-void halbb_antdiv_get_rssi_target_ant(struct bb_info *bb)
+static void halbb_antdiv_get_rssi_target_ant(struct bb_info *bb)
 {
 	struct bb_antdiv_info *bb_ant_div = &bb->bb_ant_div_i;
 	struct bb_antdiv_rssi_info *rssi = &bb_ant_div->bb_rssi_i;
@@ -425,7 +425,7 @@ void halbb_antdiv_get_rssi_target_ant(struct bb_info *bb)
 		(bb_ant_div->target_ant_rssi == MAIN_ANT) ? "MAIN_ANT" : "AUX_ANT");
 }
 
-void halbb_antdiv_get_cn_target_ant(struct bb_info *bb)
+static void halbb_antdiv_get_cn_target_ant(struct bb_info *bb)
 {
 	struct bb_antdiv_info *bb_ant_div = &bb->bb_ant_div_i;
 	struct bb_link_info *bb_link = &bb->bb_link_i;
@@ -1218,7 +1218,7 @@ void halbb_antenna_diversity(struct bb_info *bb)
 	halbb_evm_based_antdiv(bb);
 }
 
-void halbb_antdiv_get_rssi_stat(struct bb_info *bb)
+static void halbb_antdiv_get_rssi_stat(struct bb_info *bb)
 {
 	struct bb_physts_rslt_hdr_info	*psts_h = &bb->bb_physts_i.bb_physts_rslt_hdr_i;
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
@@ -1278,7 +1278,7 @@ void halbb_antdiv_get_rssi_stat(struct bb_info *bb)
 	}
 }
 
-void halbb_antdiv_get_evm_stat(struct bb_info *bb)
+static void halbb_antdiv_get_evm_stat(struct bb_info *bb)
 {
 	struct bb_physts_rslt_1_info	*psts_1 = &bb->bb_physts_i.bb_physts_rslt_1_i;
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
@@ -1335,7 +1335,7 @@ void halbb_antdiv_get_evm_stat(struct bb_info *bb)
 	}
 }
 
-void halbb_antdiv_get_cn_stat(struct bb_info *bb)
+static void halbb_antdiv_get_cn_stat(struct bb_info *bb)
 {
 	struct bb_physts_rslt_1_info	*psts_1 = &bb->bb_physts_i.bb_physts_rslt_1_i;
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
@@ -1371,7 +1371,7 @@ void halbb_antdiv_get_cn_stat(struct bb_info *bb)
 	}
 }
 
-void halbb_antdiv_get_rate_stat(struct bb_info *bb)
+static void halbb_antdiv_get_rate_stat(struct bb_info *bb)
 {
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
 	//struct bb_pkt_cnt_su_info *pkt_cnt = &cmn_rpt->bb_pkt_cnt_su_i;
@@ -1721,7 +1721,7 @@ void halbb_antdiv_io_en(struct bb_info *bb)
 	halbb_evm_based_antdiv(bb);
 }
 
-void halbb_antdiv_callback(void *context)
+static void halbb_antdiv_callback(void *context)
 {
 	struct bb_info *bb = (struct bb_info *)context;
 	struct halbb_timer_info *timer = &bb->bb_ant_div_i.antdiv_timer_i;

--- a/phl/hal_g6/phy/bb/halbb_api.c
+++ b/phl/hal_g6/phy/bb/halbb_api.c
@@ -152,7 +152,7 @@ u8 halbb_ch_2_band(struct bb_info *bb, u8 fc_ch)
 
 #ifdef BB_8852B_SUPPORT
 
-bool halbb_rf_sw_si_test(struct bb_info *bb, enum rf_path rx_path, u8 reg_addr, int ch_idx)
+static bool halbb_rf_sw_si_test(struct bb_info *bb, enum rf_path rx_path, u8 reg_addr, int ch_idx)
 {
 	u32 channel_change[3] = {0x1, 0x24, 0x99};
 	u32 ofdm_rx = 0x0, reg_value_0 = 0x0, reg_value_1 = 0x0;
@@ -307,7 +307,7 @@ u16 halbb_cfg_cmac_tx_ant(struct bb_info *bb, enum rf_path tx_path)
 }
 
 
-void halbb_gpio_ctrl_dump(struct bb_info *bb)
+static void halbb_gpio_ctrl_dump(struct bb_info *bb)
 {
 	switch (bb->ic_type) {
 
@@ -346,7 +346,7 @@ void halbb_gpio_ctrl_dump(struct bb_info *bb)
 	}
 }
 
-void halbb_gpio_rfm(struct bb_info *bb, enum bb_path path,
+static void halbb_gpio_rfm(struct bb_info *bb, enum bb_path path,
 		    enum bb_rfe_src_sel src, bool dis_tx_gnt_wl,
 		    bool active_tx_opt, bool act_bt_en, u8 rfm_output_val)
 {
@@ -390,7 +390,7 @@ void halbb_gpio_rfm(struct bb_info *bb, enum bb_path path,
 	}
 }
 
-void halbb_gpio_trsw_table(struct bb_info *bb, enum bb_path path,
+static void halbb_gpio_trsw_table(struct bb_info *bb, enum bb_path path,
 			   bool path_en, bool trsw_tx, bool trsw_rx,
 			   bool trsw, bool trsw_b)
 {
@@ -2260,7 +2260,7 @@ void halbb_ctrl_btc_preagc(struct bb_info *bb, bool bt_en)
 	#endif
 }
 
-void halbb_clk_en(struct bb_info *bb, bool en, enum phl_phy_idx phy_idx)
+static void halbb_clk_en(struct bb_info *bb, bool en, enum phl_phy_idx phy_idx)
 {
 	switch (bb->ic_type) {
 
@@ -2275,7 +2275,7 @@ void halbb_clk_en(struct bb_info *bb, bool en, enum phl_phy_idx phy_idx)
 	}
 }
 
-void halbb_pwr_en(struct bb_info *bb, bool en)
+static void halbb_pwr_en(struct bb_info *bb, bool en)
 {
 	switch (bb->ic_type) {
 
@@ -2641,7 +2641,7 @@ bool halbb_ctrl_mlo(struct bb_info *bb, enum mlo_dbcc_mode_type mode)
 }
 #endif
 
-void halbb_set_digital_pwr_comp(struct bb_info *bb, bool en, enum phl_phy_idx phy_idx)
+static void halbb_set_digital_pwr_comp(struct bb_info *bb, bool en, enum phl_phy_idx phy_idx)
 {
 	switch (bb->ic_type) {
 
@@ -2788,7 +2788,7 @@ void halbb_set_tx_pow_per_path_lmt(struct bb_info *bb, s16 pwr_lmt_a, s16 pwr_lm
 	}
 }
 
-u32 halbb_set_tx_pow_chk_cw_boundary(struct bb_info *bb, s16 pw_s10_3)
+static u32 halbb_set_tx_pow_chk_cw_boundary(struct bb_info *bb, s16 pw_s10_3)
 {
 	s16 rf_pw_cw = 0;
 	u32 pw_cw = pw_s10_3;
@@ -2806,7 +2806,7 @@ u32 halbb_set_tx_pow_chk_cw_boundary(struct bb_info *bb, s16 pw_s10_3)
 	return pw_cw;
 }
 
-void halbb_set_tx_pow_ref_and_cw(struct bb_info *bb,
+static void halbb_set_tx_pow_ref_and_cw(struct bb_info *bb,
 				  enum bb_path ref_pow_path,
 				  s16 pw_dbm_ofdm, /*s(9,2)*/
 				  s16 pw_dbm_cck, u8 path_pow_ofst_decrease,/*s(8,3)*/
@@ -3103,7 +3103,7 @@ void halbb_normal_efuse_verify_cck(struct bb_info *bb, s8 rx_gain_offset,
 	}
 }
 
-void halbb_rx_gain_dbg(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_rx_gain_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 			char *output, u32 *_out_len)
 {
 	switch (bb->ic_type) {
@@ -3119,7 +3119,7 @@ void halbb_rx_gain_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 	}
 }
 
-void halbb_rx_op1db_dbg(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_rx_op1db_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 			char *output, u32 *_out_len)
 {
 	switch (bb->ic_type) {
@@ -3211,7 +3211,7 @@ void halbb_agc_tia_shrink(struct bb_info *bb, bool shrink_en, bool shrink_init,
 	}
 }
 
-void halbb_agc_step_en(struct bb_info *bb, bool pre_pd_agc_en,
+static void halbb_agc_step_en(struct bb_info *bb, bool pre_pd_agc_en,
 		       bool linear_agc_en, bool post_pd_agc_en,
 		       bool nlgc_agc_en, enum rf_path path,
 		       enum phl_phy_idx phy_idx)

--- a/phl/hal_g6/phy/bb/halbb_auto_dbg.c
+++ b/phl/hal_g6/phy/bb/halbb_auto_dbg.c
@@ -29,7 +29,7 @@
 #define HALBB_CHK_HANG_APIS
 
 #ifdef HALBB_CHK_HANG_APIS
-void halbb_auto_chk_hang_reset(struct bb_info *bb)
+static void halbb_auto_chk_hang_reset(struct bb_info *bb)
 {
 	struct bb_auto_dbg_info *a_dbg = &bb->bb_auto_dbg_i;
 	struct bb_chk_hang_info *chk_hang = &a_dbg->bb_chk_hang_i;
@@ -37,7 +37,7 @@ void halbb_auto_chk_hang_reset(struct bb_info *bb)
 	halbb_mem_set(bb, chk_hang->dbg_port_val, 0, chk_hang->table_size);
 }
 
-void halbb_auto_chk_hang(struct bb_info *bb)
+static void halbb_auto_chk_hang(struct bb_info *bb)
 {
 	struct bb_auto_dbg_info *a_dbg = &bb->bb_auto_dbg_i;
 	struct bb_chk_hang_info *chk_hang = &a_dbg->bb_chk_hang_i;
@@ -78,7 +78,7 @@ void halbb_auto_chk_hang(struct bb_info *bb)
 	halbb_auto_chk_hang_reset(bb);
 }
 
-void halbb_auto_chk_hang_init(struct bb_info *bb)
+static void halbb_auto_chk_hang_init(struct bb_info *bb)
 {
 	struct bb_auto_dbg_info *a_dbg = &bb->bb_auto_dbg_i;
 	struct bb_chk_hang_info *chk_hang = &a_dbg->bb_chk_hang_i;

--- a/phl/hal_g6/phy/bb/halbb_cfo_trk.c
+++ b/phl/hal_g6/phy/bb/halbb_cfo_trk.c
@@ -117,7 +117,7 @@ void halbb_dyn_cfo_trk_loop_init(struct bb_info *bb)
 
 #endif
 
-void halbb_digital_cfo_comp(struct bb_info *bb, s32 curr_cfo)
+static void halbb_digital_cfo_comp(struct bb_info *bb, s32 curr_cfo)
 {
 	switch (bb->ic_type) {
 
@@ -168,7 +168,7 @@ void halbb_digital_cfo_comp(struct bb_info *bb, s32 curr_cfo)
 	}
 }
 
-void halbb_digital_cfo_comp_init(struct bb_info *bb)
+static void halbb_digital_cfo_comp_init(struct bb_info *bb)
 {
 	struct bb_cfo_trk_info *cfo_trk = &bb->bb_cfo_trk_i;
 	struct bb_cfo_trk_cr_info *cr = &bb->bb_cfo_trk_i.bb_cfo_trk_cr_i;
@@ -189,7 +189,7 @@ void halbb_digital_cfo_comp_init(struct bb_info *bb)
 	}
 }
 
-void halbb_cfo_trk_reset(struct bb_info *bb)
+static void halbb_cfo_trk_reset(struct bb_info *bb)
 {
 	struct bb_cfo_trk_info *bb_cfo_trk = &bb->bb_cfo_trk_i;
 
@@ -207,7 +207,7 @@ void halbb_cfo_trk_reset(struct bb_info *bb)
 }
 
 #ifdef HALBB_CFO_DAMPING_CHK
-void halbb_cfo_recorder(struct bb_info *bb, u8 step_curr, bool is_positive)
+static void halbb_cfo_recorder(struct bb_info *bb, u8 step_curr, bool is_positive)
 {
 	struct bb_cfo_trk_info *bb_cfo_trk = &bb->bb_cfo_trk_i;
 	struct bb_cfo_rc_info *bb_cfo_rc = &bb_cfo_trk->bb_cfo_rc_i;
@@ -240,7 +240,7 @@ void halbb_cfo_recorder(struct bb_info *bb, u8 step_curr, bool is_positive)
 	       bb_cfo_rc->step_bitmap & BIT0);
 }
 
-void halbb_cfo_damping_chk(struct bb_info *bb)
+static void halbb_cfo_damping_chk(struct bb_info *bb)
 {
 	struct bb_cfo_trk_info *bb_cfo_trk = &bb->bb_cfo_trk_i;
 	struct bb_cfo_rc_info *bb_cfo_rc = &bb_cfo_trk->bb_cfo_rc_i;
@@ -320,7 +320,7 @@ void halbb_cfo_damping_chk(struct bb_info *bb)
 	       bb_cfo_rc->force_damping_step, step_pattern_match);
 }
 
-void halbb_cfo_damping_chk_init(struct bb_info *bb)
+static void halbb_cfo_damping_chk_init(struct bb_info *bb)
 {
 	struct bb_cfo_trk_info *bb_cfo_trk = &bb->bb_cfo_trk_i;
 	struct bb_cfo_rc_info *bb_cfo_rc = &bb_cfo_trk->bb_cfo_rc_i;
@@ -352,7 +352,7 @@ void halbb_cfo_acc_io_en(struct bb_info *bb)
 	halbb_cfg_timers(bb, BB_SET_TIMER, &bb->bb_cfo_trk_i.cfo_timer_i);
 }
 
-void halbb_cfo_acc_callback(void *context)
+static void halbb_cfo_acc_callback(void *context)
 {
 	struct bb_info *bb = (struct bb_info *)context;
 	struct bb_cfo_trk_info *cfo_trk = &bb->bb_cfo_trk_i;
@@ -488,7 +488,7 @@ void halbb_set_crystal_cap(struct bb_info *bb, u8 crystal_cap)
 		bb_cfo_trk->x_cap_ofst = bb_cfo_trk->x_cap_ofst * (-1);
 }
 
-void halbb_crystal_cap_adjust(struct bb_info *bb, s32 curr_cfo)
+static void halbb_crystal_cap_adjust(struct bb_info *bb, s32 curr_cfo)
 {
 	struct bb_cfo_trk_info *bb_cfo_trk = &bb->bb_cfo_trk_i;
 	struct bb_cfo_rc_info *bb_cfo_rc = &bb_cfo_trk->bb_cfo_rc_i;
@@ -567,7 +567,7 @@ void halbb_crystal_cap_adjust(struct bb_info *bb, s32 curr_cfo)
 	halbb_set_crystal_cap(bb, x_cap);
 }
 
-s32 halbb_avg_cfo_calc(struct bb_info *bb)
+static s32 halbb_avg_cfo_calc(struct bb_info *bb)
 {
 	struct bb_cfo_trk_info *bb_cfo_trk = &bb->bb_cfo_trk_i;
 	struct bb_link_info *bb_link = &bb->bb_link_i;
@@ -597,7 +597,7 @@ s32 halbb_avg_cfo_calc(struct bb_info *bb)
 	return cfo_all_avg;
 }
 
-s32 halbb_multi_sta_avg_cfo_calc(struct bb_info *bb)
+static s32 halbb_multi_sta_avg_cfo_calc(struct bb_info *bb)
 {
 	struct bb_cfo_trk_info *bb_cfo_trk = &bb->bb_cfo_trk_i;
 	struct rtw_hal_com_t *hal = bb->hal_com;
@@ -791,7 +791,7 @@ void halbb_set_cfo_pause_val(struct bb_info *bb, u32 *val_buf, u8 val_len)
 	halbb_set_crystal_cap(bb, (u8)(val_buf[0] & 0xff));
 }
 
-void
+static void
 halbb_cfo_counter_rst(struct bb_info *bb)
 {
 	struct bb_cfo_trk_info *bb_cfo_trk = &bb->bb_cfo_trk_i;
@@ -824,7 +824,7 @@ halbb_cfo_counter_rst(struct bb_info *bb)
 	bb_cfo_trk->cfo_pkt_cnt = 0;
 }
 
-bool
+static bool
 halbb_cfo_trk_abort(struct bb_info *bb)
 {
 	struct bb_cfo_trk_info *cfo_trk = &bb->bb_cfo_trk_i;
@@ -915,7 +915,7 @@ void halbb_cfo_ul_ofdma_acc_disable(struct bb_info *bb)
 	bb_cfo_trk->bb_cfo_trk_acc_mode = CFO_ACC_MODE_0;
 }
 
-bool halbb_cfo_acc_mode_en(struct bb_info *bb)
+static bool halbb_cfo_acc_mode_en(struct bb_info *bb)
 {
 	struct bb_cfo_trk_info *cfo_trk = &bb->bb_cfo_trk_i;
 	struct bb_link_info *link = &bb->bb_link_i;

--- a/phl/hal_g6/phy/bb/halbb_ch_info.c
+++ b/phl/hal_g6/phy/bb/halbb_ch_info.c
@@ -99,7 +99,7 @@ bool halbb_ch_info_valid_chk_8852a(struct bb_info *bb, struct physts_rxd *desc)
 	return true;
 }
 
-void halbb_ch_info_cr_dump(struct bb_info *bb)
+static void halbb_ch_info_cr_dump(struct bb_info *bb)
 {
 	struct bb_ch_rpt_info *ch_rpt = &bb->bb_ch_rpt_i;
 	struct bb_ch_info_cr_info *cr = &ch_rpt->bb_ch_info_cr_i;
@@ -123,7 +123,7 @@ void halbb_ch_info_cr_dump(struct bb_info *bb)
 		 cur_cfg->ch_i_ele_bitmap, cur_cfg->ch_i_type, cur_cfg->ch_i_seg_len);
 }
 
-void halbb_ch_info_physts_get_buf(struct bb_info *bb, u8 *rpt_buf,
+static void halbb_ch_info_physts_get_buf(struct bb_info *bb, u8 *rpt_buf,
 				 struct bb_ch_rpt_hdr_info *hdr,
 				 struct bb_phy_info_rpt *phy_info,
 				 struct bb_ch_info_drv_rpt *drv)
@@ -138,7 +138,7 @@ void halbb_ch_info_physts_get_buf(struct bb_info *bb, u8 *rpt_buf,
 	rpt_buf = (u8*)buf->octet;
 }
 
-void halbb_ch_info_print(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_ch_info_print(struct bb_info *bb, char input[][16], u32 *_used,
 			 char *output, u32 *_out_len)
 {
 	struct bb_ch_rpt_info *ch_rpt = &bb->bb_ch_rpt_i;
@@ -327,7 +327,7 @@ bool halbb_ch_info_wait_from_physts(struct bb_info *bb, u32 dly, u32 dly_max,
 	return rpt_success;
 }
 
-bool halbb_ch_info_chk_cr_valid(struct bb_info *bb, struct bb_ch_info_cr_cfg_info *cfg)
+static bool halbb_ch_info_chk_cr_valid(struct bb_info *bb, struct bb_ch_info_cr_cfg_info *cfg)
 {
 	struct bb_ch_rpt_info *ch_rpt = &bb->bb_ch_rpt_i;
 	struct bb_ch_rpt_size_info *rpt_size = &ch_rpt->bb_ch_rpt_size_i;
@@ -579,7 +579,7 @@ void halbb_ch_info_status_en(struct bb_info *bb, bool en, enum phl_phy_idx phy_i
 	}
 }
 
-void halbb_ch_info_self_test(struct bb_info *bb)
+static void halbb_ch_info_self_test(struct bb_info *bb)
 {
 	struct bb_ch_rpt_info *ch_rpt = &bb->bb_ch_rpt_i;
 	struct bb_ch_info_cr_cfg_info *cfg = &ch_rpt->bb_ch_info_cr_cfg_i;
@@ -610,7 +610,7 @@ void halbb_ch_info_self_test(struct bb_info *bb)
 	}
 }
 
-enum bb_ch_info_t halbb_ch_info_get_data(struct bb_info *bb, struct physts_rxd *desc, u8 *addr, u32 len,
+static enum bb_ch_info_t halbb_ch_info_get_data(struct bb_info *bb, struct physts_rxd *desc, u8 *addr, u32 len,
 					struct bb_ch_rpt_hdr_info *hdr,
 					struct bb_phy_info_rpt *phy_info,
 					struct bb_ch_info_drv_rpt *drv)
@@ -759,7 +759,7 @@ enum bb_ch_info_t halbb_ch_info_parsing(struct bb_info *bb, u8 *addr, u32 len,
 	return rpt;
 }
 
-void halbb_ch_info_bbcr_init(struct bb_info *bb)
+static void halbb_ch_info_bbcr_init(struct bb_info *bb)
 {
 	struct bb_ch_rpt_info *ch_rpt = &bb->bb_ch_rpt_i;
 	struct bb_ch_info_cr_cfg_info *cfg = &ch_rpt->bb_ch_info_cr_cfg_i;
@@ -853,7 +853,7 @@ void halbb_ch_info_init(struct bb_info *bb)
 	halbb_ch_info_size_query(bb, &ch_rpt_size_info, bb->bb_phy_idx);
 }
 
-void halbb_ch_info_print_buf(struct bb_info *bb)
+static void halbb_ch_info_print_buf(struct bb_info *bb)
 {
 	struct bb_ch_rpt_info *ch_rpt = &bb->bb_ch_rpt_i;
 	u16 i = 0;
@@ -906,7 +906,7 @@ bool halbb_ch_info_buf_alloc(struct bb_info *bb)
 	return true;
 }
 
-void halbb_ch_info_reset(struct bb_info *bb)
+static void halbb_ch_info_reset(struct bb_info *bb)
 {
 	struct bb_ch_rpt_info *ch_rpt = &bb->bb_ch_rpt_i;
 

--- a/phl/hal_g6/phy/bb/halbb_cmn_rpt.c
+++ b/phl/hal_g6/phy/bb/halbb_cmn_rpt.c
@@ -62,7 +62,7 @@ void halbb_print_hist_2_buf(struct bb_info *bb, u16 *val, u16 len, char *buf,
 	}
 }
 
-void halbb_rx_pop_hist(struct bb_info *bb)
+static void halbb_rx_pop_hist(struct bb_info *bb)
 {
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
 	u8 pop_idx = 0;
@@ -82,7 +82,7 @@ void halbb_rx_pop_hist(struct bb_info *bb)
 		cmn_rpt->bb_physts_pop_i.pop_hist_ofdm[pop_idx]++;
 }
 
-void halbb_rx_pkt_cnt_rpt_beacon(struct bb_info *bb, struct physts_rxd *desc)
+static void halbb_rx_pkt_cnt_rpt_beacon(struct bb_info *bb, struct physts_rxd *desc)
 {
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
 
@@ -174,7 +174,7 @@ u16 halbb_get_plurality_rx_rate_mu(struct bb_info *bb)
 	return rx_rate_plurality;
 }
 
-void halbb_mu_rate_idx_generate(struct bb_info *bb, struct physts_rxd *desc, struct bb_rate_info *ra_i)
+static void halbb_mu_rate_idx_generate(struct bb_info *bb, struct physts_rxd *desc, struct bb_rate_info *ra_i)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
 	struct bb_physts_rslt_13_info *psts_13 = &physts->bb_physts_rslt_13_i;
@@ -439,7 +439,7 @@ void halbb_show_rssi_and_rate_distribution_mu(struct bb_info *bb)
 	}
 }
 
-void halbb_rx_pkt_mu_cnt_rpt(struct bb_info *bb, struct physts_rxd *desc, enum channel_width rx_bw)
+static void halbb_rx_pkt_mu_cnt_rpt(struct bb_info *bb, struct physts_rxd *desc, enum channel_width rx_bw)
 {
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
 	struct bb_pkt_cnt_mu_info *pkt_cnt = &cmn_rpt->bb_pkt_cnt_mu_i;
@@ -500,7 +500,7 @@ void halbb_rx_pkt_mu_cnt_rpt(struct bb_info *bb, struct physts_rxd *desc, enum c
 	}
 }
 
-void halbb_rx_pkt_mu_rssi_statistic(struct bb_info *bb)
+static void halbb_rx_pkt_mu_rssi_statistic(struct bb_info *bb)
 {
 	struct bb_physts_rslt_hdr_info	*psts_h = &bb->bb_physts_i.bb_physts_rslt_hdr_i;
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
@@ -533,7 +533,7 @@ void halbb_rx_pkt_mu_rssi_statistic(struct bb_info *bb)
 #define CMN_RPT_SU
 #ifdef CMN_RPT_SU
 
-void halbb_basic_dbg_07_hist_su_per_path(struct bb_info *bb)
+static void halbb_basic_dbg_07_hist_su_per_path(struct bb_info *bb)
 {
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
 	struct bb_pkt_cnt_su_info *pkt_cnt = &cmn_rpt->bb_pkt_cnt_su_i;
@@ -1056,7 +1056,7 @@ void halbb_show_rssi_and_rate_distribution_su(struct bb_info *bb)
 	}
 }
 
-void halbb_rx_pkt_su_non_data_cnt_rpt(struct bb_info *bb, struct physts_rxd *desc, enum channel_width rx_bw)
+static void halbb_rx_pkt_su_non_data_cnt_rpt(struct bb_info *bb, struct physts_rxd *desc, enum channel_width rx_bw)
 {
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
 	struct bb_pkt_cnt_su_info *pkt_cnt = &cmn_rpt->bb_pkt_cnt_su_i;
@@ -1070,7 +1070,7 @@ void halbb_rx_pkt_su_non_data_cnt_rpt(struct bb_info *bb, struct physts_rxd *des
 	}
 }
 
-void halbb_rx_pkt_su_cnt_rpt(struct bb_info *bb, struct physts_rxd *desc, enum channel_width rx_bw)
+static void halbb_rx_pkt_su_cnt_rpt(struct bb_info *bb, struct physts_rxd *desc, enum channel_width rx_bw)
 {
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
 	struct bb_pkt_cnt_su_info *pkt_cnt = &cmn_rpt->bb_pkt_cnt_su_i;
@@ -1175,7 +1175,7 @@ void halbb_rx_pkt_su_cnt_rpt(struct bb_info *bb, struct physts_rxd *desc, enum c
 	}
 }
 
-void halbb_rx_pkt_su_phy_hist_per_path(struct bb_info *bb, u32 physts_bitmap)
+static void halbb_rx_pkt_su_phy_hist_per_path(struct bb_info *bb, u32 physts_bitmap)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
 	struct bb_physts_rslt_4_to_7_info *psts_r = NULL;
@@ -1207,7 +1207,7 @@ void halbb_rx_pkt_su_phy_hist_per_path(struct bb_info *bb, u32 physts_bitmap)
 	}
 }
 
-void halbb_rx_pkt_su_phy_hist(struct bb_info *bb)
+static void halbb_rx_pkt_su_phy_hist(struct bb_info *bb)
 {
 	struct bb_physts_rslt_1_info	*psts_1 = &bb->bb_physts_i.bb_physts_rslt_1_i;
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
@@ -1272,7 +1272,7 @@ void halbb_rx_pkt_su_phy_hist(struct bb_info *bb)
 	//	acc->cfo_avg_acc, acc->evm_max_acc, acc->evm_min_acc, acc->cn_avg_acc);
 }
 
-void halbb_rx_pkt_su_rssi_statistic(struct bb_info *bb)
+static void halbb_rx_pkt_su_rssi_statistic(struct bb_info *bb)
 {
 	struct bb_physts_rslt_hdr_info	*psts_h = &bb->bb_physts_i.bb_physts_rslt_hdr_i;
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
@@ -1309,7 +1309,7 @@ void halbb_rx_pkt_su_rssi_statistic(struct bb_info *bb)
 
 //#define ORI_RSSI_FLAG
 
-void halbb_rx_pkt_su_store_in_sta_info(struct bb_info *bb, struct physts_rxd *desc)
+static void halbb_rx_pkt_su_store_in_sta_info(struct bb_info *bb, struct physts_rxd *desc)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
 	struct bb_physts_rslt_hdr_info	*psts_h = &physts->bb_physts_rslt_hdr_i;
@@ -1539,7 +1539,7 @@ void halbb_cmn_rpt(struct bb_info *bb, struct physts_rxd *desc, u32 physts_bitma
 	}
 }
 
-void halbb_physts_hist_init(struct bb_info *bb)
+static void halbb_physts_hist_init(struct bb_info *bb)
 {
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
 	struct bb_physts_hist_th_info *hist_th = &cmn_rpt->bb_physts_hist_th_i;

--- a/phl/hal_g6/phy/bb/halbb_dbg.c
+++ b/phl/hal_g6/phy/bb/halbb_dbg.c
@@ -87,7 +87,7 @@ void halbb_tdma_cr_sel_io_en(struct bb_info *bb)
 	halbb_tdma_cr_sel_main(bb);
 }
 
-void halbb_tdma_cr_sel_callback(void *context)
+static void halbb_tdma_cr_sel_callback(void *context)
 {
 	struct bb_info *bb = (struct bb_info *)context;
 	struct halbb_timer_info *timer = &bb->bb_dbg_i.tdma_cr_timer_i;
@@ -373,7 +373,7 @@ u32 halbb_get_dbgport_val_by_racing(struct bb_info *bb, u32 dbg_port)
 #endif
 
 #if HALBB_DBG_DVLP_FLAG /*Common debug message - relative*/
-void halbb_crc32_cnt2_cmn_log(struct bb_info *bb)
+static void halbb_crc32_cnt2_cmn_log(struct bb_info *bb)
 {
 	struct bb_stat_info *stat_t = &bb->bb_stat_i;
 	struct bb_crc2_info *crc2 = &stat_t->bb_crc2_i;
@@ -404,7 +404,7 @@ void halbb_crc32_cnt2_cmn_log(struct bb_info *bb)
 	       crc2->cnt_vht2_crc32_error, crc2->cnt_he2_crc32_error);
 }
 
-void halbb_crc32_cnt3_cmn_log(struct bb_info *bb)
+static void halbb_crc32_cnt3_cmn_log(struct bb_info *bb)
 {
 	struct bb_stat_info *stat_t = &bb->bb_stat_i;
 	struct bb_usr_set_info *usr_set = &stat_t->bb_usr_set_i;
@@ -493,7 +493,7 @@ void halbb_crc32_cnt3_cmn_log(struct bb_info *bb)
 	}
 }
 
-void halbb_dig_cmn_log(struct bb_info *bb)
+static void halbb_dig_cmn_log(struct bb_info *bb)
 {
 	struct bb_dig_cr_info *cr = &bb->bb_dig_i.bb_dig_cr_i;
 	u8 i = 0;
@@ -840,7 +840,7 @@ void halbb_get_tx_dbg_reg(struct bb_info *bb)
 	}
 }
 
-void halbb_basic_dbg_msg_ra_dbg_reg(struct bb_info *bb)
+static void halbb_basic_dbg_msg_ra_dbg_reg(struct bb_info *bb)
 {
 	struct rtw_phl_com_t *phl = bb->phl_com;
 	struct dev_cap_t *dev = &phl->dev_cap;
@@ -915,7 +915,7 @@ void halbb_basic_dbg_msg_ra_dbg_reg(struct bb_info *bb)
 	}
 }
 
-void halbb_basic_dbg_msg_tx_dbg_reg(struct bb_info *bb)
+static void halbb_basic_dbg_msg_tx_dbg_reg(struct bb_info *bb)
 {
 	struct bb_dbg_info *dbg = &bb->bb_dbg_i;
 	struct bb_tx_info *txdbg = &dbg->tx_info_i;
@@ -1194,7 +1194,7 @@ void halbb_basic_dbg_msg_tx_dbg_reg(struct bb_info *bb)
 	}
 }
 
-void halbb_basic_dbg_03_msg_pmac(struct bb_info *bb)
+static void halbb_basic_dbg_03_msg_pmac(struct bb_info *bb)
 {
 
 #ifdef HALBB_STATISTICS_SUPPORT
@@ -1258,7 +1258,7 @@ void halbb_basic_dbg_03_msg_pmac(struct bb_info *bb)
 #endif
 }
 
-void halbb_basic_dbg_05_rx(struct bb_info *bb)
+static void halbb_basic_dbg_05_rx(struct bb_info *bb)
 {
 	struct bb_ch_info *ch = &bb->bb_ch_i;
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
@@ -1296,7 +1296,7 @@ void halbb_basic_dbg_05_rx(struct bb_info *bb)
 	BB_DBG(bb, DBG_CMN, "BB monitor1 = (0x%x)\n", bb_monitor1);
 }
 
-void halbb_basic_dbg_msg_tx_info(struct bb_info *bb)
+static void halbb_basic_dbg_msg_tx_info(struct bb_info *bb)
 {
 	struct bb_ch_info *ch = &bb->bb_ch_i;
 	struct rtw_phl_stainfo_t *sta;
@@ -1367,7 +1367,7 @@ void halbb_basic_dbg_msg_tx_info(struct bb_info *bb)
 	halbb_basic_dbg_msg_ra_dbg_reg(bb);
 }
 
-void halbb_basic_dbg_08_rssi_rate_mu(struct bb_info *bb)
+static void halbb_basic_dbg_08_rssi_rate_mu(struct bb_info *bb)
 {
 	struct bb_ch_info *ch = &bb->bb_ch_i;
 	struct bb_link_info *link = &bb->bb_link_i;
@@ -1393,7 +1393,7 @@ void halbb_basic_dbg_08_rssi_rate_mu(struct bb_info *bb)
 	halbb_show_rssi_and_rate_distribution_mu(bb);
 }
 
-void halbb_basic_dbg_06_rssi_rate(struct bb_info *bb)
+static void halbb_basic_dbg_06_rssi_rate(struct bb_info *bb)
 {
 	struct bb_ch_info *ch = &bb->bb_ch_i;
 	struct bb_link_info *link = &bb->bb_link_i;
@@ -1430,7 +1430,7 @@ void halbb_basic_dbg_06_rssi_rate(struct bb_info *bb)
 		  avg_phy_rate, utility);
 }
 
-void halbb_basic_dbg_01_system(struct bb_info *bb)
+static void halbb_basic_dbg_01_system(struct bb_info *bb)
 {
 	struct bb_link_info	*link = &bb->bb_link_i;
 	struct bb_ch_info	*ch = &bb->bb_ch_i;
@@ -1516,7 +1516,7 @@ void halbb_basic_dbg_01_system(struct bb_info *bb)
 	}
 }
 
-void halbb_basic_dbg_04_tx(struct bb_info *bb)
+static void halbb_basic_dbg_04_tx(struct bb_info *bb)
 {
 	if (!(bb->cmn_dbg_msg_component & BB_BASIC_DBG_04_TX)) {
 		BB_DBG(bb, DBG_CMN, "Disabled\n");
@@ -1529,7 +1529,7 @@ void halbb_basic_dbg_04_tx(struct bb_info *bb)
 		halbb_basic_dbg_msg_tx_info(bb);
 }
 
-void halbb_basic_dbg_09_dm_summary(struct bb_info *bb)
+static void halbb_basic_dbg_09_dm_summary(struct bb_info *bb)
 {
 #ifdef HALBB_CFO_TRK_SUPPORT
 	struct bb_cfo_trk_info *cfo_trk = &bb->bb_cfo_trk_i;

--- a/phl/hal_g6/phy/bb/halbb_dbg_cmd.c
+++ b/phl/hal_g6/phy/bb/halbb_dbg_cmd.c
@@ -33,7 +33,7 @@
 #include "halbb_precomp.h"
 #include "halbb_dbg_cmd_table.h"
 
-void halbb_bbcr_rw_dbg(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_bbcr_rw_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 		       char *output, u32 *_out_len)
 {
 	u32 val[10] = {0};
@@ -118,7 +118,7 @@ void halbb_bbcr_rw_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 #endif
 }
 
-void halbb_bb_td_dbg(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_bb_td_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 			      char *output, u32 *_out_len)
 {
 	struct bb_dbg_info *dbg = &bb->bb_dbg_i;
@@ -211,7 +211,7 @@ void halbb_bb_td_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 	}
 }
 
-void halbb_bb_fd_dbg(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_bb_fd_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 			      char *output, u32 *_out_len)
 {
 	u32 val[10] = {0};
@@ -245,7 +245,7 @@ void halbb_bb_fd_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 	//odm_fill_h2c_cmd(bb, PHYDM_H2C_FW_TRACE_EN, cmd_length, h2c_parameter);
 }*/
 
-void halbb_cmn_msg_setting(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_cmn_msg_setting(struct bb_info *bb, char input[][16], u32 *_used,
 			   char *output, u32 *_out_len)
 {
 	u32 val[3] = {0};
@@ -270,7 +270,7 @@ void halbb_cmn_msg_setting(struct bb_info *bb, char input[][16], u32 *_used,
 	}
 }
 
-void halbb_trace_dbg(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_trace_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 		       char *output, u32 *_out_len)
 {
 	u64 pre_debug_components, one = 1;
@@ -438,7 +438,7 @@ void halbb_trace_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 	*_out_len = out_len;
 }
 
-u32 halbb_get_multiple(u8 pow, u8 base)
+static u32 halbb_get_multiple(u8 pow, u8 base)
 {
 	u8 i;
 	u32 return_value = 1;
@@ -449,7 +449,7 @@ u32 halbb_get_multiple(u8 pow, u8 base)
 	return	return_value;
 }
 
-u32 halbb_str_2_dec(u8 val)
+static u32 halbb_str_2_dec(u8 val)
 {
 	if (val >= 0x30 && val <= 0x39) /*0~9*/
 		return	(val - 0x30);
@@ -921,7 +921,7 @@ s32 halbb_cmd(struct bb_info *bb, char *input, char *output, u32 out_len)
 	return 0;
 }
 
-void halbb_fwdbg_trace(struct bb_info *bb, u32 dbg_comp, u8 fw_trace_en)
+static void halbb_fwdbg_trace(struct bb_info *bb, u32 dbg_comp, u8 fw_trace_en)
 {
 	struct bb_fw_dbg_cmn_info *bb_fwdbg = &bb->bb_fwdbg_i;
 	u32 *bb_h2c = (u32 *) bb_fwdbg;

--- a/phl/hal_g6/phy/bb/halbb_dbg_cnsl_out.c
+++ b/phl/hal_g6/phy/bb/halbb_dbg_cnsl_out.c
@@ -27,7 +27,7 @@
 
 #ifdef HALBB_CNSL_CMN_INFO_SUPPORT
 
-void halbb_env_mntr_log_cnsl(struct bb_info *bb, u32 *_used,
+static void halbb_env_mntr_log_cnsl(struct bb_info *bb, u32 *_used,
 			     char *output, u32 *_out_len)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
@@ -180,7 +180,7 @@ void halbb_env_mntr_log_cnsl(struct bb_info *bb, u32 *_used,
 	}
 }
 
-void halbb_edcca_cmn_log_cnsl(struct bb_info *bb, u32 *_used, char *output,
+static void halbb_edcca_cmn_log_cnsl(struct bb_info *bb, u32 *_used, char *output,
 			      u32 *_out_len)
 {
 	struct bb_edcca_info *bb_edcca = &bb->bb_edcca_i;
@@ -212,7 +212,7 @@ void halbb_edcca_cmn_log_cnsl(struct bb_info *bb, u32 *_used, char *output,
 		    obss_th - 128);
 }
 
-void halbb_basic_dbg_msg_pmac_cnsl(struct bb_info *bb, u32 *_used,
+static void halbb_basic_dbg_msg_pmac_cnsl(struct bb_info *bb, u32 *_used,
 				   char *output, u32 *_out_len)
 {
 #ifdef HALBB_STATISTICS_SUPPORT
@@ -269,7 +269,7 @@ void halbb_basic_dbg_msg_pmac_cnsl(struct bb_info *bb, u32 *_used,
 #endif
 }
 
-void halbb_crc32_cnt2_cmn_log_cnsl(struct bb_info *bb, u32 *_used,
+static void halbb_crc32_cnt2_cmn_log_cnsl(struct bb_info *bb, u32 *_used,
 				   char *output, u32 *_out_len)
 {
 	struct bb_stat_info *stat_t = &bb->bb_stat_i;
@@ -301,7 +301,7 @@ void halbb_crc32_cnt2_cmn_log_cnsl(struct bb_info *bb, u32 *_used,
 		    crc2->cnt_vht2_crc32_error, crc2->cnt_he2_crc32_error);
 }
 
-void halbb_crc32_cnt3_cmn_log_cnsl(struct bb_info *bb, u32 *_used,
+static void halbb_crc32_cnt3_cmn_log_cnsl(struct bb_info *bb, u32 *_used,
 				   char *output, u32 *_out_len)
 {
 	struct bb_stat_info *stat_t = &bb->bb_stat_i;
@@ -807,7 +807,7 @@ void halbb_basic_dbg_msg_tx_dbg_reg_cnsl(struct bb_info *bb, u32 *_used,
 	}
 }
 
-void halbb_basic_dbg_msg_tx_info_cnsl(struct bb_info *bb, u32 *_used,
+static void halbb_basic_dbg_msg_tx_info_cnsl(struct bb_info *bb, u32 *_used,
 				      char *output, u32 *_out_len)
 {
 	struct bb_ch_info *ch = &bb->bb_ch_i;
@@ -849,7 +849,7 @@ void halbb_basic_dbg_msg_tx_info_cnsl(struct bb_info *bb, u32 *_used,
 	halbb_ra_dbgreg_cnsl(bb, _used, output, _out_len);
 }
 
-void halbb_basic_dbg_msg_rx_info_cnsl(struct bb_info *bb, u32 *_used,
+static void halbb_basic_dbg_msg_rx_info_cnsl(struct bb_info *bb, u32 *_used,
 				      char *output, u32 *_out_len)
 {
 	struct bb_ch_info *ch = &bb->bb_ch_i;
@@ -888,7 +888,7 @@ void halbb_basic_dbg_msg_rx_info_cnsl(struct bb_info *bb, u32 *_used,
 }
 
 
-void halbb_basic_dbg_msg_physts_su_cnsl(struct bb_info *bb, u32 *_used,
+static void halbb_basic_dbg_msg_physts_su_cnsl(struct bb_info *bb, u32 *_used,
 					char *output, u32 *_out_len)
 {
 	struct bb_ch_info *ch = &bb->bb_ch_i;
@@ -1272,7 +1272,7 @@ void halbb_basic_dbg_msg_physts_su_cnsl(struct bb_info *bb, u32 *_used,
 }
 
 
-void halbb_show_phy_hitogram_su_cnsl(struct bb_info *bb, u32 *_used,
+static void halbb_show_phy_hitogram_su_cnsl(struct bb_info *bb, u32 *_used,
 						 char *output, u32 *_out_len)
 {
 	struct bb_cmn_rpt_info	*cmn_rpt = &bb->bb_cmn_rpt_i;
@@ -1360,7 +1360,7 @@ void halbb_show_phy_hitogram_su_cnsl(struct bb_info *bb, u32 *_used,
 		    "valid_cnt = %d\n", valid_cnt);
 }
 
-void halbb_basic_dbg_msg_physts_mu_cnsl(struct bb_info *bb, u32 *_used,
+static void halbb_basic_dbg_msg_physts_mu_cnsl(struct bb_info *bb, u32 *_used,
 					char *output, u32 *_out_len)
 {
 	struct bb_ch_info *ch = &bb->bb_ch_i;
@@ -1606,7 +1606,7 @@ void halbb_basic_dbg_msg_physts_mu_cnsl(struct bb_info *bb, u32 *_used,
 	}
 }
 
-void halbb_dm_summary_cnsl(struct bb_info *bb, u32 *_used,
+static void halbb_dm_summary_cnsl(struct bb_info *bb, u32 *_used,
 			   char *output, u32 *_out_len)
 {
 #ifdef HALBB_CFO_TRK_SUPPORT
@@ -1685,7 +1685,7 @@ void halbb_dm_summary_cnsl(struct bb_info *bb, u32 *_used,
 #endif
 }
 
-void halbb_reset_cnsl(struct bb_info *bb)
+static void halbb_reset_cnsl(struct bb_info *bb)
 {
 	if (bb->bb_cmn_hooker->bb_cmn_dbg_i.cmn_log_2_cnsl_en ||
 	    bb->bb_cmn_hooker->bb_cmn_dbg_i.cmn_log_2_drv_statistic_en) {

--- a/phl/hal_g6/phy/bb/halbb_dig.c
+++ b/phl/hal_g6/phy/bb/halbb_dig.c
@@ -200,7 +200,7 @@ bool halbb_dig_gaincode_update_en_8852a(struct bb_info *bb)
 #endif
 
 #ifdef HALBB_DIG_DAMPING_CHK
-void halbb_dig_recorder_reset(struct bb_info *bb)
+static void halbb_dig_recorder_reset(struct bb_info *bb)
 {
 	struct bb_dig_info *dig = &bb->bb_dig_i;
 	struct bb_dig_record_info *dig_rc = &dig->bb_dig_record_i;
@@ -210,7 +210,7 @@ void halbb_dig_recorder_reset(struct bb_info *bb)
 	halbb_mem_set(bb, dig_rc, 0, sizeof(struct bb_dig_record_info));
 }
 
-void halbb_dig_recorder(struct bb_info *bb, u8 igi_curr, u32 fa_metrics)
+static void halbb_dig_recorder(struct bb_info *bb, u8 igi_curr, u32 fa_metrics)
 {
 	struct bb_dig_info *dig = &bb->bb_dig_i;
 	struct bb_dig_record_info *dig_rc = &dig->bb_dig_record_i;
@@ -266,7 +266,7 @@ void halbb_dig_recorder(struct bb_info *bb, u8 igi_curr, u32 fa_metrics)
 	       dig_rc->igi_bitmap & BIT0);
 }
 
-void halbb_dig_damping_chk(struct bb_info *bb)
+static void halbb_dig_damping_chk(struct bb_info *bb)
 {
 	struct bb_dig_info *dig = &bb->bb_dig_i;
 	struct bb_dig_record_info *dig_rc = &dig->bb_dig_record_i;
@@ -389,7 +389,7 @@ void halbb_dig_damping_chk(struct bb_info *bb)
 	       dig_rc->damping_lock_en, fa_pattern_match, diff1, diff2);
 }
 
-void halbb_dig_damping_chk_init(struct bb_info *bb)
+static void halbb_dig_damping_chk_init(struct bb_info *bb)
 {
 	struct bb_dig_info *dig = &bb->bb_dig_i;
 	struct bb_dig_record_info *dig_rc = &dig->bb_dig_record_i;
@@ -467,7 +467,7 @@ u8 halbb_get_rxb_idx(struct bb_info *bb, enum rf_path path)
 	return rxb_idx;
 }
 
-u8 halbb_igi_by_edcca(struct bb_info *bb, u8 igi)
+static u8 halbb_igi_by_edcca(struct bb_info *bb, u8 igi)
 {
 #ifdef HALBB_EDCCA_SUPPORT
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
@@ -484,7 +484,7 @@ u8 halbb_igi_by_edcca(struct bb_info *bb, u8 igi)
 	return igi;
 }
 
-void halbb_dig_noisy_lv_decision(struct bb_info *bb)
+static void halbb_dig_noisy_lv_decision(struct bb_info *bb)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 	struct bb_dig_op_unit *bb_dig_u = bb_dig->p_cur_dig_unit;
@@ -517,7 +517,7 @@ void halbb_dig_noisy_lv_decision(struct bb_info *bb)
 	bb_dig_u->fa_valid_state_cnt = 0;
 }
 
-s8 halbb_dig_ofst_by_fa(struct bb_info *bb, u16 fa)
+static s8 halbb_dig_ofst_by_fa(struct bb_info *bb, u16 fa)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 	struct bb_dig_op_para_unit *para = &bb_dig->p_cur_dig_unit->dig_op_para;
@@ -600,7 +600,7 @@ u8 halbb_dig_igi_by_ofst(struct bb_info *bb, u8 igi_pre, s8 ofst)
 	return igi_new;
 }
 
-void halbb_dig_igi_ofst_by_env(struct bb_info *bb)
+static void halbb_dig_igi_ofst_by_env(struct bb_info *bb)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 	struct bb_dig_op_unit *bb_dig_u = bb_dig->p_cur_dig_unit;
@@ -633,7 +633,7 @@ void halbb_dig_igi_ofst_by_env(struct bb_info *bb)
 		   bb_dig_u->cur_noisy_lv, fa_rssi_ofst_pre, bb_dig_u->fa_rssi_ofst, IGI_OFFSET_MAX);
 }
 
-u8 halbb_dig_igi_bound_decision(struct bb_info *bb)
+static u8 halbb_dig_igi_bound_decision(struct bb_info *bb)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 	struct bb_dig_op_unit *bb_dig_u = bb_dig->p_cur_dig_unit;
@@ -682,7 +682,7 @@ u8 halbb_dig_igi_bound_decision(struct bb_info *bb)
 	return igi_new;
 }
 
-bool halbb_dig_fahm_trig(struct bb_info *bb, u16 mntr_time)
+static bool halbb_dig_fahm_trig(struct bb_info *bb, u16 mntr_time)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 	bool is_trig_success = false;
@@ -706,7 +706,7 @@ bool halbb_dig_fahm_trig(struct bb_info *bb, u16 mntr_time)
 	return is_trig_success;
 }
 
-bool halbb_dig_fahm_latch(struct bb_info *bb)
+static bool halbb_dig_fahm_latch(struct bb_info *bb)
 {
 	struct bb_dig_info *dig = &bb->bb_dig_i;
 	struct bb_dig_op_unit *dig_u = dig->p_cur_dig_unit;
@@ -754,7 +754,7 @@ bool halbb_dig_fahm_latch(struct bb_info *bb)
 	return true;
 }
 
-void halbb_sdagc_follow_pagc_config(struct bb_info *bb, bool set_en)
+static void halbb_sdagc_follow_pagc_config(struct bb_info *bb, bool set_en)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 	const struct bb_dig_cr_info *cr = &bb_dig->bb_dig_cr_i;
@@ -778,7 +778,7 @@ void halbb_sdagc_follow_pagc_config(struct bb_info *bb, bool set_en)
 	BB_DIG_DBG(bb, DIG_DBG_LV1, "sdagc_follow_pagc=%d\n", val);
 }
 
-void halbb_dyn_pd_th_cck(struct bb_info *bb, u8 rssi, bool set_en)
+static void halbb_dyn_pd_th_cck(struct bb_info *bb, u8 rssi, bool set_en)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 	struct bb_dig_op_unit *bb_dig_u = bb_dig->p_cur_dig_unit;
@@ -807,7 +807,7 @@ void halbb_dyn_pd_th_cck(struct bb_info *bb, u8 rssi, bool set_en)
 	}
 }
 
-void halbb_dyn_pd_th_ofdm(struct bb_info *bb, u8 rssi, bool set_en)
+static void halbb_dyn_pd_th_ofdm(struct bb_info *bb, u8 rssi, bool set_en)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 	struct bb_dig_op_unit *bb_dig_u = bb_dig->p_cur_dig_unit;
@@ -856,7 +856,7 @@ void halbb_dig_mode_update(struct bb_info *bb, enum dig_op_mode mode, enum phl_p
 	BB_DIG_DBG(bb, DIG_DBG_LV0, "Set DIG op mode %d\n", bb_dig->dig_mode);
 }
 
-void halbb_dig_gain_para_init(struct bb_info *bb)
+static void halbb_dig_gain_para_init(struct bb_info *bb)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 	struct bb_dig_cr_info *cr = &bb_dig->bb_dig_cr_i;
@@ -976,7 +976,7 @@ void halbb_dig_gain_para_init(struct bb_info *bb)
 static const u16 fa_th_no_link[FA_TH_NUM] = {196, 352, 440, 528};
 static const u16 fa_th_linked[FA_TH_NUM] = {4, 8, 12, 16};
 
-void halbb_dig_para_update(struct bb_info *bb)
+static void halbb_dig_para_update(struct bb_info *bb)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 	struct bb_link_info *bb_link = &bb->bb_link_i;
@@ -1013,7 +1013,7 @@ void halbb_dig_para_update(struct bb_info *bb)
 #endif
 }
 
-void halbb_dig_fa_info_update(struct bb_info *bb)
+static void halbb_dig_fa_info_update(struct bb_info *bb)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 	struct bb_dig_op_unit *bb_dig_u = bb_dig->p_cur_dig_unit;
@@ -1023,7 +1023,7 @@ void halbb_dig_fa_info_update(struct bb_info *bb)
 	bb_dig_u->fa_r_acc = 0;
 }
 
-void halbb_dig_op_unit_para_reset_h(struct bb_info *bb)
+static void halbb_dig_op_unit_para_reset_h(struct bb_info *bb)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 	struct bb_dig_op_unit *unit_cur = &bb_dig->dig_state_h_i;
@@ -1040,7 +1040,7 @@ void halbb_dig_op_unit_para_reset_h(struct bb_info *bb)
 }
 
 #ifdef HALBB_DIG_TDMA_SUPPORT
-void halbb_dig_op_unit_para_reset_l(struct bb_info *bb)
+static void halbb_dig_op_unit_para_reset_l(struct bb_info *bb)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 	struct bb_dig_op_unit *unit_cur = &bb_dig->dig_state_l_i;
@@ -1055,7 +1055,7 @@ void halbb_dig_op_unit_para_reset_l(struct bb_info *bb)
 }
 #endif
 
-void halbb_dig_fahm_para_init(struct bb_info *bb)
+static void halbb_dig_fahm_para_init(struct bb_info *bb)
 {
 	struct bb_dig_info *dig = &bb->bb_dig_i;
 #ifdef HALBB_ENV_MNTR_SUPPORT
@@ -1071,7 +1071,7 @@ void halbb_dig_fahm_para_init(struct bb_info *bb)
 	dig->fahm_is_triggered = false;
 }
 
-void halbb_dig_para_reset(struct bb_info *bb)
+static void halbb_dig_para_reset(struct bb_info *bb)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 
@@ -1092,7 +1092,7 @@ void halbb_dig_para_reset(struct bb_info *bb)
 #endif
 }
 
-void halbb_dig_reset(struct bb_info *bb)
+static void halbb_dig_reset(struct bb_info *bb)
 {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 
@@ -1114,7 +1114,7 @@ void halbb_dig_reset(struct bb_info *bb)
 	halbb_sdagc_follow_pagc_config(bb, false);
 }
 
-void halbb_dig_init_io_en(struct bb_info *bb)
+static void halbb_dig_init_io_en(struct bb_info *bb)
 {
 	struct bb_dig_info *dig = &bb->bb_dig_i;
 	u8 igi_new;
@@ -1169,7 +1169,7 @@ void halbb_dig_init(struct bb_info *bb)
 	halbb_dig_init_io_en(bb);
 }
 
-bool halbb_dig_abort(struct bb_info *bb)
+static bool halbb_dig_abort(struct bb_info *bb)
 {
 	struct bb_dig_info *dig = &bb->bb_dig_i;
 
@@ -1370,7 +1370,7 @@ DIG_END:
 }
 
 #ifdef HALBB_DIG_TDMA_SUPPORT
-void halbb_tdma_dig(struct bb_info *bb) {
+static void halbb_tdma_dig(struct bb_info *bb) {
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;
 	struct bb_dig_op_unit *bb_dig_u = bb_dig->p_cur_dig_unit;
 	bool fahm_op_status = false;
@@ -1498,7 +1498,7 @@ void halbb_tdmadig_io_en(struct bb_info *bb)
 	halbb_cfg_timers(bb, BB_SET_TIMER, &bb->bb_dig_i.dig_timer_i);
 }
 
-void halbb_tdmadig_callback(void *context)
+static void halbb_tdmadig_callback(void *context)
 {
 	struct bb_info *bb = (struct bb_info *)context;
 	struct halbb_timer_info *timer = &bb->bb_dig_i.dig_timer_i;
@@ -2247,7 +2247,7 @@ u32 halbb_c2h_mccdm_check(struct bb_info *bb, u16 len, u8 *c2h)
 	return _SUCCESS;
 }
 
-void halbb_mccdm_h2ccmd_rst(struct bb_info *bb)
+static void halbb_mccdm_h2ccmd_rst(struct bb_info *bb)
 {
 	struct mcc_h2c *mcc_cfg;
 	bool ret_val = false;
@@ -2276,7 +2276,7 @@ void halbb_mccdm_h2ccmd_rst(struct bb_info *bb)
 		hal_mem_free(bb->hal_com, mcc_cfg, cmdlen);
 }
 
-void Halbb_mccdm_h2c_handler(struct bb_info *bb)
+static void Halbb_mccdm_h2c_handler(struct bb_info *bb)
 {
 	struct halbb_mcc_dm *mcc_dm = &bb->mcc_dm;
 	struct mcc_h2c_reg_content *reg_cont;
@@ -2345,7 +2345,7 @@ void Halbb_mccdm_h2c_handler(struct bb_info *bb)
 		hal_mem_free(bb->hal_com, mcc_cfg, cmdlen);
 }
 
-void halbb_mccdm_ctrl(struct bb_info *bb)
+static void halbb_mccdm_ctrl(struct bb_info *bb)
 {
 	struct halbb_mcc_dm *mcc_dm = &bb->mcc_dm;
 	u32 val[2] = {0};
@@ -2372,7 +2372,7 @@ void halbb_mccdm_ctrl(struct bb_info *bb)
 	mcc_dm->mcc_pre_status_en = mcc_dm->mcc_status_en;
 }
 
-void halbb_fill_mcccmd(struct bb_info *bb, u8 regid, u16 reg_add, u16 mask,
+static void halbb_fill_mcccmd(struct bb_info *bb, u8 regid, u16 reg_add, u16 mask,
 		       u8 band, u16 val)
 {
 	struct halbb_mcc_dm *mcc_dm = &bb->mcc_dm;
@@ -2383,7 +2383,7 @@ void halbb_fill_mcccmd(struct bb_info *bb, u8 regid, u16 reg_add, u16 mask,
 	mcc_dm->mcc_dm_val[regid][band] = val;
 }
 
-void halbb_mccdm_igi_rst(struct bb_info *bb, u8 clr_port)
+static void halbb_mccdm_igi_rst(struct bb_info *bb, u8 clr_port)
 {
 	struct halbb_mcc_dm *mcc_dm = &bb->mcc_dm;
 
@@ -2410,7 +2410,7 @@ void halbb_mcc_igi_chk(struct bb_info *bb)
 }
 #endif
 
-u8 halbb_mccdm_pd_lower_bound_cal(struct bb_info *bb, u8 bound,
+static u8 halbb_mccdm_pd_lower_bound_cal(struct bb_info *bb, u8 bound,
 				      enum channel_width bw)
 {
 	/*
@@ -2462,7 +2462,7 @@ u8 halbb_mccdm_pd_lower_bound_cal(struct bb_info *bb, u8 bound,
 	return bound_idx;
 }
 
-void halbb_mccdm_pd_cal(struct bb_info *bb)
+static void halbb_mccdm_pd_cal(struct bb_info *bb)
 {
 	struct halbb_mcc_dm *mcc_dm = &bb->mcc_dm;
 	struct bb_dig_info *bb_dig = &bb->bb_dig_i;

--- a/phl/hal_g6/phy/bb/halbb_dyn_1r_cca.c
+++ b/phl/hal_g6/phy/bb/halbb_dyn_1r_cca.c
@@ -26,7 +26,7 @@
 
 #ifdef HALBB_DYN_1R_CCA_SUPPORT
 
-void halbb_1r_cca_cr_cfg(struct bb_info *bb, enum rf_path rx_path)
+static void halbb_1r_cca_cr_cfg(struct bb_info *bb, enum rf_path rx_path)
 {
 	struct bb_dyn_1r_cca_info *dyn_1r_cca = &bb->bb_dyn_1r_cca_i;
 
@@ -44,7 +44,7 @@ void halbb_1r_cca_cr_cfg(struct bb_info *bb, enum rf_path rx_path)
 	}
 }
 
-void halbb_dyn_1r_cca_cfg(struct bb_info *bb, enum rf_path rx_path)
+static void halbb_dyn_1r_cca_cfg(struct bb_info *bb, enum rf_path rx_path)
 {
 	struct bb_dyn_1r_cca_info *dyn_1r_cca = &bb->bb_dyn_1r_cca_i;
 
@@ -150,7 +150,7 @@ void halbb_dyn_1r_cca_init(struct bb_info *bb)
 	dyn_1r_cca->dyn_1r_cca_rssi_min_th= 40 << 5;
 }
 
-void halbb_dyn_1r_cca_en(struct bb_info *bb, bool en)
+static void halbb_dyn_1r_cca_en(struct bb_info *bb, bool en)
 {
 	struct bb_dyn_1r_cca_info *dyn_1r_cca = &bb->bb_dyn_1r_cca_i;
 

--- a/phl/hal_g6/phy/bb/halbb_dyn_csi_rsp.c
+++ b/phl/hal_g6/phy/bb/halbb_dyn_csi_rsp.c
@@ -33,7 +33,7 @@ bool halbb_dyn_csi_rsp_rlt_get(struct bb_info *bb){
 	return bf->is_csi_rsp_en;
 }
 
-void halbb_csi_rsp_rlt(struct bb_info *bb, bool en)
+static void halbb_csi_rsp_rlt(struct bb_info *bb, bool en)
 {
 	struct bf_ch_raw_info *bf = &bb->bb_cmn_hooker->bf_ch_raw_i;
 	enum dcr_csi_rsp;
@@ -65,7 +65,7 @@ void halbb_csi_rsp_rlt(struct bb_info *bb, bool en)
 #endif
 }
 
-bool halbb_dcr_is_he_connect(struct bb_info *bb) {
+static bool halbb_dcr_is_he_connect(struct bb_info *bb) {
 	struct rtw_phl_stainfo_t *sta;
 	struct bb_link_info *link = &bb->bb_link_i;
 	bool rlt = false;
@@ -87,7 +87,7 @@ bool halbb_dcr_is_he_connect(struct bb_info *bb) {
 	return rlt;
 }	
 
-void halbb_dcr_config_ch_info_he(struct bb_info *bb) {
+static void halbb_dcr_config_ch_info_he(struct bb_info *bb) {
 	struct bb_ch_rpt_info *ch_rpt = &bb->bb_ch_rpt_i;
 	struct bb_ch_info_cr_cfg_info *cfg = &ch_rpt->bb_ch_info_cr_cfg_i;
 	struct bf_ch_raw_info *bf = &bb->bb_cmn_hooker->bf_ch_raw_i;
@@ -116,7 +116,7 @@ void halbb_dcr_config_ch_info_he(struct bb_info *bb) {
 
 }
 
-bool halbb_dcr_get_ch_raw_info(struct bb_info *bb, bool is_csi_en)
+static bool halbb_dcr_get_ch_raw_info(struct bb_info *bb, bool is_csi_en)
 {	
 	struct bf_ch_raw_info *bf = &bb->bb_cmn_hooker->bf_ch_raw_i;
 	struct bb_ch_info_physts_info *ch_physts = &bb->bb_ch_rpt_i.bb_ch_info_physts_i;
@@ -197,7 +197,7 @@ void halbb_dcr_reset(struct bb_info *bb)
 	bf->is_csi_rsp_en = true;
 }
 
-bool halbb_dcr_abort(struct bb_info *bb)
+static bool halbb_dcr_abort(struct bb_info *bb)
 {
 	struct bb_link_info *link = &bb->bb_link_i;
 	struct bf_ch_raw_info *bf = &bb->bb_cmn_hooker->bf_ch_raw_i;
@@ -236,7 +236,7 @@ bool halbb_dcr_abort(struct bb_info *bb)
 	return false;
 }
 
-bool halbb_dcr_ch_est(struct bb_info *bb, u16 *addr)
+static bool halbb_dcr_ch_est(struct bb_info *bb, u16 *addr)
 {
 	struct bf_ch_raw_info *bf = &bb->bb_cmn_hooker->bf_ch_raw_i;
 	u32 ix;

--- a/phl/hal_g6/phy/bb/halbb_dyn_dtr.c
+++ b/phl/hal_g6/phy/bb/halbb_dyn_dtr.c
@@ -66,7 +66,7 @@ void halbb_dtr_acc_io_en(struct bb_info *bb)
 
 }
 
-void halbb_dtr_acc_callback(void *context)
+static void halbb_dtr_acc_callback(void *context)
 {
 	struct bb_info *bb = (struct bb_info *)context;
 	struct bb_dyn_dtr_info *bb_dyn_dtr = &bb->bb_dyn_dtr_i;
@@ -99,7 +99,7 @@ void halbb_dtr_deinit(struct bb_info *bb)
 	BB_DBG(bb, DBG_DBG_API, "halbb_dtr_deinit");
 }
 
-bool halbb_dtr_acc_mode_en(struct bb_info *bb)
+static bool halbb_dtr_acc_mode_en(struct bb_info *bb)
 {
 	struct bb_link_info *link = &bb->bb_link_i;
 	struct bb_dyn_dtr_info *bb_dyn_dtr = &bb->bb_dyn_dtr_i;

--- a/phl/hal_g6/phy/bb/halbb_edcca.c
+++ b/phl/hal_g6/phy/bb/halbb_edcca.c
@@ -25,7 +25,7 @@
 #include "halbb_precomp.h"
 
 #ifdef HALBB_EDCCA_SUPPORT
-bool halbb_edcca_abort(struct bb_info *bb)
+static bool halbb_edcca_abort(struct bb_info *bb)
 {
 	if (!(bb->support_ability & BB_EDCCA)) {
 		BB_DBG(bb, DBG_EDCCA, "edcca disable\n");
@@ -103,7 +103,7 @@ void halbb_set_collision_th(struct bb_info *bb)
 }
 #endif
 
-void halbb_set_edcca_thre(struct bb_info *bb)
+static void halbb_set_edcca_thre(struct bb_info *bb)
 {
 	struct bb_edcca_info *bb_edcca = &bb->bb_edcca_i;
 	struct bb_edcca_cr_info *cr = &bb->bb_edcca_i.bb_edcca_cr_i;
@@ -146,7 +146,7 @@ void halbb_set_edcca_thre(struct bb_info *bb)
 	/* ppdu_level_s80 = max(r_ppdu_level + 3, r_obss_level + 6)*/
 }
 
-u8 halbb_edcca_thre_transfer_rssi(struct bb_info *bb)
+static u8 halbb_edcca_thre_transfer_rssi(struct bb_info *bb)
 {
 	struct bb_link_info *bb_link = &bb->bb_link_i;
 	u8 rssi_min = bb->bb_ch_i.rssi_min >> 1;
@@ -234,7 +234,7 @@ void halbb_edcca_event_nofity(struct bb_info *bb, u8 pause_type)
 	pause_result = halbb_pause_func(bb, F_EDCCA, pause_type, HALBB_PAUSE_LV_2, 1, val, bb->bb_phy_idx);
 }
 
-void halbb_edcca_log(struct bb_info *bb)
+static void halbb_edcca_log(struct bb_info *bb)
 {
 	struct bb_edcca_info *bb_edcca = &bb->bb_edcca_i;
 	struct edcca_hw_rpt *rpt = &bb_edcca->edcca_rpt;
@@ -530,7 +530,7 @@ void halbb_fw_edcca(struct bb_info *bb)
 #endif
 }
 
-void halbb_fw_i(struct bb_info *bb, u8 enable)
+static void halbb_fw_i(struct bb_info *bb, u8 enable)
 {
 	struct bb_h2c_fw_edcca *fw_edcca_i = &bb->bb_fw_edcca_i;
 	u8 cmdlen;
@@ -580,7 +580,7 @@ void halbb_edcca_cmn_log(struct bb_info *bb)
 	       edcca_s_th - 128, ppdu_s_th - 128, obss_th - 128);
 }
 
-void halbb_edcca_cnsl_log(struct bb_info *bb, u32 *_used, char *output,
+static void halbb_edcca_cnsl_log(struct bb_info *bb, u32 *_used, char *output,
 			  u32 *_out_len)
 {
 	struct bb_edcca_info *bb_edcca = &bb->bb_edcca_i;

--- a/phl/hal_g6/phy/bb/halbb_env_mntr.c
+++ b/phl/hal_g6/phy/bb/halbb_env_mntr.c
@@ -26,7 +26,7 @@
 
 #ifdef HALBB_ENV_MNTR_SUPPORT
 
-u16 halbb_ccx_get_ratio(struct bb_info *bb, u16 rpt, u16 score)
+static u16 halbb_ccx_get_ratio(struct bb_info *bb, u16 rpt, u16 score)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	u32 numer = 0;
@@ -44,7 +44,7 @@ u16 halbb_ccx_get_ratio(struct bb_info *bb, u16 rpt, u16 score)
 	return ret;
 }
 
-void halbb_ccx_ms_2_period_unit(struct bb_info *bb, u16 time_ms, u32 *period,
+static void halbb_ccx_ms_2_period_unit(struct bb_info *bb, u16 time_ms, u32 *period,
 				u32 *unit_idx)
 {
 	if (time_ms >= 2097)
@@ -75,7 +75,7 @@ u32 halbb_ccx_idx_cnt_2_us(struct bb_info *bb, u16 idx_cnt)
 	return time_us;
 }
 
-u16 halbb_ccx_us_2_idx_cnt(struct bb_info *bb, u32 time_us)
+static u16 halbb_ccx_us_2_idx_cnt(struct bb_info *bb, u32 time_us)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	u16 idx_cnt = 0;
@@ -85,7 +85,7 @@ u16 halbb_ccx_us_2_idx_cnt(struct bb_info *bb, u32 time_us)
 	return idx_cnt;
 }
 
-void halbb_ccx_top_setting_init(struct bb_info *bb)
+static void halbb_ccx_top_setting_init(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -109,7 +109,7 @@ void halbb_ccx_top_setting_init(struct bb_info *bb)
 			       4); /*dccl output, full bandwidth*/
 }
 
-void halbb_ccx_racing_release(struct bb_info *bb, u8 func_sel)
+static void halbb_ccx_racing_release(struct bb_info *bb, u8 func_sel)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 
@@ -126,7 +126,7 @@ void halbb_ccx_racing_release(struct bb_info *bb, u8 func_sel)
 	env->edcca_clm_app = EDCCA_CLM_INIT;
 }
 
-u8 halbb_ccx_racing_ctrl(struct bb_info *bb, enum halbb_racing_lv rac_lv)
+static u8 halbb_ccx_racing_ctrl(struct bb_info *bb, enum halbb_racing_lv rac_lv)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	u8 set_result = HALBB_SET_SUCCESS;
@@ -154,7 +154,7 @@ u8 halbb_ccx_racing_ctrl(struct bb_info *bb, enum halbb_racing_lv rac_lv)
 	return set_result;
 }
 
-void halbb_ccx_trigger(struct bb_info *bb, u8 func_sel)
+static void halbb_ccx_trigger(struct bb_info *bb, u8 func_sel)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -180,7 +180,7 @@ void halbb_ccx_trigger(struct bb_info *bb, u8 func_sel)
 	env->ccx_ongoing = true;
 }
 
-void halbb_ccx_edcca_opt_set(struct bb_info *bb, enum ccx_edcca_opt_sc_idx sc)
+static void halbb_ccx_edcca_opt_set(struct bb_info *bb, enum ccx_edcca_opt_sc_idx sc)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -414,7 +414,7 @@ void halbb_ccx_edcca_opt_set(struct bb_info *bb, enum ccx_edcca_opt_sc_idx sc)
 	}
 }
 
-void halbb_ccx_ext_loss_update(struct bb_info *bb)
+static void halbb_ccx_ext_loss_update(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_ch_info *ch = &bb->bb_ch_i;
@@ -468,7 +468,7 @@ void halbb_ccx_ext_loss_update(struct bb_info *bb)
 
 #ifdef NHM_SUPPORT
 
-void halbb_nhm_cal_wgt(struct bb_info *bb)
+static void halbb_nhm_cal_wgt(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	u8 i = 0;
@@ -499,7 +499,7 @@ void halbb_nhm_cal_wgt(struct bb_info *bb)
 	       env->nhm_wgt[2], env->nhm_wgt[1], env->nhm_wgt[0]);
 }
 
-u8 halbb_nhm_cal_wgt_avg(struct bb_info *bb, u8 start_i, u8 end_i, u16 n_sum,
+static u8 halbb_nhm_cal_wgt_avg(struct bb_info *bb, u8 start_i, u8 end_i, u16 n_sum,
 			 u8 frac_bit_num)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
@@ -536,7 +536,7 @@ u8 halbb_nhm_cal_wgt_avg(struct bb_info *bb, u8 start_i, u8 end_i, u16 n_sum,
 	return wgt_avg;
 }
 
-u16 halbb_nhm_exclu_noise_figure(struct bb_info *bb)
+static u16 halbb_nhm_exclu_noise_figure(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct rtw_hw_band *hw_band = &bb->hal_com->band[bb->bb_phy_idx];
@@ -592,7 +592,7 @@ u16 halbb_nhm_exclu_noise_figure(struct bb_info *bb)
 	return non_noise_f;
 }
 
-void halbb_nhm_get_utility(struct bb_info *bb)
+static void halbb_nhm_get_utility(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_edcca_info *bb_edcca = &bb->bb_edcca_i;
@@ -663,7 +663,7 @@ void halbb_nhm_get_utility(struct bb_info *bb)
 	       5 * (env->nhm_pwr_0p5 & 0x1));
 }
 
-bool halbb_nhm_get_fw_result_h2c(struct bb_info *bb)
+static bool halbb_nhm_get_fw_result_h2c(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	u8 env_h2c_content[4];
@@ -694,7 +694,7 @@ bool halbb_nhm_get_fw_result_h2c(struct bb_info *bb)
 	return true;
 }
 
-void halbb_nhm_get_fw_result_c2h(struct bb_info *bb_0, u8 *c2h)
+static void halbb_nhm_get_fw_result_c2h(struct bb_info *bb_0, u8 *c2h)
 {
 	struct bb_info *bb = bb_0;
 	struct bb_env_mntr_info *env = NULL;
@@ -752,7 +752,7 @@ void halbb_nhm_get_fw_result_c2h(struct bb_info *bb_0, u8 *c2h)
 	       5 * (env->nhm_pwr_0p5 & 0x1));
 }
 
-bool halbb_nhm_get_result(struct bb_info *bb)
+static bool halbb_nhm_get_result(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -826,7 +826,7 @@ bool halbb_nhm_get_result(struct bb_info *bb)
 	return true;
 }
 
-void halbb_nhm_set_th_reg(struct bb_info *bb)
+static void halbb_nhm_set_th_reg(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -887,7 +887,7 @@ void halbb_nhm_set_th_reg(struct bb_info *bb)
 	       env->nhm_th[2], env->nhm_th[1], env->nhm_th[0]);
 }
 
-bool
+static bool
 halbb_nhm_th_update_chk(struct bb_info *bb, struct ccx_para_info *para,
 			u8 *nhm_th)
 {
@@ -959,7 +959,7 @@ CHK_NHM_UPDATE_FINISHED:
 	return is_update;
 }
 
-bool halbb_nhm_set(struct bb_info *bb, struct ccx_para_info *para)
+static bool halbb_nhm_set(struct bb_info *bb, struct ccx_para_info *para)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_link_info *link = &bb->bb_link_i;
@@ -1093,7 +1093,7 @@ bool halbb_nhm_set(struct bb_info *bb, struct ccx_para_info *para)
 	return HALBB_SET_SUCCESS;
 }
 
-void halbb_nhm_init(struct bb_info *bb)
+static void halbb_nhm_init(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -1315,14 +1315,14 @@ void halbb_nhm_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 #endif /*#ifdef NHM_SUPPORT*/
 #ifdef CLM_SUPPORT
 
-void halbb_clm_get_utility(struct bb_info *bb)
+static void halbb_clm_get_utility(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 
 	env->clm_ratio = (u8)halbb_ccx_get_ratio(bb, env->clm_result, 100);
 }
 
-bool
+static bool
 halbb_clm_get_result(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
@@ -1343,7 +1343,7 @@ halbb_clm_get_result(struct bb_info *bb)
 	return true;
 }
 
-bool halbb_clm_set(struct bb_info *bb, struct ccx_para_info *para)
+static bool halbb_clm_set(struct bb_info *bb, struct ccx_para_info *para)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -1449,7 +1449,7 @@ bool halbb_clm_set(struct bb_info *bb, struct ccx_para_info *para)
 	return HALBB_SET_SUCCESS;
 }
 
-void halbb_clm_init(struct bb_info *bb)
+static void halbb_clm_init(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -1472,7 +1472,7 @@ void halbb_clm_init(struct bb_info *bb)
 	halbb_set_reg_curr_phy(bb, cr->clm_en, cr->clm_en_m, true);
 }
 
-void halbb_clm_set_dbg_sel(struct bb_info *bb, u8 dbg_sel)
+static void halbb_clm_set_dbg_sel(struct bb_info *bb, u8 dbg_sel)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -1615,7 +1615,7 @@ void halbb_clm_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 
 #ifdef IFS_CLM_SUPPORT
 
-void halbb_ifs_clm_get_utility(struct bb_info *bb)
+static void halbb_ifs_clm_get_utility(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	u8 i = 0;
@@ -1680,7 +1680,7 @@ void halbb_ifs_clm_get_utility(struct bb_info *bb)
 		       env->ifs_clm_cca_avg[i]);
 }
 
-bool
+static bool
 halbb_ifs_clm_get_result(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
@@ -1795,7 +1795,7 @@ halbb_ifs_clm_get_result(struct bb_info *bb)
 	return true;
 }
 
-void halbb_ifs_clm_set_th_reg(struct bb_info *bb)
+static void halbb_ifs_clm_set_th_reg(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -1841,7 +1841,7 @@ void halbb_ifs_clm_set_th_reg(struct bb_info *bb)
 		       i + 1, env->ifs_clm_th_l[i], env->ifs_clm_th_h[i]);
 }
 
-bool halbb_ifs_clm_th_update_chk(struct bb_info *bb, struct ccx_para_info *para,
+static bool halbb_ifs_clm_th_update_chk(struct bb_info *bb, struct ccx_para_info *para,
 				 u16 *ifs_th_l, u16 *ifs_th_h)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
@@ -1903,7 +1903,7 @@ CHK_IFS_UPDATE_FINISHED:
 	return is_update;
 }
 
-bool halbb_ifs_clm_set(struct bb_info *bb, struct ccx_para_info *para)
+static bool halbb_ifs_clm_set(struct bb_info *bb, struct ccx_para_info *para)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -1974,7 +1974,7 @@ bool halbb_ifs_clm_set(struct bb_info *bb, struct ccx_para_info *para)
 	return HALBB_SET_SUCCESS;
 }
 
-void halbb_ifs_clm_init(struct bb_info *bb)
+static void halbb_ifs_clm_init(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -2157,7 +2157,7 @@ void halbb_ifs_clm_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 #endif
 
 #ifdef FAHM_SUPPORT
-u16 halbb_fahm_get_ratio(struct bb_info *bb, u16 rpt, u16 score)
+static u16 halbb_fahm_get_ratio(struct bb_info *bb, u16 rpt, u16 score)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	u32 numer = 0;
@@ -2175,7 +2175,7 @@ u16 halbb_fahm_get_ratio(struct bb_info *bb, u16 rpt, u16 score)
 	return ret;
 }
 
-void halbb_fahm_racing_release(struct bb_info *bb)
+static void halbb_fahm_racing_release(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 
@@ -2187,7 +2187,7 @@ void halbb_fahm_racing_release(struct bb_info *bb)
 	env->fahm_app = FAHM_INIT;
 }
 
-u8 halbb_fahm_racing_ctrl(struct bb_info *bb, enum halbb_racing_lv rac_lv)
+static u8 halbb_fahm_racing_ctrl(struct bb_info *bb, enum halbb_racing_lv rac_lv)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	u8 set_result = HALBB_SET_SUCCESS;
@@ -2214,7 +2214,7 @@ u8 halbb_fahm_racing_ctrl(struct bb_info *bb, enum halbb_racing_lv rac_lv)
 	return set_result;
 }
 
-void halbb_fahm_hw_trigger(struct bb_info *bb)
+static void halbb_fahm_hw_trigger(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -2229,7 +2229,7 @@ void halbb_fahm_hw_trigger(struct bb_info *bb)
 	env->fahm_ongoing = true;
 }
 
-void halbb_fahm_cal_wgt(struct bb_info *bb)
+static void halbb_fahm_cal_wgt(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	u8 i = 0;
@@ -2260,7 +2260,7 @@ void halbb_fahm_cal_wgt(struct bb_info *bb)
 	       env->fahm_wgt[2], env->fahm_wgt[1], env->fahm_wgt[0]);
 }
 
-u8 halbb_fahm_cal_wgt_avg(struct bb_info *bb, u8 start_i, u8 end_i, u16 n_sum,
+static u8 halbb_fahm_cal_wgt_avg(struct bb_info *bb, u8 start_i, u8 end_i, u16 n_sum,
 		        u8 frac_bit_num)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
@@ -2298,7 +2298,7 @@ u8 halbb_fahm_cal_wgt_avg(struct bb_info *bb, u8 start_i, u8 end_i, u16 n_sum,
 }
 
 
-void halbb_fahm_get_utility(struct bb_info *bb)
+static void halbb_fahm_get_utility(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	u8 i = 0;
@@ -2355,7 +2355,7 @@ void halbb_fahm_get_utility(struct bb_info *bb)
 	       env->fahm_denom_ratio, env->fahm_denom_permil);
 }
 
-bool halbb_fahm_get_result(struct bb_info *bb)
+static bool halbb_fahm_get_result(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -2420,7 +2420,7 @@ bool halbb_fahm_get_result(struct bb_info *bb)
 	return true;
 }
 
-void halbb_fahm_set_th_reg(struct bb_info *bb)
+static void halbb_fahm_set_th_reg(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -2492,7 +2492,7 @@ void halbb_fahm_set_th_reg(struct bb_info *bb)
 	       env->fahm_th[1], env->fahm_th[0]);
 }
 
-bool
+static bool
 halbb_fahm_th_update_chk(struct bb_info *bb, struct fahm_para_info *para,
 			 u8 *fahm_th)
 {
@@ -2565,7 +2565,7 @@ CHK_FAHM_UPDATE_FINISHED:
 	return is_update;
 }
 
-bool halbb_fahm_set(struct bb_info *bb, struct fahm_para_info *para)
+static bool halbb_fahm_set(struct bb_info *bb, struct fahm_para_info *para)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_link_info *link = &bb->bb_link_i;
@@ -2666,7 +2666,7 @@ bool halbb_fahm_set(struct bb_info *bb, struct fahm_para_info *para)
 	return HALBB_SET_SUCCESS;
 }
 
-void halbb_fahm_get_bg_result(struct bb_info *bb, struct fahm_report *bg_rpt)
+static void halbb_fahm_get_bg_result(struct bb_info *bb, struct fahm_report *bg_rpt)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 
@@ -2674,7 +2674,7 @@ void halbb_fahm_get_bg_result(struct bb_info *bb, struct fahm_report *bg_rpt)
 		      sizeof(struct fahm_report));
 }
 
-void halbb_fahm_get_bg_setting(struct bb_info *bb,
+static void halbb_fahm_get_bg_setting(struct bb_info *bb,
 			       struct fahm_para_info *bg_para)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
@@ -2758,7 +2758,7 @@ bool halbb_fahm_result(struct bb_info *bb, struct fahm_report *rpt)
 	return rpt->fahm_rpt_result;
 }
 
-void halbb_fahm_init(struct bb_info *bb)
+static void halbb_fahm_init(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -2943,7 +2943,7 @@ void halbb_fahm_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 #endif
 #ifdef EDCCA_CLM_SUPPORT
 
-void halbb_edcca_clm_get_utility(struct bb_info *bb)
+static void halbb_edcca_clm_get_utility(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 
@@ -2952,7 +2952,7 @@ void halbb_edcca_clm_get_utility(struct bb_info *bb)
 						       100);
 }
 
-bool
+static bool
 halbb_edcca_clm_get_result(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
@@ -2976,7 +2976,7 @@ halbb_edcca_clm_get_result(struct bb_info *bb)
 	return true;
 }
 
-bool halbb_edcca_clm_set(struct bb_info *bb, struct ccx_para_info *para)
+static bool halbb_edcca_clm_set(struct bb_info *bb, struct ccx_para_info *para)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -3028,7 +3028,7 @@ bool halbb_edcca_clm_set(struct bb_info *bb, struct ccx_para_info *para)
 	return HALBB_SET_SUCCESS;
 }
 
-void halbb_edcca_clm_init(struct bb_info *bb)
+static void halbb_edcca_clm_init(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	struct bb_env_mntr_cr_info *cr = &env->bb_env_mntr_cr_i;
@@ -3135,7 +3135,7 @@ u32 halbb_env_mntr_get_fw_result_c2h(struct bb_info *bb, u8 *c2h)
 	return true;
 }
 
-bool
+static bool
 halbb_env_mntr_init_app_chk(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
@@ -3150,7 +3150,7 @@ halbb_env_mntr_init_app_chk(struct bb_info *bb)
 	return chk_result;
 }
 
-bool
+static bool
 halbb_env_mntr_bg_app_chk(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
@@ -3167,7 +3167,7 @@ halbb_env_mntr_bg_app_chk(struct bb_info *bb)
 	return chk_result;
 }
 
-void halbb_env_mntr_cmn_log(struct bb_info *bb)
+static void halbb_env_mntr_cmn_log(struct bb_info *bb)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 	u8 i = 0;
@@ -3666,7 +3666,7 @@ u8 halbb_env_mntr_result(struct bb_info *bb_0, struct env_mntr_rpt *rpt,
 	return rpt->ccx_rpt_result;
 }
 
-void halbb_env_mntr_fw_ctrl(struct bb_info *bb, u8 func_sel, u8 pause_type)
+static void halbb_env_mntr_fw_ctrl(struct bb_info *bb, u8 func_sel, u8 pause_type)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
 
@@ -3691,7 +3691,7 @@ void halbb_env_mntr_fw_ctrl(struct bb_info *bb, u8 func_sel, u8 pause_type)
 }
 
 /*Environment Monitor*/
-bool
+static bool
 halbb_env_mntr_watchdog_chk(struct bb_info *bb, bool is_chk_fahm)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
@@ -3867,7 +3867,7 @@ void halbb_env_mntr_init(struct bb_info *bb)
 	env->idle_pwr_physts= 0;
 }
 
-void halbb_env_mntr_dbg_show_rpt(struct bb_info *bb, u32 *_used, char *output,
+static void halbb_env_mntr_dbg_show_rpt(struct bb_info *bb, u32 *_used, char *output,
 				 u32 *_out_len, struct env_mntr_rpt *rpt,
 				 struct fahm_report *fahm_rpt, bool is_show_rpt,
 				 bool is_show_nhm_rpt, bool is_show_fahm_rpt,
@@ -4088,7 +4088,7 @@ void halbb_env_mntr_dbg_show_rpt(struct bb_info *bb, u32 *_used, char *output,
 	}
 }
 
-void halbb_env_mntr_dbg_bg_result(struct bb_info *bb, u32 *_used, char *output,
+static void halbb_env_mntr_dbg_bg_result(struct bb_info *bb, u32 *_used, char *output,
 				  u32 *_out_len)
 {
 	struct env_mntr_rpt rpt = {0};
@@ -4110,7 +4110,7 @@ void halbb_env_mntr_dbg_bg_result(struct bb_info *bb, u32 *_used, char *output,
 				    is_show_fahm_rpt, is_show_extloss);
 }
 
-void halbb_env_mntr_dbg_bg_para(struct bb_info *bb, u32 *_used, char *output,
+static void halbb_env_mntr_dbg_bg_para(struct bb_info *bb, u32 *_used, char *output,
 				u32 *_out_len)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;
@@ -4166,7 +4166,7 @@ void halbb_env_mntr_dbg_bg_para(struct bb_info *bb, u32 *_used, char *output,
 		    env->fahm_numer_opt, env->fahm_denom_opt);
 }
 
-void halbb_env_mntr_dbg_trigger(struct bb_info *bb, u32 *_used, char *output,
+static void halbb_env_mntr_dbg_trigger(struct bb_info *bb, u32 *_used, char *output,
 				  u32 *_out_len, bool is_adv_trig,
 				  u16 mntr_time)
 {
@@ -4230,7 +4230,7 @@ void halbb_env_mntr_dbg_trigger(struct bb_info *bb, u32 *_used, char *output,
 		    fahm_set_result, fahm_trig_rpt.fahm_rpt_stamp);
 }
 
-void halbb_env_mntr_dbg_get_result(struct bb_info *bb, u32 *_used, char *output,
+static void halbb_env_mntr_dbg_get_result(struct bb_info *bb, u32 *_used, char *output,
 				  u32 *_out_len)
 {
 	struct bb_env_mntr_info *env = &bb->bb_env_mntr_i;

--- a/phl/hal_g6/phy/bb/halbb_hw_cfg.c
+++ b/phl/hal_g6/phy/bb/halbb_hw_cfg.c
@@ -315,7 +315,7 @@ bool halbb_init_gain_table(struct bb_info *bb, bool is_form_folder, u32 folder_l
 }
 
 
-void halbb_get_efuse_ofst_init(struct bb_info *bb)
+static void halbb_get_efuse_ofst_init(struct bb_info *bb)
 {
 	switch (bb->ic_type) {
 

--- a/phl/hal_g6/phy/bb/halbb_init.c
+++ b/phl/hal_g6/phy/bb/halbb_init.c
@@ -14,7 +14,7 @@
  *****************************************************************************/
 #include "halbb_precomp.h"
 
-bool halbb_chk_bb_rf_pkg_set_valid(struct bb_info *bb)
+static bool halbb_chk_bb_rf_pkg_set_valid(struct bb_info *bb)
 {
 	struct rtw_hal_com_t	*hal_i = bb->hal_com;
 	u8 bb_ver = 0; /*hal_i->bb_para_pkg_ver;*/ /*TBD*/
@@ -228,7 +228,7 @@ void halbb_bb_post_init(struct bb_info *bb, enum phl_phy_idx phy_idx)
 	}
 }
 
-void halbb_mlo_cfg_init(struct bb_info *bb)
+static void halbb_mlo_cfg_init(struct bb_info *bb)
 {
 	BB_DBG(bb, DBG_INIT, "[%s]\n", __func__);
 
@@ -250,7 +250,7 @@ void halbb_mlo_cfg_init(struct bb_info *bb)
 	}
 }
 
-void halbb_cmn_info_self_init_cmn_hook(struct bb_info *bb)
+static void halbb_cmn_info_self_init_cmn_hook(struct bb_info *bb)
 {
 	BB_DBG(bb, DBG_INIT, "[%s]\n", __func__);
 
@@ -417,7 +417,7 @@ void halbb_cmn_info_self_init_per_phy(struct bb_info *bb)
 	bb->bb_dbg_i.cr_fake_init_hook_val = 0xfc;
 }
 
-u64 halbb_supportability_default(struct bb_info *bb)
+static u64 halbb_supportability_default(struct bb_info *bb)
 {
 	struct rtw_phl_com_t *phl = bb->phl_com;
 	struct dev_cap_t *dev = &phl->dev_cap;
@@ -540,7 +540,7 @@ u64 halbb_supportability_default(struct bb_info *bb)
 	return support_ability;
 }
 
-void halbb_supportability_init(struct bb_info *bb)
+static void halbb_supportability_init(struct bb_info *bb)
 {
 	u64 support_ability;
 

--- a/phl/hal_g6/phy/bb/halbb_interface.c
+++ b/phl/hal_g6/phy/bb/halbb_interface.c
@@ -359,7 +359,7 @@ bool halbb_test_h2c_c2h_flow(struct bb_info *bb)
 }
 
 
-u32 halbb_c2h_mu_gptbl_rpt(struct bb_info *bb, u16 len, u8 *c2h)
+static u32 halbb_c2h_mu_gptbl_rpt(struct bb_info *bb, u16 len, u8 *c2h)
 {
 	/* Set MU grouping table and return value */
 	u32 val = 0;
@@ -395,7 +395,7 @@ u32 halbb_c2h_mu_gptbl_rpt(struct bb_info *bb, u16 len, u8 *c2h)
 }
 
 #ifdef HALBB_DYN_L2H_SUPPORT
-u32 halbb_c2h_lowrt_rty(struct bb_info *bb, u16 len, u8 *c2h)
+static u32 halbb_c2h_lowrt_rty(struct bb_info *bb, u16 len, u8 *c2h)
 {
 	u32 c2h_rty_cnt = 0;
 	struct bb_dyn_l2h_info *dyn_l2h_i = &bb->bb_dyn_l2h_i;
@@ -405,7 +405,7 @@ u32 halbb_c2h_lowrt_rty(struct bb_info *bb, u16 len, u8 *c2h)
 	return 0;
 }
 
-void halbb_fw_ctrl_rtyrpt(struct bb_info *bb, u8 rpt_rtycnt, u8 en_fw_rpt)
+static void halbb_fw_ctrl_rtyrpt(struct bb_info *bb, u8 rpt_rtycnt, u8 en_fw_rpt)
 {
 	struct bb_fw_dbg_cmn_info *fwmn_i = &bb->bb_fwdbg_i;
 	u32 *bb_h2c = (u32 *) fwmn_i;
@@ -445,7 +445,7 @@ u32 halbb_c2h_fw_trig_tx_rpt(struct bb_info *bb, u16 len, u8 *c2h)
 	return val;
 }*/
 
-u32 halbb_c2h_fw_h2c_test(struct bb_info *bb, u16 len, u8 *c2h)
+static u32 halbb_c2h_fw_h2c_test(struct bb_info *bb, u16 len, u8 *c2h)
 {
 	u16 i;
 	u32 val = (u32)false;
@@ -456,7 +456,7 @@ u32 halbb_c2h_fw_h2c_test(struct bb_info *bb, u16 len, u8 *c2h)
 	return val;
 }
 
-u32 halbb_c2h_ra_parsing(struct bb_info *bb, u8 cmdid, u16 len, u8 *c2h)
+static u32 halbb_c2h_ra_parsing(struct bb_info *bb, u8 cmdid, u16 len, u8 *c2h)
 {
 	u32 val = 0;
 	u16 i;
@@ -483,7 +483,7 @@ u32 halbb_c2h_ra_parsing(struct bb_info *bb, u8 cmdid, u16 len, u8 *c2h)
 	return val;
 }
 
-u32 halbb_c2h_dm_parsing(struct bb_info *bb, u8 cmdid, u16 len, u8 *c2h)
+static u32 halbb_c2h_dm_parsing(struct bb_info *bb, u8 cmdid, u16 len, u8 *c2h)
 {
 	u32 val = 0;
 	u16 i;
@@ -515,7 +515,7 @@ u32 halbb_c2h_dm_parsing(struct bb_info *bb, u8 cmdid, u16 len, u8 *c2h)
 	return val;
 }
 
-u32 halbb_c2h_rua_parsing(struct bb_info *bb, u8 cmdid, u16 len, u8 *c2h)
+static u32 halbb_c2h_rua_parsing(struct bb_info *bb, u8 cmdid, u16 len, u8 *c2h)
 {
 	u32 val = 0;
 	u8 *printaddr = c2h;
@@ -559,7 +559,7 @@ u32 rtw_halbb_c2h_parsing(struct bb_info *bb, u8 classid, u8 cmdid, u16 len, u8 
 	return val;
 }
 
-enum rf_path halbb_config_path(struct bb_info *bb, enum phl_band_idx band_idx,
+static enum rf_path halbb_config_path(struct bb_info *bb, enum phl_band_idx band_idx,
 			u8 rf_num)
 {
 	enum rf_path path_set = RF_PATH_A;
@@ -725,7 +725,7 @@ u8 halbb_set_cmac_databw_er(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_st
 	return 0;
 }
 
-bool halbb_set_pwr_by_rate_tbl(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
+static bool halbb_set_pwr_by_rate_tbl(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
 {
 	struct halbb_pwr_by_rate_tbl pwr_t = {{0}};
 	u8 i = 0;

--- a/phl/hal_g6/phy/bb/halbb_la_mode.c
+++ b/phl/hal_g6/phy/bb/halbb_la_mode.c
@@ -34,7 +34,7 @@
 #define SET_MAC_GET_BUF_RPT 1
 
 #if (SET_MAC_GET_BUF_RPT)
-u8 halbb_la_ptrn_chk(struct bb_info *bb)
+static u8 halbb_la_ptrn_chk(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_string_info *buf = &la->la_string_i;
@@ -97,7 +97,7 @@ u8 halbb_la_ptrn_chk(struct bb_info *bb)
 	return ptrn_match;
 }
 
-void halbb_la_rpt_buf_get(struct bb_info *bb, u16 finish_ofst, bool is_round_up)
+static void halbb_la_rpt_buf_get(struct bb_info *bb, u16 finish_ofst, bool is_round_up)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_string_info *buf = &la->la_string_i;
@@ -181,7 +181,7 @@ void halbb_la_mac_phy_src_sel(struct bb_info *bb, enum phl_phy_idx phy_idx)
 }
 #endif
 
-void halbb_la_set_mac_trig_time(struct bb_info *bb, u32 trig_time, u8 *unit, u8 *unit_num)
+static void halbb_la_set_mac_trig_time(struct bb_info *bb, u32 trig_time, u8 *unit, u8 *unit_num)
 {
 	u32 ref_time = 128;
 	u8 time_unit_num = 0;
@@ -206,7 +206,7 @@ void halbb_la_set_mac_trig_time(struct bb_info *bb, u32 trig_time, u8 *unit, u8 
 	       unit_num[0], unit[0]);
 }
 
-bool halbb_la_mac_cfg_buf(struct bb_info *bb, enum la_buff_mode_t mode)
+static bool halbb_la_mac_cfg_buf(struct bb_info *bb, enum la_buff_mode_t mode)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_mac_cfg_info	*cfg = &la->la_mac_cfg_i;
@@ -288,7 +288,7 @@ bool halbb_la_mac_cfg_buf(struct bb_info *bb, enum la_buff_mode_t mode)
 	return true;
 }
 
-void halbb_la_mac_cfg_buf_default(struct bb_info *bb)
+static void halbb_la_mac_cfg_buf_default(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_string_info *buf = &la->la_string_i;
@@ -333,7 +333,7 @@ void halbb_la_mac_cfg_buf_default(struct bb_info *bb)
 	buf->smp_number_max = buf->buffer_size >> 3;
 }
 
-void halbb_la_mac_cfg_cmn(struct bb_info *bb)
+static void halbb_la_mac_cfg_cmn(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_mac_cfg_info	*cfg = &la->la_mac_cfg_i;
@@ -349,7 +349,7 @@ void halbb_la_mac_cfg_cmn(struct bb_info *bb)
 
 }
 
-void halbb_la_mac_init(struct bb_info *bb)
+static void halbb_la_mac_init(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_mac_cfg_info	*cfg = &la->la_mac_cfg_i;
@@ -365,7 +365,7 @@ void halbb_la_mac_init(struct bb_info *bb)
 #endif
 
 #if SET_MAC_TRIG
-void halbb_la_mac_set_adv_reset(struct bb_info *bb)
+static void halbb_la_mac_set_adv_reset(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_trig_mac_info *trig_mac = &la->la_trig_mac_i;
@@ -373,7 +373,7 @@ void halbb_la_mac_set_adv_reset(struct bb_info *bb)
 	halbb_mem_set(bb, trig_mac, 0, sizeof(struct la_trig_mac_info));
 }
 
-void halbb_la_mac_set_trig(struct bb_info *bb, bool mac_trig_en)
+static void halbb_la_mac_set_trig(struct bb_info *bb, bool mac_trig_en)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_trig_mac_info	*trig_mac = &la->la_trig_mac_i;
@@ -427,7 +427,7 @@ void halbb_la_mac_set_trig(struct bb_info *bb, bool mac_trig_en)
 #endif
 
 #if SET_BB_DMA_FMT
-void halbb_la_bb_set_dma_type(struct bb_info *bb)
+static void halbb_la_bb_set_dma_type(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_dma_info	*dma = &la->la_dma_i;
@@ -476,7 +476,7 @@ void halbb_la_bb_set_dma_type(struct bb_info *bb)
 	halbb_set_reg_cmn(bb, cr->r_dma_rdrdy, cr->r_dma_rdrdy_m, r_dma_rdrdy, bb->bb_phy_idx);
 }
 
-void halbb_la_bb_set_dma_type_reset(struct bb_info *bb)
+static void halbb_la_bb_set_dma_type_reset(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_dma_info	*dma = &la->la_dma_i;
@@ -501,7 +501,7 @@ void halbb_la_bb_set_dma_type_reset(struct bb_info *bb)
 #endif
 
 #if SET_BB_TRIG_RULE
-void halbb_la_bb_set_adv_reset(struct bb_info *bb)
+static void halbb_la_bb_set_adv_reset(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_adv_trig_info *adv = &la->adv_trig_i;
@@ -509,7 +509,7 @@ void halbb_la_bb_set_adv_reset(struct bb_info *bb)
 	halbb_mem_set(bb, adv, 0, sizeof(struct la_adv_trig_info));
 }
 
-void halbb_la_bb_set_smp_rate(struct bb_info *bb, u8 fix_mode_en,
+static void halbb_la_bb_set_smp_rate(struct bb_info *bb, u8 fix_mode_en,
 					  enum la_bb_smp_clk la_smp_rate_in)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
@@ -545,7 +545,7 @@ void halbb_la_bb_set_smp_rate(struct bb_info *bb, u8 fix_mode_en,
 		 __func__, smp_rate_tmp, la->la_smp_rate_log);
 }
 
-void halbb_la_bb_set_cmn_reset(struct bb_info *bb)
+static void halbb_la_bb_set_cmn_reset(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	enum channel_width bw = bb->hal_com->band[bb->bb_phy_idx].cur_chandef.bw;
@@ -574,7 +574,7 @@ void halbb_la_bb_set_cmn_reset(struct bb_info *bb)
 #endif
 }
 
-void halbb_la_bb_set_re_trig_reset(struct bb_info *bb)
+static void halbb_la_bb_set_re_trig_reset(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_re_trig_info *re_trig = &la->la_re_trig_i;
@@ -582,7 +582,7 @@ void halbb_la_bb_set_re_trig_reset(struct bb_info *bb)
 	halbb_mem_set(bb, re_trig, 0, sizeof(struct la_re_trig_info));
 }
 
-void halbb_la_bb_set_re_trig(struct bb_info *bb, bool re_trig_en)
+static void halbb_la_bb_set_re_trig(struct bb_info *bb, bool re_trig_en)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_re_trig_info *re_trig = &la->la_re_trig_i;
@@ -610,7 +610,7 @@ void halbb_la_bb_set_re_trig(struct bb_info *bb, bool re_trig_en)
 	halbb_set_reg_cmn(bb, cr->la_re_and1_inv, cr->la_re_and1_inv_m,
 		      re_trig->la_re_and0_inv, bb->bb_phy_idx);
 }
-void halbb_la_bb_set_trig(struct bb_info *bb, bool and0_trig_disable, bool adv_trig_en, bool not_stop_trig_en)
+static void halbb_la_bb_set_trig(struct bb_info *bb, bool and0_trig_disable, bool adv_trig_en, bool not_stop_trig_en)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_adv_trig_info *adv = &la->adv_trig_i;
@@ -713,7 +713,7 @@ void halbb_la_bb_set_trig(struct bb_info *bb, bool and0_trig_disable, bool adv_t
 			      adv->la_and7_val, bb->bb_phy_idx);
 }
 
-void halbb_la_bb_set_dbg_port(struct bb_info *bb, bool not_stop_trig_en)
+static void halbb_la_bb_set_dbg_port(struct bb_info *bb, bool not_stop_trig_en)
 {
 	
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
@@ -738,7 +738,7 @@ void halbb_la_bb_set_dbg_port(struct bb_info *bb, bool not_stop_trig_en)
 	}
 }
 
-void halbb_la_bb_set_general(struct bb_info *bb)
+static void halbb_la_bb_set_general(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_dma_info	*dma = &la->la_dma_i;
@@ -784,7 +784,7 @@ void halbb_la_bb_set_general(struct bb_info *bb)
 #endif
 
 #if LAMODE_MAIN
-void
+static void
 halbb_la_drv_buf_release(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
@@ -796,7 +796,7 @@ halbb_la_drv_buf_release(struct bb_info *bb)
 	}
 }
 
-bool
+static bool
 halbb_la_drv_buf_allocate(struct bb_info *bb)
 {
 	
@@ -819,14 +819,14 @@ halbb_la_drv_buf_allocate(struct bb_info *bb)
 	return ret;
 }
 
-void halbb_la_stop(struct bb_info *bb)
+static void halbb_la_stop(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 
 	la->la_mode_state = LA_STATE_IDLE;
 }
 
-void halbb_la_main(struct bb_info *bb)
+static void halbb_la_main(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_dma_info	*dma = &la->la_dma_i;
@@ -977,7 +977,7 @@ void halbb_la_deinit(struct bb_info *bb)
 	halbb_la_drv_buf_release(bb);
 }
 
-void halbb_la_reset(struct bb_info *bb)
+static void halbb_la_reset(struct bb_info *bb)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
 	struct la_string_info *la_string = &la->la_string_i;
@@ -1594,7 +1594,7 @@ void halbb_cr_cfg_la_init(struct bb_info *bb)
 #endif
 
 #if LAMODE_ECHO_CMD
-void halbb_la_cr_dump(struct bb_info *bb)
+static void halbb_la_cr_dump(struct bb_info *bb)
 {
 	struct bb_la_cr_info *cr = &bb->bb_cmn_hooker->bb_la_mode_i.bb_la_cr_i;
 	u32 cr_table[18];
@@ -1627,7 +1627,7 @@ void halbb_la_cr_dump(struct bb_info *bb)
 	halbb_cr_table_dump(bb, cr_table, cr_len);
 }
 
-void halbb_la_buffer_print(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_la_buffer_print(struct bb_info *bb, char input[][16], u32 *_used,
 		      char *output, u32 *_out_len)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
@@ -1726,7 +1726,7 @@ void halbb_la_buffer_print(struct bb_info *bb, char input[][16], u32 *_used,
 		     "Dump_End\n\n");
 }
 
-void halbb_la_cmd_bb_show_cfg(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_la_cmd_bb_show_cfg(struct bb_info *bb, char input[][16], u32 *_used,
 			      char *output, u32 *_out_len)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
@@ -1848,7 +1848,7 @@ void halbb_la_cmd_bb_show_cfg(struct bb_info *bb, char input[][16], u32 *_used,
 		    "max_num {val:%d}: consective capture LA pattern number\n", la->la_count);
 }
 
-void halbb_la_cmd_bb_cmn(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_la_cmd_bb_cmn(struct bb_info *bb, char input[][16], u32 *_used,
 			      char *output, u32 *_out_len)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
@@ -1877,7 +1877,7 @@ void halbb_la_cmd_bb_cmn(struct bb_info *bb, char input[][16], u32 *_used,
 	halbb_la_bb_set_smp_rate(bb, true, (enum la_bb_smp_clk)val[4]);
 }
 
-void halbb_la_cmd_bb_dma(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_la_cmd_bb_dma(struct bb_info *bb, char input[][16], u32 *_used,
 			      char *output, u32 *_out_len)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
@@ -1914,7 +1914,7 @@ void halbb_la_cmd_bb_dma(struct bb_info *bb, char input[][16], u32 *_used,
 	}
 }
 
-void halbb_la_cmd_bb_trig(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_la_cmd_bb_trig(struct bb_info *bb, char input[][16], u32 *_used,
 			      char *output, u32 *_out_len)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
@@ -1980,7 +1980,7 @@ void halbb_la_cmd_bb_trig(struct bb_info *bb, char input[][16], u32 *_used,
 		 "[Adv_trig_en=%d]\n\n", adv->adv_trig_en);
 }
 
-void halbb_la_cmd_bb_re_trig(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_la_cmd_bb_re_trig(struct bb_info *bb, char input[][16], u32 *_used,
 			      char *output, u32 *_out_len)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
@@ -2038,7 +2038,7 @@ void halbb_la_timer_init(struct bb_info *bb)
 	halbb_init_timer(bb, &timer->timer_list, halbb_la_callback, bb, "halbb_la_timer");
 }
 
-void halbb_la_cmd_rtl_test(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_la_cmd_rtl_test(struct bb_info *bb, char input[][16], u32 *_used,
 			    char *output, u32 *_out_len)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
@@ -2231,7 +2231,7 @@ void halbb_la_cmd_rtl_test(struct bb_info *bb, char input[][16], u32 *_used,
 	halbb_print_devider(bb, BB_DEVIDER_LEN_32, true, FRC_PRINT_LINE);
 }
 
-void halbb_la_cmd_mac_trig(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_la_cmd_mac_trig(struct bb_info *bb, char input[][16], u32 *_used,
 			      char *output, u32 *_out_len)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;
@@ -2265,7 +2265,7 @@ void halbb_la_cmd_mac_trig(struct bb_info *bb, char input[][16], u32 *_used,
 	
 }
 
-void halbb_la_cmd_fast(struct bb_info *bb, char input[][16], u32 *_used,
+static void halbb_la_cmd_fast(struct bb_info *bb, char input[][16], u32 *_used,
 			    char *output, u32 *_out_len)
 {
 	struct bb_la_mode_info *la = &bb->bb_cmn_hooker->bb_la_mode_i;

--- a/phl/hal_g6/phy/bb/halbb_math_lib.c
+++ b/phl/hal_g6/phy/bb/halbb_math_lib.c
@@ -237,7 +237,7 @@ u16 halbb_show_fraction_num(u32 frac_val, u8 bit_num)
 	return val;
 }
 
-u32 halbb_show_fraction_num_opt(u32 frac_val, u8 bit_num, u8 decimal_place)
+static u32 halbb_show_fraction_num_opt(u32 frac_val, u8 bit_num, u8 decimal_place)
 {
 	u8 i = 0;
 	u32 val = 0;

--- a/phl/hal_g6/phy/bb/halbb_mp.c
+++ b/phl/hal_g6/phy/bb/halbb_mp.c
@@ -68,7 +68,7 @@ u16 halbb_mp_get_tx_ok(struct bb_info *bb, u32 rate_index,
 	return (u16)tx_ok;
 }
 
-u32 halbb_rx_crc_ok_6(struct bb_info *bb, enum phl_phy_idx phy_idx)
+static u32 halbb_rx_crc_ok_6(struct bb_info *bb, enum phl_phy_idx phy_idx)
 {
 	u32 cck_ok = 0, ofdm_ok = 0, ht_ok = 0, vht_ok = 0, he_ok = 0;
 	u32 crc_ok;
@@ -100,7 +100,7 @@ u32 halbb_rx_crc_ok_6(struct bb_info *bb, enum phl_phy_idx phy_idx)
 	return crc_ok;
 }
 
-u32 halbb_rx_crc_ok_7(struct bb_info *bb, enum phl_phy_idx phy_idx)
+static u32 halbb_rx_crc_ok_7(struct bb_info *bb, enum phl_phy_idx phy_idx)
 {
 	u32 cck_ok = 0, ofdm_ok = 0, ht_ok = 0, vht_ok = 0, he_ok = 0, eht_ok = 0;
 	u32 crc_ok;
@@ -150,7 +150,7 @@ u32 halbb_mp_get_rx_crc_ok(struct bb_info *bb, enum phl_phy_idx phy_idx)
 	return crc_ok;
 }
 
-u32 halbb_rx_crc_err_6(struct bb_info *bb, enum phl_phy_idx phy_idx)
+static u32 halbb_rx_crc_err_6(struct bb_info *bb, enum phl_phy_idx phy_idx)
 {
 	u32 cck_err = 0, ofdm_err = 0, ht_err = 0, vht_err = 0, he_err = 0;
 	u32 crc_err;
@@ -182,7 +182,7 @@ u32 halbb_rx_crc_err_6(struct bb_info *bb, enum phl_phy_idx phy_idx)
 	return crc_err;
 }
 
-u32 halbb_rx_crc_err_7(struct bb_info *bb, enum phl_phy_idx phy_idx)
+static u32 halbb_rx_crc_err_7(struct bb_info *bb, enum phl_phy_idx phy_idx)
 {
 	u32 cck_err = 0, ofdm_err = 0, ht_err = 0, vht_err = 0, he_err = 0, eht_err = 0;
 	u32 crc_err;
@@ -252,7 +252,7 @@ void halbb_mp_reset_cnt(struct bb_info *bb)
 	halbb_set_reg_cmn(bb, cr->rst_all_cnt, cr->rst_all_cnt_m, 0, HW_PHY_1);
 }
 
-void halbb_mp_psts_setting(struct bb_info *bb, u32 ie_bitmap_setting)
+static void halbb_mp_psts_setting(struct bb_info *bb, u32 ie_bitmap_setting)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
 	struct bb_rpt_cr_info *cr = &bb->bb_rpt_i.bb_rpt_cr_i;
@@ -283,7 +283,7 @@ void halbb_mp_psts_setting(struct bb_info *bb, u32 ie_bitmap_setting)
 
 }
 
-void
+static void
 halbb_mp_get_psts_ie_bitmap(struct bb_info *bb, struct bb_mp_psts *bb_mp_physts)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
@@ -297,7 +297,7 @@ halbb_mp_get_psts_ie_bitmap(struct bb_info *bb, struct bb_mp_psts *bb_mp_physts)
 }
 
 
-void
+static void
 halbb_mp_get_psts_ie_00(struct bb_info *bb, struct bb_mp_psts *bb_mp_physts)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
@@ -310,7 +310,7 @@ halbb_mp_get_psts_ie_00(struct bb_info *bb, struct bb_mp_psts *bb_mp_physts)
 
 }
 
-void
+static void
 halbb_mp_get_psts_ie_01(struct bb_info *bb, struct bb_mp_psts *bb_mp_physts)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
@@ -345,7 +345,7 @@ halbb_mp_get_psts(struct bb_info *bb , struct bb_mp_psts *bb_mp_physts)
 	}
 }
 
-void halbb_keeper_cond(struct bb_info *bb, bool keeper_en, u8 keeper_trig_cond,
+static void halbb_keeper_cond(struct bb_info *bb, bool keeper_en, u8 keeper_trig_cond,
 		       u8 dbg_sel, enum phl_phy_idx phy_idx)
 {
 	struct bb_rpt_cr_info *cr = &bb->bb_rpt_i.bb_rpt_cr_i;
@@ -795,7 +795,7 @@ u8 halbb_mp_get_rssi(struct bb_info *bb, enum rf_path path)
 #endif
 }
 
-s32 halbb_rssi_cal(struct bb_info *bb, u8 rssi_0, u8 rssi_1, bool is_higher_rssi_path, enum phl_phy_idx phy_idx)
+static s32 halbb_rssi_cal(struct bb_info *bb, u8 rssi_0, u8 rssi_1, bool is_higher_rssi_path, enum phl_phy_idx phy_idx)
 {
 	u8 rssi_diff = rssi_0 - rssi_1;
 	s32 rssi_cal;

--- a/phl/hal_g6/phy/bb/halbb_path_div.c
+++ b/phl/hal_g6/phy/bb/halbb_path_div.c
@@ -26,7 +26,7 @@
 
 #ifdef HALBB_PATH_DIV_SUPPORT
 
-bool halbb_pathdiv_abort(struct bb_info *bb)
+static bool halbb_pathdiv_abort(struct bb_info *bb)
 {
 	if (!(bb->support_ability & BB_PATH_DIV)) {
 		BB_DBG(bb, DBG_PATH_DIV, "Not support path diversity\n");
@@ -150,7 +150,7 @@ void halbb_set_tx_path_by_cmac_tbl(struct bb_info *bb, u8 macid, enum bb_path tx
 
 }
 
-void halbb_set_tx_path_by_reg(struct bb_info *bb, u8 macid, enum bb_path tx_path_sel_1ss)
+static void halbb_set_tx_path_by_reg(struct bb_info *bb, u8 macid, enum bb_path tx_path_sel_1ss)
 {
 	struct bb_pathdiv_info *bb_path_div = &bb->bb_path_div_i;
 	struct rtw_hal_com_t *hal_com = bb->hal_com;

--- a/phl/hal_g6/phy/bb/halbb_physts.c
+++ b/phl/hal_g6/phy/bb/halbb_physts.c
@@ -323,7 +323,7 @@ END:
 	//	 __func__, ch_idx, band, seq_160m_bw, ch_ofst, ch_idx_encoded_tmp);
 }
 
-void halbb_physts_per_path_ie_rpt_en(struct bb_info *bb, bool en)
+static void halbb_physts_per_path_ie_rpt_en(struct bb_info *bb, bool en)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
 	u32 u32_tmp = 0;
@@ -368,7 +368,7 @@ void halbb_physts_cvrt_2_mp(struct bb_info *bb)
 	physts->show_phy_sts_all_pkt = true;
 }
 
-void halbb_physts_detail_dump_ie_11(struct bb_info *bb)
+static void halbb_physts_detail_dump_ie_11(struct bb_info *bb)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
 	struct bb_physts_rslt_11_info *psts_11 = &physts->bb_physts_rslt_11_i;
@@ -480,7 +480,7 @@ void halbb_physts_detail_dump_ie_11(struct bb_info *bb)
 	}
 }
 
-void halbb_physts_detail_dump_ie_4_7(struct bb_info *bb, enum bb_physts_ie_t ie)
+static void halbb_physts_detail_dump_ie_4_7(struct bb_info *bb, enum bb_physts_ie_t ie)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
 	struct bb_physts_rslt_4_to_7_info *psts_r = NULL;
@@ -523,7 +523,7 @@ void halbb_physts_detail_dump_ie_4_7(struct bb_info *bb, enum bb_physts_ie_t ie)
 		 ie_4_7->rf_tia_gain_idx, ie_4_7->tia_shrink_indicator);
 }
 
-void halbb_physts_detail_dump(struct bb_info *bb, u32 bitmap, u32 bitmap_mask)
+static void halbb_physts_detail_dump(struct bb_info *bb, u32 bitmap, u32 bitmap_mask)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
 	struct bb_physts_rslt_hdr_info	*psts_h = &physts->bb_physts_rslt_hdr_i;
@@ -965,7 +965,7 @@ void halbb_physts_brk_fail_rpt_en(struct bb_info *bb, bool enable,
 	}
 }
 
-void halbb_physts_td_time_rpt_en(struct bb_info *bb, bool en,
+static void halbb_physts_td_time_rpt_en(struct bb_info *bb, bool en,
 				 enum phl_phy_idx phy_idx)
 {
 	struct bb_physts_info *physts = &bb->bb_physts_i;
@@ -998,7 +998,7 @@ void halbb_mod_rssi_by_path_en(struct bb_info *bb, u8 rx_path_en)
 		psts_h->rssi_avg = valid_rssi_max;
 }
 
-u8 halbb_physts_ie_hdr(struct bb_info *bb,
+static u8 halbb_physts_ie_hdr(struct bb_info *bb,
 		       u8 *addr,
 		       struct physts_rxd *desc, u16 *ie_length_hdr)
 {
@@ -1040,7 +1040,7 @@ u8 halbb_physts_ie_hdr(struct bb_info *bb,
 	return physts_hdr->is_valid;
 }
 
-bool halbb_physts_ie_00(struct bb_info *bb,
+static bool halbb_physts_ie_00(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1067,7 +1067,7 @@ bool halbb_physts_ie_00(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_01(struct bb_info *bb,
+static bool halbb_physts_ie_01(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1144,7 +1144,7 @@ bool halbb_physts_ie_01(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_02(struct bb_info *bb,
+static bool halbb_physts_ie_02(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1196,7 +1196,7 @@ bool halbb_physts_ie_02(struct bb_info *bb,
 	
 	return true;
 }
-bool halbb_physts_ie_03(struct bb_info *bb,
+static bool halbb_physts_ie_03(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1226,7 +1226,7 @@ bool halbb_physts_ie_03(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_04_07(struct bb_info *bb,
+static bool halbb_physts_ie_04_07(struct bb_info *bb,
 			   enum bb_physts_ie_t ie,
 			   u8 *addr,
 			   u16 ie_length,
@@ -1274,7 +1274,7 @@ bool halbb_physts_ie_04_07(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_08(struct bb_info *bb,
+static bool halbb_physts_ie_08(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1407,7 +1407,7 @@ bool halbb_physts_ie_08(struct bb_info *bb,
 	return true;
 }
 
-void halbb_physts_ie_09_lgcy(struct bb_info *bb,
+static void halbb_physts_ie_09_lgcy(struct bb_info *bb,
 			   u8 *addr,
 			   u8 rate_mode,
 			   struct physts_rxd *desc)
@@ -1421,7 +1421,7 @@ void halbb_physts_ie_09_lgcy(struct bb_info *bb,
 	psts_9->l_sig = (ie_9->l_sig_m << 11) | (ie_9->l_sig_lm << 3) | (ie_9->l_sig_l);
 }
 
-void halbb_physts_ie_09_vht(struct bb_info *bb,
+static void halbb_physts_ie_09_vht(struct bb_info *bb,
 			   u8 *addr,
 			   u8 rate_mode,
 			   struct physts_rxd *desc)
@@ -1437,7 +1437,7 @@ void halbb_physts_ie_09_vht(struct bb_info *bb,
 	psts_9->sig_a2 = (ie_9->sig_a2_m << 2) | (ie_9->sig_a2_l);
 }
 
-void halbb_physts_ie_09_he(struct bb_info *bb,
+static void halbb_physts_ie_09_he(struct bb_info *bb,
 			   u8 *addr,
 			   u8 rate_mode,
 			   struct physts_rxd *desc)
@@ -1465,7 +1465,7 @@ void halbb_physts_ie_09_he(struct bb_info *bb,
 #endif
 }
 
-bool halbb_physts_ie_09(struct bb_info *bb,
+static bool halbb_physts_ie_09(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1487,7 +1487,7 @@ bool halbb_physts_ie_09(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_10(struct bb_info *bb,
+static bool halbb_physts_ie_10(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1509,7 +1509,7 @@ bool halbb_physts_ie_10(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_11(struct bb_info *bb,
+static bool halbb_physts_ie_11(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1531,7 +1531,7 @@ bool halbb_physts_ie_11(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_12(struct bb_info *bb,
+static bool halbb_physts_ie_12(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1583,7 +1583,7 @@ bool halbb_physts_ie_12(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_13(struct bb_info *bb,
+static bool halbb_physts_ie_13(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1648,7 +1648,7 @@ bool halbb_physts_ie_13(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_14(struct bb_info *bb,
+static bool halbb_physts_ie_14(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1699,7 +1699,7 @@ bool halbb_physts_ie_14(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_15(struct bb_info *bb,
+static bool halbb_physts_ie_15(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1755,7 +1755,7 @@ bool halbb_physts_ie_15(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_17(struct bb_info *bb,
+static bool halbb_physts_ie_17(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1814,7 +1814,7 @@ bool halbb_physts_ie_17(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_18(struct bb_info *bb,
+static bool halbb_physts_ie_18(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1841,7 +1841,7 @@ bool halbb_physts_ie_18(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_19(struct bb_info *bb,
+static bool halbb_physts_ie_19(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1876,7 +1876,7 @@ bool halbb_physts_ie_19(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_20(struct bb_info *bb,
+static bool halbb_physts_ie_20(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1966,7 +1966,7 @@ bool halbb_physts_ie_20(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_21(struct bb_info *bb,
+static bool halbb_physts_ie_21(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -2056,7 +2056,7 @@ bool halbb_physts_ie_21(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_22(struct bb_info *bb,
+static bool halbb_physts_ie_22(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -2080,7 +2080,7 @@ bool halbb_physts_ie_22(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_24(struct bb_info *bb,
+static bool halbb_physts_ie_24(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -2127,7 +2127,7 @@ bool halbb_physts_ie_24(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_25(struct bb_info *bb,
+static bool halbb_physts_ie_25(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -2171,7 +2171,7 @@ bool halbb_physts_ie_25(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_26(struct bb_info *bb,
+static bool halbb_physts_ie_26(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -2184,7 +2184,7 @@ bool halbb_physts_ie_26(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_27(struct bb_info *bb,
+static bool halbb_physts_ie_27(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -2197,7 +2197,7 @@ bool halbb_physts_ie_27(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_28(struct bb_info *bb,
+static bool halbb_physts_ie_28(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -2244,7 +2244,7 @@ bool halbb_physts_ie_28(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_29(struct bb_info *bb,
+static bool halbb_physts_ie_29(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -2291,7 +2291,7 @@ bool halbb_physts_ie_29(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_30(struct bb_info *bb,
+static bool halbb_physts_ie_30(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -2304,7 +2304,7 @@ bool halbb_physts_ie_30(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_physts_ie_31(struct bb_info *bb,
+static bool halbb_physts_ie_31(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -2443,7 +2443,7 @@ void halbb_physts_rpt_gen(struct bb_info *bb, u32 physts_bitmap,
 		rpt->snr_fd_avg, rpt->snr_fd[0], rpt->snr_fd[1], rpt->snr_fd[2], rpt->snr_fd[3]);
 }
 
-void halbb_physts_print(struct bb_info *bb, struct physts_rxd *desc,
+static void halbb_physts_print(struct bb_info *bb, struct physts_rxd *desc,
 			u16 total_len, u8 *addr, u32 physts_bitmap)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
@@ -2517,7 +2517,7 @@ void halbb_physts_print(struct bb_info *bb, struct physts_rxd *desc,
 	BB_TRACE("==============================================\n");
 }
 
-bool halbb_6_physts_parsing(struct bb_info *bb_0,
+static bool halbb_6_physts_parsing(struct bb_info *bb_0,
 			      u8 *addr,
 			      u16 physts_total_length,
 			      struct physts_rxd *desc,
@@ -3016,7 +3016,7 @@ void halbb_physts_parsing_init(struct bb_info *bb)
 	halbb_physts_parsing_init_io_en(bb);
 }
 
-void halbb_physts_query_from_bbcr(struct bb_info *bb)
+static void halbb_physts_query_from_bbcr(struct bb_info *bb)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
 	//struct bb_physts_cr_info *cr = &physts->bb_physts_cr_i;

--- a/phl/hal_g6/phy/bb/halbb_physts_7.c
+++ b/phl/hal_g6/phy/bb/halbb_physts_7.c
@@ -26,7 +26,7 @@
 
 #ifdef HALBB_PHYSTS_PARSING_SUPPORT
 
-void halbb_7_physts_detail_dump_ie_4_7(struct bb_info *bb, enum bb_physts_ie_t ie)
+static void halbb_7_physts_detail_dump_ie_4_7(struct bb_info *bb, enum bb_physts_ie_t ie)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
 	struct bb_physts_rslt_4_to_7_info *psts_r = NULL;
@@ -69,7 +69,7 @@ void halbb_7_physts_detail_dump_ie_4_7(struct bb_info *bb, enum bb_physts_ie_t i
 		 ie_4_7->rf_tia_gain_idx, ie_4_7->tia_shrink_indicator);
 }
 
-void halbb_7_physts_detail_dump(struct bb_info *bb, u32 bitmap, u32 bitmap_mask)
+static void halbb_7_physts_detail_dump(struct bb_info *bb, u32 bitmap, u32 bitmap_mask)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
 	struct bb_physts_rslt_hdr_info	*psts_h = &physts->bb_physts_rslt_hdr_i;
@@ -402,7 +402,7 @@ void halbb_7_physts_detail_dump(struct bb_info *bb, u32 bitmap, u32 bitmap_mask)
 	#endif
 }
 
-u8 halbb_7_physts_ie_hdr(struct bb_info *bb,
+static u8 halbb_7_physts_ie_hdr(struct bb_info *bb,
 		       u8 *addr,
 		       struct physts_rxd *desc, u16 *ie_length_hdr)
 {
@@ -442,7 +442,7 @@ u8 halbb_7_physts_ie_hdr(struct bb_info *bb,
 	return physts_hdr->is_valid;
 }
 
-bool halbb_7_physts_ie_00(struct bb_info *bb,
+static bool halbb_7_physts_ie_00(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -469,7 +469,7 @@ bool halbb_7_physts_ie_00(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_01(struct bb_info *bb,
+static bool halbb_7_physts_ie_01(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -546,7 +546,7 @@ bool halbb_7_physts_ie_01(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_02(struct bb_info *bb,
+static bool halbb_7_physts_ie_02(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -598,7 +598,7 @@ bool halbb_7_physts_ie_02(struct bb_info *bb,
 	
 	return true;
 }
-bool halbb_7_physts_ie_03(struct bb_info *bb,
+static bool halbb_7_physts_ie_03(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -628,7 +628,7 @@ bool halbb_7_physts_ie_03(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_04_07(struct bb_info *bb,
+static bool halbb_7_physts_ie_04_07(struct bb_info *bb,
 			   enum bb_physts_ie_t ie,
 			   u8 *addr,
 			   u16 ie_length,
@@ -676,7 +676,7 @@ bool halbb_7_physts_ie_04_07(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_08(struct bb_info *bb,
+static bool halbb_7_physts_ie_08(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -809,7 +809,7 @@ bool halbb_7_physts_ie_08(struct bb_info *bb,
 	return true;
 }
 
-void halbb_7_physts_ie_09_lgcy(struct bb_info *bb,
+static void halbb_7_physts_ie_09_lgcy(struct bb_info *bb,
 			   u8 *addr,
 			   u8 rate_mode,
 			   struct physts_rxd *desc)
@@ -823,7 +823,7 @@ void halbb_7_physts_ie_09_lgcy(struct bb_info *bb,
 	psts_9->l_sig = (ie_9->l_sig_m << 11) | (ie_9->l_sig_lm << 3) | (ie_9->l_sig_l);
 }
 
-void halbb_7_physts_ie_09_vht(struct bb_info *bb,
+static void halbb_7_physts_ie_09_vht(struct bb_info *bb,
 			   u8 *addr,
 			   u8 rate_mode,
 			   struct physts_rxd *desc)
@@ -839,7 +839,7 @@ void halbb_7_physts_ie_09_vht(struct bb_info *bb,
 	psts_9->sig_a2 = (ie_9->sig_a2_m << 2) | (ie_9->sig_a2_l);
 }
 
-void halbb_7_physts_ie_09_he(struct bb_info *bb,
+static void halbb_7_physts_ie_09_he(struct bb_info *bb,
 			   u8 *addr,
 			   u8 rate_mode,
 			   struct physts_rxd *desc)
@@ -867,7 +867,7 @@ void halbb_7_physts_ie_09_he(struct bb_info *bb,
 #endif
 }
 
-bool halbb_7_physts_ie_09(struct bb_info *bb,
+static bool halbb_7_physts_ie_09(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -889,7 +889,7 @@ bool halbb_7_physts_ie_09(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_10(struct bb_info *bb,
+static bool halbb_7_physts_ie_10(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -911,7 +911,7 @@ bool halbb_7_physts_ie_10(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_11(struct bb_info *bb,
+static bool halbb_7_physts_ie_11(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -933,7 +933,7 @@ bool halbb_7_physts_ie_11(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_12(struct bb_info *bb,
+static bool halbb_7_physts_ie_12(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -985,7 +985,7 @@ bool halbb_7_physts_ie_12(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_13(struct bb_info *bb,
+static bool halbb_7_physts_ie_13(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1050,7 +1050,7 @@ bool halbb_7_physts_ie_13(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_14(struct bb_info *bb,
+static bool halbb_7_physts_ie_14(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1101,7 +1101,7 @@ bool halbb_7_physts_ie_14(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_15(struct bb_info *bb,
+static bool halbb_7_physts_ie_15(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1157,7 +1157,7 @@ bool halbb_7_physts_ie_15(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_17(struct bb_info *bb,
+static bool halbb_7_physts_ie_17(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1216,7 +1216,7 @@ bool halbb_7_physts_ie_17(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_18(struct bb_info *bb,
+static bool halbb_7_physts_ie_18(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1243,7 +1243,7 @@ bool halbb_7_physts_ie_18(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_19(struct bb_info *bb,
+static bool halbb_7_physts_ie_19(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1278,7 +1278,7 @@ bool halbb_7_physts_ie_19(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_20(struct bb_info *bb,
+static bool halbb_7_physts_ie_20(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1368,7 +1368,7 @@ bool halbb_7_physts_ie_20(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_21(struct bb_info *bb,
+static bool halbb_7_physts_ie_21(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1458,7 +1458,7 @@ bool halbb_7_physts_ie_21(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_22(struct bb_info *bb,
+static bool halbb_7_physts_ie_22(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1482,7 +1482,7 @@ bool halbb_7_physts_ie_22(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_24(struct bb_info *bb,
+static bool halbb_7_physts_ie_24(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1529,7 +1529,7 @@ bool halbb_7_physts_ie_24(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_25(struct bb_info *bb,
+static bool halbb_7_physts_ie_25(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1573,7 +1573,7 @@ bool halbb_7_physts_ie_25(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_26(struct bb_info *bb,
+static bool halbb_7_physts_ie_26(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1586,7 +1586,7 @@ bool halbb_7_physts_ie_26(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_27(struct bb_info *bb,
+static bool halbb_7_physts_ie_27(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1599,7 +1599,7 @@ bool halbb_7_physts_ie_27(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_28(struct bb_info *bb,
+static bool halbb_7_physts_ie_28(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1646,7 +1646,7 @@ bool halbb_7_physts_ie_28(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_29(struct bb_info *bb,
+static bool halbb_7_physts_ie_29(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1693,7 +1693,7 @@ bool halbb_7_physts_ie_29(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_30(struct bb_info *bb,
+static bool halbb_7_physts_ie_30(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1706,7 +1706,7 @@ bool halbb_7_physts_ie_30(struct bb_info *bb,
 	return true;
 }
 
-bool halbb_7_physts_ie_31(struct bb_info *bb,
+static bool halbb_7_physts_ie_31(struct bb_info *bb,
 			   u8 *addr,
 			   u16 ie_length,
 			   struct physts_rxd *desc)
@@ -1719,7 +1719,7 @@ bool halbb_7_physts_ie_31(struct bb_info *bb,
 	return true;
 }
 
-void halbb_7_physts_print(struct bb_info *bb, struct physts_rxd *desc,
+static void halbb_7_physts_print(struct bb_info *bb, struct physts_rxd *desc,
 			u16 total_len, u8 *addr, u32 physts_bitmap)
 {
 	struct bb_physts_info	*physts = &bb->bb_physts_i;

--- a/phl/hal_g6/phy/bb/halbb_plcp_gen.c
+++ b/phl/hal_g6/phy/bb/halbb_plcp_gen.c
@@ -68,7 +68,7 @@ u32 halbb_max(u32 val_1, u32 val_2)
 	u32 out = val_1 < val_2 ? val_2 : val_1;
 	return out;
 }
-enum spec_list halbb_format2spec(enum packet_format_t in, bool *valid)
+static enum spec_list halbb_format2spec(enum packet_format_t in, bool *valid)
 {
 	enum spec_list spec = SPEC_B_MODE;
 
@@ -109,7 +109,7 @@ enum spec_list halbb_format2spec(enum packet_format_t in, bool *valid)
 	return spec;
 }
 
-void halbb_find_apep(u32 *apep, bool *can_find, u32 *n_mpdu, u32 *mpdu_length, u8 spec_idx)
+static void halbb_find_apep(u32 *apep, bool *can_find, u32 *n_mpdu, u32 *mpdu_length, u8 spec_idx)
 {
 	u32 apep_tmp;
 	bool is_match;
@@ -149,7 +149,7 @@ void halbb_find_apep(u32 *apep, bool *can_find, u32 *n_mpdu, u32 *mpdu_length, u
 }
 
 
-void halbb_com_par_cal(struct bb_info *bb, u16 n_sd, enum coding_rate_t code_rate, u8 n_bpscs, u8 nss, bool dcm, struct plcp_mcs_table_out_t *out)
+static void halbb_com_par_cal(struct bb_info *bb, u16 n_sd, enum coding_rate_t code_rate, u8 n_bpscs, u8 nss, bool dcm, struct plcp_mcs_table_out_t *out)
 {
 	if (dcm)
 		out->n_cbps = (n_sd * nss * n_bpscs) >> 1;
@@ -174,7 +174,7 @@ void halbb_com_par_cal(struct bb_info *bb, u16 n_sd, enum coding_rate_t code_rat
 	}
 }
 
-bool ldpc_extra_check(u32 n_avbits, u32 n_pld, u8 code_rate)
+static bool ldpc_extra_check(u32 n_avbits, u32 n_pld, u8 code_rate)
 {
 	bool cnd0, cnd1, cnd2;
 	u32 n_cw = 0, l_ldpc = 0, l_ldpc_idx = 0;
@@ -229,7 +229,7 @@ bool ldpc_extra_check(u32 n_avbits, u32 n_pld, u8 code_rate)
 	return (cnd0 && cnd1) || cnd2;
 }
 
-bool halbb_legacy_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in_t *in, struct plcp_mcs_table_out_t *out)
+static bool halbb_legacy_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in_t *in, struct plcp_mcs_table_out_t *out)
 {
 	u16 n_dbps_table[8] = {24, 36, 48, 72, 96, 144, 192, 216}; // int size
 	u16 n_cbps_table[8] = {48, 48, 96, 96, 192, 192, 288, 288};
@@ -259,7 +259,7 @@ bool halbb_legacy_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in_t
 	return true;
 }
 
-bool halbb_ht_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in_t *in, struct plcp_mcs_table_out_t *out)
+static bool halbb_ht_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in_t *in, struct plcp_mcs_table_out_t *out)
 {
 
 	u8 nss, mcs;
@@ -299,7 +299,7 @@ bool halbb_ht_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in_t *in
 	return true;
 }
 
-bool halbb_vht_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in_t *in, struct plcp_mcs_table_out_t *out){
+static bool halbb_vht_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in_t *in, struct plcp_mcs_table_out_t *out){
 	u16 n_sd_table[4] = {52, 108, 234, 468};
 	enum coding_rate_t code_rate_table[12] = {R12, R12, R34, R12, R34, R23,
 						  R34, R56, R34, R56, R34, R56};
@@ -375,7 +375,7 @@ bool halbb_vht_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in_t *i
 	return true;
 }
 
-bool halbb_he_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in_t *in, struct plcp_mcs_table_out_t *out)
+static bool halbb_he_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in_t *in, struct plcp_mcs_table_out_t *out)
 {
 	struct plcp_mcs_table_out_t out_temp;
 	u16 n_sd_table[8] = {24, 48, 102, 234, 468, 980, 1960, 52};
@@ -404,7 +404,7 @@ bool halbb_he_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in_t *in
 	return true;
 }
 
-bool halbb_eht_mcs_table(struct bb_info* bb, const struct plcp_mcs_table_in_t* in, struct plcp_mcs_table_out_t* out)
+static bool halbb_eht_mcs_table(struct bb_info* bb, const struct plcp_mcs_table_in_t* in, struct plcp_mcs_table_out_t* out)
 {
 	struct plcp_mcs_table_out_t out_temp;
 	u16 n_sd_table[17] = { 24, 48, 102, 234, 468, 980, 1960, 52 ,3920, 72, 126, 702, 1448, 1682, 2482, 2940, 3408 };
@@ -440,7 +440,7 @@ bool halbb_eht_mcs_table(struct bb_info* bb, const struct plcp_mcs_table_in_t* i
 	return true;
 }
 
-enum plcp_sts halbb_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in_t *in, struct plcp_mcs_table_out_t *out)
+static enum plcp_sts halbb_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in_t *in, struct plcp_mcs_table_out_t *out)
 {
 	switch ((enum spec_list)(in->spec_idx)) {
 		case SPEC_LEGACY:
@@ -473,7 +473,7 @@ enum plcp_sts halbb_mcs_table(struct bb_info *bb, const struct plcp_mcs_table_in
 }
 
 
-void halbb_get_mcs_out(struct bb_info *bb, const struct plcp_tx_pre_fec_padding_setting_in_t *in, struct plcp_tx_pre_fec_padding_setting_par_t *par, struct plcp_tx_pre_fec_padding_setting_out_t *out, bool *valid){
+static void halbb_get_mcs_out(struct bb_info *bb, const struct plcp_tx_pre_fec_padding_setting_in_t *in, struct plcp_tx_pre_fec_padding_setting_par_t *par, struct plcp_tx_pre_fec_padding_setting_out_t *out, bool *valid){
 	
 	bool mu_usr_en[14] = { false,false,false,false,false,false,false,true,true,false,true,true,false,true };
 	struct plcp_mcs_table_in_t mcs_in;
@@ -536,7 +536,7 @@ void halbb_get_mcs_out(struct bb_info *bb, const struct plcp_tx_pre_fec_padding_
 	}
 }
 
-void halbb_get_nsym_init(struct bb_info *bb, const struct plcp_tx_pre_fec_padding_setting_in_t *in, struct plcp_tx_pre_fec_padding_setting_par_t *par)
+static void halbb_get_nsym_init(struct bb_info *bb, const struct plcp_tx_pre_fec_padding_setting_in_t *in, struct plcp_tx_pre_fec_padding_setting_par_t *par)
 {
 	u8 n_tail = 6;
 	u8 n_service = 16;
@@ -578,7 +578,7 @@ void halbb_get_nsym_init(struct bb_info *bb, const struct plcp_tx_pre_fec_paddin
 
 }
 
-void halbb_get_nsym(struct bb_info *bb, const struct plcp_tx_pre_fec_padding_setting_in_t *in, const struct plcp_tx_pre_fec_padding_setting_par_t *par, struct plcp_tx_pre_fec_padding_setting_out_t *out)
+static void halbb_get_nsym(struct bb_info *bb, const struct plcp_tx_pre_fec_padding_setting_in_t *in, const struct plcp_tx_pre_fec_padding_setting_par_t *par, struct plcp_tx_pre_fec_padding_setting_out_t *out)
 {
 	u8 n_service, n_tail;
 	u8 t_pe_table[4][4] = {{0, 2, 4, 5}, {0, 0, 1, 2}, {0, 0, 2, 3}, {0, 1, 3, 4}};
@@ -672,7 +672,7 @@ void halbb_get_nsym(struct bb_info *bb, const struct plcp_tx_pre_fec_padding_set
 		out->n_sym_ehtsig = par->com.n_hesigb_sym;
 }
 
-void halbb_get_txtime(struct bb_info *bb, const struct plcp_tx_pre_fec_padding_setting_in_t *in, struct plcp_tx_pre_fec_padding_setting_par_t *par, struct plcp_tx_pre_fec_padding_setting_out_t *out)
+static void halbb_get_txtime(struct bb_info *bb, const struct plcp_tx_pre_fec_padding_setting_in_t *in, struct plcp_tx_pre_fec_padding_setting_par_t *par, struct plcp_tx_pre_fec_padding_setting_out_t *out)
 {
 	struct bb_h2c_fw_tx_setting *fw_tx_i = &bb->bb_fwtx_h2c_i;
 	//n_ma, m_ma
@@ -716,7 +716,7 @@ void halbb_get_txtime(struct bb_info *bb, const struct plcp_tx_pre_fec_padding_s
 	out->gi = par->com.gi;
 }
 
-void halbb_refine_input(struct bb_info *bb, const struct plcp_tx_pre_fec_padding_setting_in_t *in, struct plcp_tx_pre_fec_padding_setting_par_t *par)
+static void halbb_refine_input(struct bb_info *bb, const struct plcp_tx_pre_fec_padding_setting_in_t *in, struct plcp_tx_pre_fec_padding_setting_par_t *par)
 {
 	bool can_find = false , disam;
 	u8 n_tail = 6;

--- a/phl/hal_g6/phy/bb/halbb_plcp_tx.c
+++ b/phl/hal_g6/phy/bb/halbb_plcp_tx.c
@@ -46,7 +46,7 @@ const u8 ru_alloc_b1_7_tbl[RU_SIZE_NUM][2] = {{0, 37}, //RU26
 					      {2, 0},  //RU996x3
 					      {2, 0}}; //RU996x3_484
 #endif
-u8 halbb_set_crc8(struct bb_info *bb, unsigned char in[], u8 len)
+static u8 halbb_set_crc8(struct bb_info *bb, unsigned char in[], u8 len)
 {
 	u16 i = 0;
 	u8 reg0 = 1;
@@ -77,7 +77,7 @@ u8 halbb_set_crc8(struct bb_info *bb, unsigned char in[], u8 len)
 
 }
 
-void halbb_ic_cfg(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_ic_cfg(struct bb_info *bb, struct halbb_plcp_info *in,
 		  struct bb_plcp_cr_info *cr, enum phl_phy_idx phy_idx)
 {
 	u16 i = 0;
@@ -515,7 +515,7 @@ u8 halbb_eht_sig_gi_ltf_tbl(struct bb_info *bb, u8 gi, u8 ltf)
 	return out;
 }
 #endif
-u32 halbb_cfg_ch20_with_data(struct bb_info *bb, struct halbb_plcp_info *in)
+static u32 halbb_cfg_ch20_with_data(struct bb_info *bb, struct halbb_plcp_info *in)
 {
 	u32 ch20_with_data = 0;
 #if 0 // BE_IC_TYPE
@@ -990,7 +990,7 @@ u32 halbb_ru_size_id_2_ru_alloc(struct bb_info *bb, u8 ru_id, u8 ru_size, u8 pri
 	return ru_alloc;
 }
 #endif
-void halbb_he_sigb(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_he_sigb(struct bb_info *bb, struct halbb_plcp_info *in,
 		   struct plcp_tx_pre_fec_padding_setting_in_t *in_plcp,
 		   enum phl_phy_idx phy_idx)
 {
@@ -1088,7 +1088,7 @@ void halbb_he_sigb(struct bb_info *bb, struct halbb_plcp_info *in,
 	}
 }
 
-bool halbb_ru_info_init(struct bb_info *bb, struct halbb_plcp_info *in,
+static bool halbb_ru_info_init(struct bb_info *bb, struct halbb_plcp_info *in,
 			struct plcp_tx_pre_fec_padding_setting_in_t *in_plcp,
 			struct plcp_tx_pre_fec_padding_setting_out_t *out,
 			enum phl_phy_idx phy_idx)
@@ -1164,7 +1164,7 @@ bool halbb_ru_info_init(struct bb_info *bb, struct halbb_plcp_info *in,
 	return invalid_chk;
 }
 
-void halbb_plcp_gen_init(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_plcp_gen_init(struct bb_info *bb, struct halbb_plcp_info *in,
 			 struct plcp_tx_pre_fec_padding_setting_in_t *in_plcp)
 {
 	u32 i = 0;
@@ -1234,7 +1234,7 @@ void halbb_plcp_gen_init(struct bb_info *bb, struct halbb_plcp_info *in,
 	}
 }
 
-void halbb_plcp_lsig(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_plcp_lsig(struct bb_info *bb, struct halbb_plcp_info *in,
 		     struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp,
 		     enum phl_phy_idx phy_idx)
 {
@@ -1292,7 +1292,7 @@ void halbb_plcp_lsig(struct bb_info *bb, struct halbb_plcp_info *in,
 	halbb_set_reg_cmn(bb, cr->lsig, cr->lsig_m, lsig, phy_idx);
 }
 
-void halbb_plcp_siga(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_plcp_siga(struct bb_info *bb, struct halbb_plcp_info *in,
 		     struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp,
 	     	     enum phl_phy_idx phy_idx)
 {
@@ -1576,7 +1576,7 @@ void halbb_plcp_siga(struct bb_info *bb, struct halbb_plcp_info *in,
 }
 
 
-void halbb_cfg_txinfo(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_cfg_txinfo(struct bb_info *bb, struct halbb_plcp_info *in,
 		      struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp,
 	     	      enum phl_phy_idx phy_idx)
 {
@@ -1663,7 +1663,7 @@ void halbb_cfg_txinfo(struct bb_info *bb, struct halbb_plcp_info *in,
 	}
 }
 
-void halbb_cfg_txctrl(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_cfg_txctrl(struct bb_info *bb, struct halbb_plcp_info *in,
 		      struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp,
 	     	      enum phl_phy_idx phy_idx)//Add random value
 {
@@ -1862,7 +1862,7 @@ void halbb_cfg_txctrl(struct bb_info *bb, struct halbb_plcp_info *in,
 	halbb_set_reg_cmn(bb, cr->n_sym, cr->n_sym_m, out_plcp->n_sym, phy_idx);
 }
 
-void halbb_plcp_delimiter(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_plcp_delimiter(struct bb_info *bb, struct halbb_plcp_info *in,
 			  struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp,
 	     		  enum phl_phy_idx phy_idx) //Add random value
 {
@@ -1937,7 +1937,7 @@ void halbb_plcp_delimiter(struct bb_info *bb, struct halbb_plcp_info *in,
 	}
 }
 
-void halbb_cfg_cck(struct bb_info *bb, struct halbb_plcp_info *in, enum phl_phy_idx phy_idx)
+static void halbb_cfg_cck(struct bb_info *bb, struct halbb_plcp_info *in, enum phl_phy_idx phy_idx)
 {
 	struct bb_plcp_cr_info *cr = &bb->bb_plcp_i.bb_plcp_cr_i;
 
@@ -1979,7 +1979,7 @@ void halbb_cfg_cck(struct bb_info *bb, struct halbb_plcp_info *in, enum phl_phy_
 	halbb_set_reg(bb, cr->b_carrier_suppress_tx, cr->b_carrier_suppress_tx_m, 0);
 }
 
-void halbb_vht_sigb(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_vht_sigb(struct bb_info *bb, struct halbb_plcp_info *in,
 		    struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp,
 	     	    enum phl_phy_idx phy_idx)
 {
@@ -2045,7 +2045,7 @@ void halbb_vht_sigb(struct bb_info *bb, struct halbb_plcp_info *in,
 	halbb_set_reg_cmn(bb, vht_sigb_cr[0], vht_sigb_cr_m[0], vht_sigb, phy_idx);
 }
 
-void halbb_service(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_service(struct bb_info *bb, struct halbb_plcp_info *in,
 	     	   enum phl_phy_idx phy_idx)
 {
 	u8 i = 0;

--- a/phl/hal_g6/phy/bb/halbb_plcp_tx_7.c
+++ b/phl/hal_g6/phy/bb/halbb_plcp_tx_7.c
@@ -46,7 +46,7 @@ const u8 ru_alloc_b1_7_tbl_7[RU_SIZE_NUM][2] = {{0, 37}, //RU26
 					      {2, 0},  //RU996x3
 					      {2, 0}}; //RU996x3_484
 
-u8 halbb_set_crc8_7(struct bb_info *bb, unsigned char in[], u8 len)
+static u8 halbb_set_crc8_7(struct bb_info *bb, unsigned char in[], u8 len)
 {
 	u16 i = 0;
 	u8 reg0 = 1;
@@ -77,7 +77,7 @@ u8 halbb_set_crc8_7(struct bb_info *bb, unsigned char in[], u8 len)
 
 }
 
-void halbb_ppdu_var_type_cfg_7(struct bb_info *bb_0, struct halbb_plcp_info *in,
+static void halbb_ppdu_var_type_cfg_7(struct bb_info *bb_0, struct halbb_plcp_info *in,
 			     enum phl_phy_idx phy_idx)
 {
 	struct bb_info *bb = bb_0;
@@ -144,7 +144,7 @@ void halbb_ppdu_var_type_cfg_7(struct bb_info *bb_0, struct halbb_plcp_info *in,
 	halbb_set_reg_cmn(bb, cr->ppdu_var, cr->ppdu_var_m, ppdu_var, phy_idx);
 }
 
-void halbb_cfg_max_mcs_7(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_cfg_max_mcs_7(struct bb_info *bb, struct halbb_plcp_info *in,
 			 enum phl_phy_idx phy_idx)
 {
 	u8 i = 0;
@@ -162,7 +162,7 @@ void halbb_cfg_max_mcs_7(struct bb_info *bb, struct halbb_plcp_info *in,
 	halbb_set_reg_cmn(bb, cr->max_mcs, cr->max_mcs_m, max_mcs, phy_idx);
 }
 
-u32 halbb_ru_occupied_sub20_he_7(struct bb_info *bb, struct halbb_plcp_info *in)
+static u32 halbb_ru_occupied_sub20_he_7(struct bb_info *bb, struct halbb_plcp_info *in)
 {
 	u32 out = 0;
 
@@ -289,7 +289,7 @@ u32 halbb_ru_occupied_sub20_he_7(struct bb_info *bb, struct halbb_plcp_info *in)
 	return out;
 }
 
-u32 halbb_ru_occupied_sub20_eht_7(struct bb_info *bb, struct halbb_plcp_info *in)
+static u32 halbb_ru_occupied_sub20_eht_7(struct bb_info *bb, struct halbb_plcp_info *in)
 {
 	u32 output = 0;
 	u8 ch20_with_data_dbw80 = 0, ch20_with_data_dbw160 = 0, nsub_80 = 4, mru_idx = 0, n_x1_flag = 0, n_x1 = 0;
@@ -402,7 +402,7 @@ u32 halbb_ru_occupied_sub20_eht_7(struct bb_info *bb, struct halbb_plcp_info *in
 	return output;
 }
 
-u8 halbb_eht_sig_gi_ltf_tbl_7(struct bb_info *bb, u8 gi, u8 ltf)
+static u8 halbb_eht_sig_gi_ltf_tbl_7(struct bb_info *bb, u8 gi, u8 ltf)
 {
 	u8 out = 0xff;
 
@@ -422,7 +422,7 @@ u8 halbb_eht_sig_gi_ltf_tbl_7(struct bb_info *bb, u8 gi, u8 ltf)
 	return out;
 }
 
-u32 halbb_cfg_ch20_with_data_7(struct bb_info *bb, struct halbb_plcp_info *in)
+static u32 halbb_cfg_ch20_with_data_7(struct bb_info *bb, struct halbb_plcp_info *in)
 {
 	u32 ch20_with_data = 0;
 
@@ -455,7 +455,7 @@ u32 halbb_cfg_ch20_with_data_7(struct bb_info *bb, struct halbb_plcp_info *in)
 	return ch20_with_data;
 }
 
-void halbb_ppdu_type_comp_mode_trans_7(struct bb_info *bb, bool ul_dl_flag,
+static void halbb_ppdu_type_comp_mode_trans_7(struct bb_info *bb, bool ul_dl_flag,
 				     enum packet_format_t ppdu_type,
 				     struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp)
 {
@@ -465,7 +465,7 @@ void halbb_ppdu_type_comp_mode_trans_7(struct bb_info *bb, bool ul_dl_flag,
 		out_plcp->ppdu_type_comp_mode = ppdu_type == EHT_TB_FMT ? 0 : 1;
 }
 
-bool halbb_punc_ch_info_2_ru_size_idx_7(struct bb_info *bb, u8 user_idx, enum plcp_dbw dbw,
+static bool halbb_punc_ch_info_2_ru_size_idx_7(struct bb_info *bb, u8 user_idx, enum plcp_dbw dbw,
 				      u8 ppdu_type_comp_mode, u8 punc_pattern,
 				      struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp)
 {
@@ -571,7 +571,7 @@ bool halbb_punc_ch_info_2_ru_size_idx_7(struct bb_info *bb, u8 user_idx, enum pl
 	return pattern_chk;
 }
 
-u32 halbb_ru_size_id_2_ru_alloc_7(struct bb_info *bb, u8 ru_id, u8 ru_size, u8 prim_sb, enum plcp_dbw dbw)
+static u32 halbb_ru_size_id_2_ru_alloc_7(struct bb_info *bb, u8 ru_id, u8 ru_size, u8 prim_sb, enum plcp_dbw dbw)
 {
 	u32 ru_alloc = 0;
 //	out_plcp->usr[0].ru_idx = 1;
@@ -775,7 +775,7 @@ u32 halbb_ru_size_id_2_ru_alloc_7(struct bb_info *bb, u8 ru_id, u8 ru_size, u8 p
 	return ru_alloc;
 }
 
-void halbb_he_sigb_7(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_he_sigb_7(struct bb_info *bb, struct halbb_plcp_info *in,
 		   struct plcp_tx_pre_fec_padding_setting_in_t *in_plcp,
 		   struct plcp_tx_pre_fec_padding_setting_out_t *out,
 		   enum phl_phy_idx phy_idx)
@@ -896,7 +896,7 @@ void halbb_he_sigb_7(struct bb_info *bb, struct halbb_plcp_info *in,
 	}
 }
 
-void halbb_eht_sig_7(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_eht_sig_7(struct bb_info *bb, struct halbb_plcp_info *in,
 		   struct plcp_tx_pre_fec_padding_setting_in_t *in_plcp,
 		   struct plcp_tx_pre_fec_padding_setting_out_t *out,
 		   enum phl_phy_idx phy_idx)
@@ -1057,7 +1057,7 @@ void halbb_eht_sig_7(struct bb_info *bb, struct halbb_plcp_info *in,
 	}
 }
 
-bool halbb_ru_info_init_7(struct bb_info *bb, struct halbb_plcp_info *in,
+static bool halbb_ru_info_init_7(struct bb_info *bb, struct halbb_plcp_info *in,
 			struct plcp_tx_pre_fec_padding_setting_in_t *in_plcp,
 			struct plcp_tx_pre_fec_padding_setting_out_t *out,
 			enum phl_phy_idx phy_idx)
@@ -1083,7 +1083,7 @@ bool halbb_ru_info_init_7(struct bb_info *bb, struct halbb_plcp_info *in,
 	return true;
 }
 
-void halbb_plcp_gen_init_7(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_plcp_gen_init_7(struct bb_info *bb, struct halbb_plcp_info *in,
 			 struct plcp_tx_pre_fec_padding_setting_in_t *in_plcp)
 {
 	u32 i = 0;
@@ -1160,7 +1160,7 @@ void halbb_plcp_gen_init_7(struct bb_info *bb, struct halbb_plcp_info *in,
 	}
 }
 
-void halbb_plcp_lsig_7(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_plcp_lsig_7(struct bb_info *bb, struct halbb_plcp_info *in,
 		     struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp,
 		     enum phl_phy_idx phy_idx)
 {
@@ -1218,7 +1218,7 @@ void halbb_plcp_lsig_7(struct bb_info *bb, struct halbb_plcp_info *in,
 	halbb_set_reg_cmn(bb, cr->lsig, cr->lsig_m, lsig, phy_idx);
 }
 
-void halbb_plcp_siga_7(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_plcp_siga_7(struct bb_info *bb, struct halbb_plcp_info *in,
 		     struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp,
 	     	     enum phl_phy_idx phy_idx)
 {
@@ -1421,7 +1421,7 @@ void halbb_plcp_siga_7(struct bb_info *bb, struct halbb_plcp_info *in,
 	halbb_set_reg_cmn(bb, cr->siga2, cr->siga2_m, siga2, phy_idx);
 }
 
-void halbb_plcp_usig_7(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_plcp_usig_7(struct bb_info *bb, struct halbb_plcp_info *in,
 		     struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp,
 	     	     enum phl_phy_idx phy_idx)
 {
@@ -1529,7 +1529,7 @@ void halbb_plcp_usig_7(struct bb_info *bb, struct halbb_plcp_info *in,
 	halbb_set_reg_cmn(bb, cr->usig_1, cr->usig_1_m, usig2_val, phy_idx);
 }
 
-void halbb_cfg_txinfo_7(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_cfg_txinfo_7(struct bb_info *bb, struct halbb_plcp_info *in,
 		      struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp,
 	     	      enum phl_phy_idx phy_idx)
 {
@@ -1566,7 +1566,7 @@ void halbb_cfg_txinfo_7(struct bb_info *bb, struct halbb_plcp_info *in,
 		halbb_set_reg_cmn(bb, cr->n_usr, cr->n_usr_m, out_plcp->n_usr, phy_idx);
 }
 
-void halbb_cfg_txctrl_7(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_cfg_txctrl_7(struct bb_info *bb, struct halbb_plcp_info *in,
 		      struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp,
 	     	      enum phl_phy_idx phy_idx)//Add random value
 {
@@ -1763,7 +1763,7 @@ void halbb_cfg_txctrl_7(struct bb_info *bb, struct halbb_plcp_info *in,
 	halbb_set_reg_cmn(bb, cr->n_sym, cr->n_sym_m, out_plcp->n_sym, phy_idx);
 }
 
-void halbb_plcp_delimiter_7(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_plcp_delimiter_7(struct bb_info *bb, struct halbb_plcp_info *in,
 			  struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp,
 	     		  enum phl_phy_idx phy_idx) //Add random value
 {
@@ -1838,7 +1838,7 @@ void halbb_plcp_delimiter_7(struct bb_info *bb, struct halbb_plcp_info *in,
 	}
 }
 
-void halbb_cfg_cck_7(struct bb_info *bb, struct halbb_plcp_info *in, enum phl_phy_idx phy_idx)
+static void halbb_cfg_cck_7(struct bb_info *bb, struct halbb_plcp_info *in, enum phl_phy_idx phy_idx)
 {
 	struct bb_plcp_cr_info *cr = &bb->bb_plcp_i.bb_plcp_cr_i;
 
@@ -1852,7 +1852,7 @@ void halbb_cfg_cck_7(struct bb_info *bb, struct halbb_plcp_info *in, enum phl_ph
 	halbb_set_reg(bb, cr->b_carrier_suppress_tx, cr->b_carrier_suppress_tx_m, 0);
 }
 
-void halbb_vht_sigb_7(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_vht_sigb_7(struct bb_info *bb, struct halbb_plcp_info *in,
 		    struct plcp_tx_pre_fec_padding_setting_out_t *out_plcp,
 	     	    enum phl_phy_idx phy_idx)
 {
@@ -1918,7 +1918,7 @@ void halbb_vht_sigb_7(struct bb_info *bb, struct halbb_plcp_info *in,
 	halbb_set_reg_cmn(bb, vht_sigb_cr[0], vht_sigb_cr_m[0], vht_sigb, phy_idx);
 }
 
-void halbb_service_7(struct bb_info *bb, struct halbb_plcp_info *in,
+static void halbb_service_7(struct bb_info *bb, struct halbb_plcp_info *in,
 	     	   enum phl_phy_idx phy_idx)
 {
 	u8 i = 0;

--- a/phl/hal_g6/phy/bb/halbb_pwr_ctrl.c
+++ b/phl/hal_g6/phy/bb/halbb_pwr_ctrl.c
@@ -28,7 +28,7 @@
 
 /* @ Dynamic CCA TH part */
 
-void halbb_set_ccath_macid(struct bb_info *bb, u16 macid, s8 cca_th, bool cca_th_en,
+static void halbb_set_ccath_macid(struct bb_info *bb, u16 macid, s8 cca_th, bool cca_th_en,
 	enum phl_band_idx hw_band)
 {
 	u32 ret_v = 0;
@@ -54,7 +54,7 @@ void halbb_set_ccath_macid(struct bb_info *bb, u16 macid, s8 cca_th, bool cca_th
 		BB_WARNING("Error Set Pwr Macid for API return fail!!\n");
 }
 
-void halbb_ccath_init(struct bb_info *bb)
+static void halbb_ccath_init(struct bb_info *bb)
 {
 	u8 i;
 	struct bb_dyncca_info *dyncca_i = &bb->bb_dyncca_i;
@@ -69,7 +69,7 @@ void halbb_ccath_init(struct bb_info *bb)
 	}
 }
 
-void halbb_cca_th_per_sta(struct bb_info *bb, u16 macid)
+static void halbb_cca_th_per_sta(struct bb_info *bb, u16 macid)
 {
 	bool noisy_state = bb->is_noisy;
 	struct bb_dyncca_info *dyncca_i = &bb->bb_dyncca_i;
@@ -101,7 +101,7 @@ void halbb_cca_th_per_sta(struct bb_info *bb, u16 macid)
 	dyn_ccath = (s8)rssi - 110 - offset; 
 }
 
-void halbb_dyncca_th(struct bb_info *bb)
+static void halbb_dyncca_th(struct bb_info *bb)
 {
 	struct bb_dyncca_info *dyncca_i = &bb->bb_dyncca_i;
 	u8 i;
@@ -123,7 +123,7 @@ void halbb_dyncca_th(struct bb_info *bb)
 }
 
 /* @ Power Ctrl part */
-s8 halbb_get_pwr_macid_idx(struct bb_info *bb, u16 macid, u8 idx)
+static s8 halbb_get_pwr_macid_idx(struct bb_info *bb, u16 macid, u8 idx)
 {
 	s8 tx_pwr = 0;
 	struct bb_dtp_info *dtp = &bb->bb_pwr_ctrl_i.dtp_i[macid];
@@ -137,7 +137,7 @@ s8 halbb_get_pwr_macid_idx(struct bb_info *bb, u16 macid, u8 idx)
 	return tx_pwr; /* S(8,1)*/
 }
 
-bool halbb_get_pwr_macid_en_idx(struct bb_info *bb, u16 macid, u8 idx)
+static bool halbb_get_pwr_macid_en_idx(struct bb_info *bb, u16 macid, u8 idx)
 {
 	bool pwr_en = false;
 	struct bb_dtp_info *dtp = &bb->bb_pwr_ctrl_i.dtp_i[macid];
@@ -183,7 +183,7 @@ void halbb_set_pwr_macid_idx(struct bb_info *bb, u16 macid, s8 pwr, bool pwr_en,
 		BB_WARNING("Error Set Pwr Macid for API return fail!!\n");
 }
 
-void halbb_pwr_ctrl_en(struct bb_info *bb, bool pwr_ctrl_en)
+static void halbb_pwr_ctrl_en(struct bb_info *bb, bool pwr_ctrl_en)
 {
 	u32 ret_v = 0;
 	u32 mask_en = 0;
@@ -242,7 +242,7 @@ void halbb_pwr_ctrl_en(struct bb_info *bb, bool pwr_ctrl_en)
 	if (ret_v != 0)
 		BB_WARNING("Error Enable Power Control for API return fail!!\n");
 }
-void halbb_pwr_ctrl_th(struct bb_info *bb)
+static void halbb_pwr_ctrl_th(struct bb_info *bb)
 {
 	bool noisy_state = bb->is_noisy;
 	struct bb_pwr_ctrl_info *pwr_ctrl_i = &bb->bb_pwr_ctrl_i;
@@ -268,7 +268,7 @@ void halbb_pwr_ctrl_th(struct bb_info *bb)
 		  pwr_ctrl_i->enhance_pwr_th[2]);
 }
 
-u8 halbb_pwr_lvl_check(struct bb_info *bb, u8 rssi_in, u8 last_pwr_lvl)
+static u8 halbb_pwr_lvl_check(struct bb_info *bb, u8 rssi_in, u8 last_pwr_lvl)
 {
 	u8 i;
 	u8 th[HALBB_PWR_STATE_NUM];
@@ -306,7 +306,7 @@ u8 halbb_pwr_lvl_check(struct bb_info *bb, u8 rssi_in, u8 last_pwr_lvl)
 		return TX_HP_LV_UNCHANGE;
 }
 
-void halbb_set_pwr_ctrl(struct bb_info *bb, u16 macid, u8 pwr_lv)
+static void halbb_set_pwr_ctrl(struct bb_info *bb, u16 macid, u8 pwr_lv)
 {
 	struct rtw_phl_stainfo_t *sta;
 	s8 pwr = 0;
@@ -347,7 +347,7 @@ void halbb_set_pwr_ctrl(struct bb_info *bb, u16 macid, u8 pwr_lv)
 	/* only use pwr_tbl_0 */
 }
 
-void halbb_pwr_ctrl_per_sta(struct bb_info *bb, u16 macid)
+static void halbb_pwr_ctrl_per_sta(struct bb_info *bb, u16 macid)
 {
 	struct rtw_phl_stainfo_t *sta;
 	struct bb_dtp_info *dtp = &bb->bb_pwr_ctrl_i.dtp_i[macid];
@@ -418,7 +418,7 @@ void halbb_pwr_ctrl(struct bb_info *bb)
 	halbb_fwofld_bitmap_en(bb, false, FW_OFLD_BB_API);
 	#endif
 }
-void halbb_pwr_ctrl_para_init(struct bb_info *bb)
+static void halbb_pwr_ctrl_para_init(struct bb_info *bb)
 {
 	struct bb_pwr_ctrl_info *pwr_ctrl_i = &bb->bb_pwr_ctrl_i;
 
@@ -927,7 +927,7 @@ void halbb_tssi_ctrl_set_fast_mode_cfg(struct bb_info *bb,
 	}
 }
 
-void halbb_set_tx_src(struct bb_info *bb, u8 option, s8 pw_val, enum phl_phy_idx phy_idx) {
+static void halbb_set_tx_src(struct bb_info *bb, u8 option, s8 pw_val, enum phl_phy_idx phy_idx) {
 
 	BB_DBG(bb, DBG_PWR_CTRL, "[%s] %d", __func__, phy_idx);
 

--- a/phl/hal_g6/phy/bb/halbb_ra.c
+++ b/phl/hal_g6/phy/bb/halbb_ra.c
@@ -83,7 +83,7 @@ u8 halbb_legacy_rate_2_spec_rate(struct bb_info *bb, u16 rate)
 	return legacy_spec_rate_t[rate_idx];
 }
 
-u64 halbb_mgnt_2_rate_mask(u8 rate)
+static u64 halbb_mgnt_2_rate_mask(u8 rate)
 {
 	u64 ret = 0;
 
@@ -139,7 +139,7 @@ u64 halbb_mgnt_2_rate_mask(u8 rate)
 	return ret;
 }
 
-u8 halbb_mcs_ss_to_fw_rate_idx(u8 mode, u8 mcs, u8 ss)
+static u8 halbb_mcs_ss_to_fw_rate_idx(u8 mode, u8 mcs, u8 ss)
 {
 	u8 fw_rate_idx = 0;
 
@@ -328,7 +328,7 @@ u8 halbb_rate_to_num_ss(struct bb_info *bb, u16 rate)
 	return num_ss;
 }
 
-u8 halbb_ss_mcs_2_mcs_ss_idx(struct bb_info *bb, enum bb_mode_type mode, u8 ss, u8 mcs_idx)
+static u8 halbb_ss_mcs_2_mcs_ss_idx(struct bb_info *bb, enum bb_mode_type mode, u8 ss, u8 mcs_idx)
 {
 	u8 mcs_ss_idx = 0;
 
@@ -524,7 +524,7 @@ u8 halbb_rate_order_compute(struct bb_info *bb, u16 rate_idx)
 	return (u8)rate_order;
 }
 
-u8 halbb_init_ra_by_rssi(struct bb_info *bb, u8 rssi_assoc)
+static u8 halbb_init_ra_by_rssi(struct bb_info *bb, u8 rssi_assoc)
 {
 	u8 init_ra_lv = 0;
 
@@ -540,7 +540,7 @@ u8 halbb_init_ra_by_rssi(struct bb_info *bb, u8 rssi_assoc)
 	return init_ra_lv;
 }
 
-bool halbb_set_csi_rate(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
+static bool halbb_set_csi_rate(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
 {
 	u8 macid;
 	union bb_h2c_ra_cmn_info *ra_cmn;
@@ -580,7 +580,7 @@ bool halbb_set_csi_rate(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
 	return true;
 }
 
-u8 halbb_rssi_lv_dec(struct bb_info *bb, u8 rssi, u8 ratr_state)
+static u8 halbb_rssi_lv_dec(struct bb_info *bb, u8 rssi, u8 ratr_state)
 {
 	/*@MCS0 ~ MCS4 , VHT1SS MCS0 ~ MCS4 , G 6M~24M*/
 	/*u8 rssi_lv_t[RA_FLOOR_TABLE_SIZE] = {20, 34, 38, 42, 46, 50, 100};*/
@@ -610,7 +610,7 @@ u8 halbb_rssi_lv_dec(struct bb_info *bb, u8 rssi, u8 ratr_state)
 	return new_rssi_lv;
 }
 
-u64 halbb_ramask_by_rssi(struct bb_info *bb, u8 rssi_lv, u64 ramask)
+static u64 halbb_ramask_by_rssi(struct bb_info *bb, u8 rssi_lv, u64 ramask)
 {
 	u64 ra_mask_bitmap = ramask;
 
@@ -644,7 +644,7 @@ u64 halbb_ramask_by_rssi(struct bb_info *bb, u8 rssi_lv, u64 ramask)
 	return ra_mask_bitmap;
 }
 
-u64 halbb_ramask_mod(struct bb_info *bb, u8 macid, u64 ramask, u8 rssi, u8 mode,
+static u64 halbb_ramask_mod(struct bb_info *bb, u8 macid, u64 ramask, u8 rssi, u8 mode,
 	u8 nss, u64 *ramask_h)
 {
 	struct bb_ra_info *bb_ra = &bb->bb_cmn_hooker->bb_ra_i[macid];
@@ -807,7 +807,7 @@ u64 halbb_ramask_mod(struct bb_info *bb, u8 macid, u64 ramask, u8 rssi, u8 mode,
 	return mod_mask_rssi;
 }
 
-void rtw_halbb_mudbg(struct bb_info *bb, u8 type, u8 mu_entry, u8 macid, 
+static void rtw_halbb_mudbg(struct bb_info *bb, u8 type, u8 mu_entry, u8 macid, 
 			   bool en_256q, bool en_1024q)
 {
 	struct bb_h2c_mu_cfg mucfg = {0};
@@ -820,7 +820,7 @@ void rtw_halbb_mudbg(struct bb_info *bb, u8 type, u8 mu_entry, u8 macid,
 	halbb_fill_h2c_cmd(bb, cmdlen, RA_H2C_MUCFG, HALBB_H2C_RA, bb_h2c);
 }
 
-u64 halbb_gen_abg_mask(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
+static u64 halbb_gen_abg_mask(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
 {
 	u64 abg_mask = 0;
 	u8 i;
@@ -850,7 +850,7 @@ u64 halbb_gen_abg_mask(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
 	return abg_mask;
 }
 
-u64 halbb_gen_vht_mask(struct bb_info *bb,
+static u64 halbb_gen_vht_mask(struct bb_info *bb,
 				struct rtw_phl_stainfo_t *phl_sta_i)
 {
 	u8 vht_cap[2] = {0};
@@ -888,7 +888,7 @@ u64 halbb_gen_vht_mask(struct bb_info *bb,
 	return tmp_mask_nss;
 }
 
-u64 halbb_gen_ht_mask(struct bb_info *bb,
+static u64 halbb_gen_ht_mask(struct bb_info *bb,
 				struct rtw_phl_stainfo_t *phl_sta_i)
 {
 	u8 ht_cap[4] = {0};
@@ -913,7 +913,7 @@ u64 halbb_gen_ht_mask(struct bb_info *bb,
 	return tmp_mask_nss;
 }
 
-u64 halbb_gen_he_mask(struct bb_info *bb,
+static u64 halbb_gen_he_mask(struct bb_info *bb,
 				struct rtw_phl_stainfo_t *phl_sta_i, enum channel_width bw)
 {
 	u8 he_cap[2] = {0};
@@ -1052,7 +1052,7 @@ bool halbb_is_ht_rate_wifi7(struct bb_info *bb, u16 rate)
 
 #endif
 
-bool halbb_chk_bw_under_20(struct bb_info *bb, u8 bw)
+static bool halbb_chk_bw_under_20(struct bb_info *bb, u8 bw)
 {
 	bool ret_val = true;
 
@@ -1075,7 +1075,7 @@ bool halbb_chk_bw_under_20(struct bb_info *bb, u8 bw)
 	return ret_val;
 }
 
-bool halbb_chk_bw_under_40(struct bb_info *bb, u8 bw)
+static bool halbb_chk_bw_under_40(struct bb_info *bb, u8 bw)
 {
 	bool ret_val = true;
 
@@ -1098,7 +1098,7 @@ bool halbb_chk_bw_under_40(struct bb_info *bb, u8 bw)
 	return ret_val;
 }
 
-bool halbb_hw_bw_mode_chk(struct bb_info *bb, u8 bw, u8 hw_mode)
+static bool halbb_hw_bw_mode_chk(struct bb_info *bb, u8 bw, u8 hw_mode)
 {
 	bool ret_val = true;
 
@@ -1133,7 +1133,7 @@ bool halbb_hw_bw_mode_chk(struct bb_info *bb, u8 bw, u8 hw_mode)
 	return ret_val;
 }
 
-u8 halbb_hw_bw_mapping(struct bb_info *bb, u8 bw, u8 hw_mode)
+static u8 halbb_hw_bw_mapping(struct bb_info *bb, u8 bw, u8 hw_mode)
 {
 	u8 hw_bw_map = CHANNEL_WIDTH_20;
 	bool ret_val;
@@ -1152,7 +1152,7 @@ u8 halbb_hw_bw_mapping(struct bb_info *bb, u8 bw, u8 hw_mode)
 	return hw_bw_map;
 }
 
-u8 halbb_hw_mode_mapping(struct bb_info *bb, u8 wifi_mode)
+static u8 halbb_hw_mode_mapping(struct bb_info *bb, u8 wifi_mode)
 {
 	u8 hw_mode_map = 0;
 	/* Driver wifi mode mapping */
@@ -1183,7 +1183,7 @@ u8 halbb_hw_mode_mapping(struct bb_info *bb, u8 wifi_mode)
 	return hw_mode_map;
 }
 
-bool halbb_ac_n_sgi_chk(struct bb_info *bb, u8 hw_mode, bool en_sgi)
+static bool halbb_ac_n_sgi_chk(struct bb_info *bb, u8 hw_mode, bool en_sgi)
 {
 	bool sgi_chk = en_sgi;
 
@@ -1195,7 +1195,7 @@ bool halbb_ac_n_sgi_chk(struct bb_info *bb, u8 hw_mode, bool en_sgi)
 	return sgi_chk;
 }
 
-u8 halbb_ax_giltf_chk(struct bb_info *bb, u8 hw_mode, u8 giltf_cap)
+static u8 halbb_ax_giltf_chk(struct bb_info *bb, u8 hw_mode, u8 giltf_cap)
 {
 	u8 giltf_chk = giltf_cap;
 	
@@ -1207,7 +1207,7 @@ u8 halbb_ax_giltf_chk(struct bb_info *bb, u8 hw_mode, u8 giltf_cap)
 	return giltf_chk;
 }
 
-bool halbb_ldpc_chk(struct bb_info *bb,  struct rtw_phl_stainfo_t *phl_sta_i, u8 hw_mode)
+static bool halbb_ldpc_chk(struct bb_info *bb,  struct rtw_phl_stainfo_t *phl_sta_i, u8 hw_mode)
 {
 	struct protocol_cap_t *asoc_cap_i;
 	bool ldpc_en = false;
@@ -1229,7 +1229,7 @@ bool halbb_ldpc_chk(struct bb_info *bb,  struct rtw_phl_stainfo_t *phl_sta_i, u8
 	return ldpc_en;
 }
 
-u8 halbb_nss_mapping(struct bb_info *bb,  u8 nss)
+static u8 halbb_nss_mapping(struct bb_info *bb,  u8 nss)
 {
 	u8 mapping_nss = 0;
 
@@ -1241,7 +1241,7 @@ u8 halbb_nss_mapping(struct bb_info *bb,  u8 nss)
 	return mapping_nss;
 }
 
-bool halbb_stbc_mapping(struct bb_info *bb,  struct rtw_phl_stainfo_t *phl_sta_i, u8 hw_mode)
+static bool halbb_stbc_mapping(struct bb_info *bb,  struct rtw_phl_stainfo_t *phl_sta_i, u8 hw_mode)
 {
 	struct protocol_cap_t *asoc_cap_i;
 	bool stbc_en = false;
@@ -1266,7 +1266,7 @@ bool halbb_stbc_mapping(struct bb_info *bb,  struct rtw_phl_stainfo_t *phl_sta_i
 	return stbc_en;
 }
 
-bool halbb_sgi_chk(struct bb_info *bb,  struct rtw_phl_stainfo_t *phl_sta_i, u8 hw_bw)
+static bool halbb_sgi_chk(struct bb_info *bb,  struct rtw_phl_stainfo_t *phl_sta_i, u8 hw_bw)
 {
 	struct protocol_cap_t *asoc_cap_i;
 	bool sgi_en = false;
@@ -1291,7 +1291,7 @@ bool halbb_sgi_chk(struct bb_info *bb,  struct rtw_phl_stainfo_t *phl_sta_i, u8 
 	return sgi_en;
 }
 
-void halbb_ramask_trans(struct bb_info *bb, u8 macid, u64 mask, u64 mask_h)
+static void halbb_ramask_trans(struct bb_info *bb, u8 macid, u64 mask, u64 mask_h)
 {
 	union bb_h2c_ra_cmn_info *ra_cmn = &bb->bb_cmn_hooker->bb_ra_i[macid].ra_cfg;
 	struct bb_h2c_ra_cfg_info *ra_cfg = &ra_cmn->bb_h2c_ra_info;
@@ -1312,7 +1312,7 @@ void halbb_ramask_trans(struct bb_info *bb, u8 macid, u64 mask, u64 mask_h)
 	}
 }
 
-u8 halbb_get_opt_giltf(struct bb_info *bb, u8 assoc_giltf)
+static u8 halbb_get_opt_giltf(struct bb_info *bb, u8 assoc_giltf)
 {
 	u8 i =0;
 	u8 opt_gi_ltf = 0;
@@ -1326,7 +1326,7 @@ u8 halbb_get_opt_giltf(struct bb_info *bb, u8 assoc_giltf)
 	return opt_gi_ltf;
 }
 
-u8 halbb_giltf_trans(struct bb_info *bb, u8 assoc_giltf, u8 cal_giltf)
+static u8 halbb_giltf_trans(struct bb_info *bb, u8 assoc_giltf, u8 cal_giltf)
 {
 	u8 i =0;
 
@@ -1462,7 +1462,7 @@ bool rtw_halbb_dft_mask(struct bb_info *bb_0,
 	}
 }
 
-u8 rtw_halbb_arfr_trans(struct bb_info *bb,
+static u8 rtw_halbb_arfr_trans(struct bb_info *bb,
 	struct rtw_phl_stainfo_t *phl_sta_i)
 {
 	struct rtw_hal_stainfo_t *hal_sta_i;
@@ -1488,7 +1488,7 @@ u8 rtw_halbb_arfr_trans(struct bb_info *bb,
 		hw_mode_map |= HE_SUPPORT;*/
 }
 
-bool halbb_ra_cfg_chk(struct bb_info *bb, u8 *mode, u8 *tx_nss, bool *tx_stbc)
+static bool halbb_ra_cfg_chk(struct bb_info *bb, u8 *mode, u8 *tx_nss, bool *tx_stbc)
 {
 	bool rpt = true;
 
@@ -1864,7 +1864,7 @@ bool rtw_halbb_raupdate(struct bb_info *bb_0,
 	return ret_val;
 }
 
-bool halbb_ra_update_mask_watchdog(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
+static bool halbb_ra_update_mask_watchdog(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
 {
 	u8 macid;
 	union bb_h2c_ra_cmn_info *ra_cmn;
@@ -2249,7 +2249,7 @@ u32 halbb_get_txsts_rpt(struct bb_info *bb, u16 len, u8 *c2h)
 	return 0;
 }
 
-void halbb_ra_rssi_setting_watchdog(struct bb_info *bb)
+static void halbb_ra_rssi_setting_watchdog(struct bb_info *bb)
 {
 	u8 macid = 0;
 	u8 i = 0, sta_cnt = 0;
@@ -2347,7 +2347,7 @@ void halbb_ra_rssi_setting_watchdog(struct bb_info *bb)
 		hal_mem_free(bb->hal_com, rssi_i, rssi_len);
 }
 
-void halbb_ra_giltf_ctrl(struct bb_info *bb, u8 macid, u8 delay_sp, u8 assoc_giltf)
+static void halbb_ra_giltf_ctrl(struct bb_info *bb, u8 macid, u8 delay_sp, u8 assoc_giltf)
 {
 	//struct bb_ra_info *bb_ra = &bb->bb_cmn_hooker->bb_ra_i[macid];
 	//struct bb_h2c_ra_cfg_info *ra_cfg = &bb->bb_cmn_hooker->bb_ra_i[macid].ra_cfg;
@@ -2365,7 +2365,7 @@ void halbb_ra_giltf_ctrl(struct bb_info *bb, u8 macid, u8 delay_sp, u8 assoc_gil
 	ra_cfg->giltf = giltf;*/
 }
 
-bool halbb_ra_bfer_chk(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
+static bool halbb_ra_bfer_chk(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
 {
 	struct protocol_cap_t *asoc_cap = &phl_sta_i->asoc_cap;
 	struct protocol_cap_t *self_cap = &phl_sta_i->rlink->protocol_cap;
@@ -2404,7 +2404,7 @@ bool halbb_ra_bfer_chk(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
 	return bfer_chk;
 }
 
-bool halbb_ra_bfee_chk(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
+static bool halbb_ra_bfee_chk(struct bb_info *bb, struct rtw_phl_stainfo_t *phl_sta_i)
 {
 	struct protocol_cap_t *asoc_cap = &phl_sta_i->asoc_cap;
 	struct protocol_cap_t *self_cap = &phl_sta_i->rlink->protocol_cap;
@@ -2519,7 +2519,7 @@ void halbb_ra_init(struct bb_info *bb)
 	}
 }
 
-u8 rtw_halbb_rts_rate(struct bb_info *bb, u16 tx_rate, bool is_erp_prot)
+static u8 rtw_halbb_rts_rate(struct bb_info *bb, u16 tx_rate, bool is_erp_prot)
 {
 
 	u8 rts_ini_rate = RTW_DATA_RATE_OFDM6;

--- a/phl/hal_g6/phy/bb/halbb_rua_tbl.c
+++ b/phl/hal_g6/phy/bb/halbb_rua_tbl.c
@@ -26,7 +26,7 @@
 
 #ifdef HALBB_RUA_SUPPORT
 
-u32 halbb_rua_tbl_hdr_cfg(struct bb_info *bb,
+static u32 halbb_rua_tbl_hdr_cfg(struct bb_info *bb,
 		struct rtw_rua_tbl_hdr *rtw_tbl_hdr,
 		struct halbb_rua_tbl_hdr_info *rua_tbl_hdr)
 {
@@ -46,7 +46,7 @@ u32 halbb_rua_tbl_hdr_cfg(struct bb_info *bb,
 	return ret;
 }
 
-void halbb_ru_rate_cfg(struct bb_info *bb,
+static void halbb_ru_rate_cfg(struct bb_info *bb,
 		struct rtw_ru_rate_ent *rate_ent,
 		struct halbb_ru_rate_info *rate)
 {
@@ -56,7 +56,7 @@ void halbb_ru_rate_cfg(struct bb_info *bb,
 	rate->ss = rate_ent->ss;
 }
 
-u32 halbb_dlfix_sta_i_ax4ru_cfg(struct bb_info *bb,
+static u32 halbb_dlfix_sta_i_ax4ru_cfg(struct bb_info *bb,
 		struct rtw_dlfix_sta_i_ax4ru *sta_ent,
 		struct halbb_dl_fix_sta_info *fix_sta_i)
 {
@@ -86,7 +86,8 @@ u32 halbb_dlfix_sta_i_ax4ru_cfg(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_dlfix_sta_i_ax8ru_cfg(struct bb_info *bb,
+#if defined(BB_8852C_SUPPORT) || defined(BB_8192XB_SUPPORT)
+static u32 halbb_dlfix_sta_i_ax8ru_cfg(struct bb_info *bb,
 			struct rtw_dlfix_sta_i_ax8ru *sta_ent,
 			struct halbb_dl_fix_sta_info_8ru *fix_sta_i)
 {
@@ -115,8 +116,10 @@ u32 halbb_dlfix_sta_i_ax8ru_cfg(struct bb_info *bb,
 	ret = RTW_HAL_STATUS_SUCCESS;
 	return ret;
 }
+#endif /* BB_8852C_SUPPORT || BB_8192XB_SUPPORT */
 
-u32 halbb_dlfix_sta_i_ext_cfg(struct bb_info *bb,
+#if defined(BB_1115_SUPPORT)
+static u32 halbb_dlfix_sta_i_ext_cfg(struct bb_info *bb,
 		struct rtw_dlfix_sta_i_ext *sta_ent,
 		struct halbb_dlfix_sta_i_ext *fix_sta_i)
 {
@@ -143,8 +146,9 @@ u32 halbb_dlfix_sta_i_ext_cfg(struct bb_info *bb,
 	ret = RTW_HAL_STATUS_SUCCESS;
 	return ret;
 }
+#endif /* BB_1115_SUPPORT */
 
-u32 halbb_ulfix_sta_i_ax4ru_cfg(struct bb_info *bb,
+static u32 halbb_ulfix_sta_i_ax4ru_cfg(struct bb_info *bb,
 		struct rtw_ulfix_sta_i_ax4ru *sta_ent,
 		struct halbb_ul_fix_sta_info *fix_sta_i)
 {
@@ -173,7 +177,8 @@ u32 halbb_ulfix_sta_i_ax4ru_cfg(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_ulfix_sta_i_ax8ru_cfg(struct bb_info *bb,
+#if defined(BB_8852C_SUPPORT) || defined(BB_8192XB_SUPPORT)
+static u32 halbb_ulfix_sta_i_ax8ru_cfg(struct bb_info *bb,
 			struct rtw_ulfix_sta_i_ax8ru *sta_ent,
 			struct halbb_ul_fix_sta_info_8ru *fix_sta_i)
 {
@@ -201,8 +206,10 @@ u32 halbb_ulfix_sta_i_ax8ru_cfg(struct bb_info *bb,
 	ret = RTW_HAL_STATUS_SUCCESS;
 	return ret;
 }
+#endif /* BB_8852C_SUPPORT || BB_8192XB_SUPPORT */
 
-u32 halbb_ulfix_sta_i_ext_cfg(struct bb_info *bb,
+#if defined(BB_1115_SUPPORT)
+static u32 halbb_ulfix_sta_i_ext_cfg(struct bb_info *bb,
 		struct rtw_ulfix_sta_i_ext *sta_ent,
 		struct halbb_ulfix_sta_i_ext *fix_sta_i)
 {
@@ -225,8 +232,10 @@ u32 halbb_ulfix_sta_i_ext_cfg(struct bb_info *bb,
 	ret = RTW_HAL_STATUS_SUCCESS;
 	return ret;
 }
+#endif /* BB_1115_SUPPORT */
 
-u32 halbb_ulfix_rupostbl_16ru_cfg(struct bb_info *bb,
+#if defined(BB_1115_SUPPORT)
+static u32 halbb_ulfix_rupostbl_16ru_cfg(struct bb_info *bb,
 		struct rtw_rupos_fixtbl *rtw_rupos,
 		struct halbb_rupos_fixtbl *halbb_rupos)
 {
@@ -272,8 +281,9 @@ u32 halbb_ulfix_rupostbl_16ru_cfg(struct bb_info *bb,
 	ret = RTW_HAL_STATUS_SUCCESS;
 	return ret;
 }
+#endif /* BB_1115_SUPPORT */
 
-u32 halbb_tf_ba_tbl_info_cfg(struct bb_info *bb,
+static u32 halbb_tf_ba_tbl_info_cfg(struct bb_info *bb,
 			struct rtw_tf_ba_tbl *tf_tbl,
 			struct halbb_tf_ba_tbl_info *tf_i)
 {
@@ -314,7 +324,7 @@ void halbb_rua_tbl_init(struct bb_info *bb)
 }
 
 
-u32 halbb_dlru_fixtbl_ax4ru(struct bb_info *bb,
+static u32 halbb_dlru_fixtbl_ax4ru(struct bb_info *bb,
 			struct rtw_dlru_fixtbl_ax4ru *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -360,7 +370,8 @@ out:
 	return ret;
 }
 
-u32 halbb_dlru_fixtbl_ax8ru(struct bb_info *bb,
+#if defined(BB_8852C_SUPPORT) || defined(BB_8192XB_SUPPORT)
+static u32 halbb_dlru_fixtbl_ax8ru(struct bb_info *bb,
 			struct rtw_dlru_fixtbl_ax8ru *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -404,8 +415,10 @@ out:
 		ret = RTW_HAL_STATUS_SUCCESS;
 	return ret;
 }
+#endif /* BB_8852C_SUPPORT || BB_8192XB_SUPPORT */
 
-u32 halbb_dlru_fixtbl_univrsl(struct bb_info *bb,
+#if defined(BB_1115_SUPPORT)
+static u32 halbb_dlru_fixtbl_univrsl(struct bb_info *bb,
 			struct rtw_dlru_fixtbl_univrsl *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -456,6 +469,7 @@ out:
 		ret = RTW_HAL_STATUS_SUCCESS;
 	return ret;
 }
+#endif /* BB_1115_SUPPORT */
 
 u32 halbb_upd_dlru_fixtbl(struct bb_info *bb,
 			union rtw_dlru_fixtbl *union_info)
@@ -507,7 +521,7 @@ u32 halbb_upd_dlru_fixtbl(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_ulru_fixtbl_ax4ru(struct bb_info *bb,
+static u32 halbb_ulru_fixtbl_ax4ru(struct bb_info *bb,
 		struct rtw_ulru_fixtbl_ax4ru *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -553,7 +567,8 @@ out:
 	return ret;
 }
 
-u32 halbb_ulru_fixtbl_ax8ru(struct bb_info *bb,
+#if defined(BB_8852C_SUPPORT) || defined(BB_8192XB_SUPPORT)
+static u32 halbb_ulru_fixtbl_ax8ru(struct bb_info *bb,
 		struct rtw_ulru_fixtbl_ax8ru *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -599,8 +614,10 @@ out:
 		ret = RTW_HAL_STATUS_SUCCESS;
 	return ret;
 }
+#endif /* BB_8852C_SUPPORT || BB_8192XB_SUPPORT */
 
-u32 halbb_ulru_fixtbl_univrsl(struct bb_info *bb,
+#if defined(BB_1115_SUPPORT)
+static u32 halbb_ulru_fixtbl_univrsl(struct bb_info *bb,
 		struct rtw_ulru_fixtbl_univrsl *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -651,6 +668,7 @@ out:
 		ret = RTW_HAL_STATUS_SUCCESS;
 	return ret;
 }
+#endif /* BB_1115_SUPPORT */
 
 u32 halbb_upd_ulru_fixtbl(struct bb_info *bb,
 		union rtw_ulru_fixtbl *union_info)
@@ -703,7 +721,8 @@ u32 halbb_upd_ulru_fixtbl(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_dlru_grptbl_ext(struct bb_info *bb,
+#if defined(BB_1115_SUPPORT)
+static u32 halbb_dlru_grptbl_ext(struct bb_info *bb,
 		struct rtw_dl_ru_gp_tbl *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -741,9 +760,10 @@ out:
 		ret = RTW_HAL_STATUS_SUCCESS;
 	return ret;
 }
+#endif /* BB_1115_SUPPORT */
 
 
-u32 halbb_dlru_grptbl(struct bb_info *bb,
+static u32 halbb_dlru_grptbl(struct bb_info *bb,
 		struct rtw_dl_ru_gp_tbl *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -831,7 +851,8 @@ u32 halbb_upd_dlru_grptbl(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_ulru_grptbl_ext(struct bb_info *bb,
+#if defined(BB_1115_SUPPORT)
+static u32 halbb_ulru_grptbl_ext(struct bb_info *bb,
 		struct rtw_ul_ru_gp_tbl *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -877,8 +898,9 @@ out:
 		ret = RTW_HAL_STATUS_SUCCESS;
 	return ret;
 }
+#endif /* BB_1115_SUPPORT */
 
-u32 halbb_ulru_grptbl(struct bb_info *bb,
+static u32 halbb_ulru_grptbl(struct bb_info *bb,
 		struct rtw_ul_ru_gp_tbl *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -1350,7 +1372,8 @@ u32 halbb_ulmacid_cfg(struct bb_info *bb, struct rtw_ul_macid_set *cfg)
 }
 
 
-u32 halbb_ch_bw_upd(struct bb_info *bb, struct rtw_ch_bw_notif *cfg){
+#if defined(BB_1115_SUPPORT) || defined(BB_8192XB_SUPPORT) || defined(BB_8852C_SUPPORT)
+static u32 halbb_ch_bw_upd(struct bb_info *bb, struct rtw_ch_bw_notif *cfg){
 	u32 ret = RTW_HAL_STATUS_FAILURE;
 
 	u8 band_idx = cfg->band_idx;
@@ -1402,6 +1425,7 @@ u32 halbb_ch_bw_upd(struct bb_info *bb, struct rtw_ch_bw_notif *cfg){
 	ret = halbb_bbinfo_cfg(bb, &h2c_pkt);
 	return ret;
 }
+#endif /* BB_1115_SUPPORT || BB_8192XB_SUPPORT || BB_8852C_SUPPORT */
 
 u32 halbb_ch_bw_notif(struct bb_info *bb, struct rtw_ch_bw_notif *cfg){
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -1516,7 +1540,7 @@ u32 halbb_cqi_cfg(struct bb_info *bb, struct rtw_cqi_set *cfg)
 
 }
 
-u32 halbb_rua_rawread(struct bb_info *bb, u8 band, u8 src_sel, u8 id, u8 ofst32){
+static u32 halbb_rua_rawread(struct bb_info *bb, u8 band, u8 src_sel, u8 id, u8 ofst32){
 	u32 ret = RTW_HAL_STATUS_FAILURE;
 
 	u8 *bbinfo_i;
@@ -1549,7 +1573,7 @@ u32 halbb_rua_rawread(struct bb_info *bb, u8 band, u8 src_sel, u8 id, u8 ofst32)
 
 }
 
-u32 halbb_rua_rawwrite(struct bb_info *bb, u8 band, u8 src_sel, u8 id, u8 ofst32, u8 ofst8, u32 w_val){
+static u32 halbb_rua_rawwrite(struct bb_info *bb, u8 band, u8 src_sel, u8 id, u8 ofst32, u8 ofst8, u32 w_val){
 	u32 ret = RTW_HAL_STATUS_FAILURE;
 
 	u8 *bbinfo_i;
@@ -1637,7 +1661,8 @@ u32 halbb_bbinfo_cfg(struct bb_info *bb, struct rtw_bbinfo_cfg *cfg)
 
 }
 
-u8 halbb_path_num(enum rf_path path){
+#if defined(BB_8852C_SUPPORT) || defined(BB_8192XB_SUPPORT)
+static u8 halbb_path_num(enum rf_path path){
 	u8 path_num = 0;
 	switch (path) {
 	case RF_PATH_AB:
@@ -1666,8 +1691,10 @@ u8 halbb_path_num(enum rf_path path){
 	}
 	return path_num;
 }
+#endif /* BB_8852C_SUPPORT || BB_8192XB_SUPPORT */
 
-u32 halbb_trxpath_upd(struct bb_info *bb, u8 txpath_num, u8 rxpath_num){
+#if defined(BB_8852C_SUPPORT) || defined(BB_8192XB_SUPPORT)
+static u32 halbb_trxpath_upd(struct bb_info *bb, u8 txpath_num, u8 rxpath_num){
 	u32 ret = RTW_HAL_STATUS_FAILURE;
 
 	struct rtw_bbinfo_cfg bbinfo_cfg;
@@ -1680,6 +1707,7 @@ u32 halbb_trxpath_upd(struct bb_info *bb, u8 txpath_num, u8 rxpath_num){
 	ret = halbb_bbinfo_cfg(bb, &bbinfo_cfg);
 	return ret;
 }
+#endif /* BB_8852C_SUPPORT || BB_8192XB_SUPPORT */
 
 u32 halbb_trxpath_notif(struct bb_info *bb, enum rf_path tx_path, enum rf_path rx_path){
 
@@ -1722,7 +1750,8 @@ u32 halbb_trxpath_notif(struct bb_info *bb, enum rf_path tx_path, enum rf_path r
 	return ret;
 }
 
-u32 halbb_pwrtbl_upd(struct bb_info *bb, struct rtw_pwrtbl_notif *cfg){
+#if defined(BB_8852C_SUPPORT) || defined(BB_8192XB_SUPPORT)
+static u32 halbb_pwrtbl_upd(struct bb_info *bb, struct rtw_pwrtbl_notif *cfg){
 	u32 ret = RTW_HAL_STATUS_FAILURE;
 	u8 len = sizeof(struct rtw_pwrtbl_notif);
 	struct halbb_pwrtbl_notif *notif;
@@ -1782,6 +1811,7 @@ u32 halbb_pwrtbl_upd(struct bb_info *bb, struct rtw_pwrtbl_notif *cfg){
 		ret = RTW_HAL_STATUS_SUCCESS;
 	return ret;
 }
+#endif /* BB_8852C_SUPPORT || BB_8192XB_SUPPORT */
 
 u32 halbb_pwrtbl_notif(struct bb_info *bb, struct rtw_pwrtbl_notif *cfg)
 {
@@ -1854,7 +1884,7 @@ u32 halbb_pbr_tbl_cfg(struct bb_info *bb, struct rtw_pwr_by_rt_tbl *cfg)
 }
 
 /* For Test mode */
-void halbb_test_dlru_gp_tbl(struct bb_info *bb, struct rtw_dl_ru_gp_tbl *tbl)
+static void halbb_test_dlru_gp_tbl(struct bb_info *bb, struct rtw_dl_ru_gp_tbl *tbl)
 {
 	tbl->tbl_hdr.rw = 1; /* write */
 	tbl->tbl_hdr.idx = 0;
@@ -1883,7 +1913,7 @@ void halbb_test_dlru_gp_tbl(struct bb_info *bb, struct rtw_dl_ru_gp_tbl *tbl)
 	tbl->tf.ma_type = 0;
 }
 
-void halbb_test_dl_sta_ent0_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_dl_sta_ent0_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 122;
@@ -1901,7 +1931,7 @@ void halbb_test_dl_sta_ent0_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru
 	sta_ent->pwr_boost_fac = 0;
 }
 
-void halbb_test_dl_sta_ent1_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_dl_sta_ent1_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
 {
 	sta_ent->mac_id = 1;
 	sta_ent->ru_pos[0] = 124;
@@ -1919,7 +1949,7 @@ void halbb_test_dl_sta_ent1_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru
 	sta_ent->pwr_boost_fac = 0;
 }
 
-void halbb_test_dl_sta_ent2_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_dl_sta_ent2_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
 {
 	sta_ent->mac_id = 2;
 	sta_ent->ru_pos[0] = 0;
@@ -1937,7 +1967,7 @@ void halbb_test_dl_sta_ent2_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru
 	sta_ent->pwr_boost_fac = 0;
 }
 
-void halbb_test_dl_sta_ent3_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_dl_sta_ent3_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
 {
 	sta_ent->mac_id = 255;
 	sta_ent->ru_pos[0] = 0;
@@ -1955,7 +1985,7 @@ void halbb_test_dl_sta_ent3_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru
 	sta_ent->pwr_boost_fac = 0;
 }
 
-void halbb_test_dl_sta_ent0_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_dl_sta_ent0_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 11;
@@ -1976,7 +2006,7 @@ void halbb_test_dl_sta_ent0_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru
 	sta_ent->coding = 1;
 	sta_ent->pwr_boost_fac = 0;
 }
-void halbb_test_dl_sta_ent1_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_dl_sta_ent1_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 12;
@@ -1997,7 +2027,7 @@ void halbb_test_dl_sta_ent1_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru
 	sta_ent->coding = 1;
 	sta_ent->pwr_boost_fac = 0;
 }
-void halbb_test_dl_sta_ent2_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_dl_sta_ent2_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 13;
@@ -2018,7 +2048,7 @@ void halbb_test_dl_sta_ent2_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru
 	sta_ent->coding = 1;
 	sta_ent->pwr_boost_fac = 0;
 }
-void halbb_test_dl_sta_ent3_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_dl_sta_ent3_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 14;
@@ -2040,7 +2070,7 @@ void halbb_test_dl_sta_ent3_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru
 	sta_ent->pwr_boost_fac = 0;
 }
 
-void halbb_test_dl_fix_tbl(struct bb_info *bb, union rtw_dlru_fixtbl *tbl)
+static void halbb_test_dl_fix_tbl(struct bb_info *bb, union rtw_dlru_fixtbl *tbl)
 {
 	halbb_mem_set(bb, tbl,0,sizeof(union rtw_dlru_fixtbl));
 
@@ -2088,7 +2118,7 @@ void halbb_test_dl_fix_tbl(struct bb_info *bb, union rtw_dlru_fixtbl *tbl)
 	}
 }
 
-void halbb_test_ru_sta_info(struct bb_info *bb, struct rtw_ru_sta_info *tbl)
+static void halbb_test_ru_sta_info(struct bb_info *bb, struct rtw_ru_sta_info *tbl)
 {
 	halbb_mem_set(bb, tbl,0,sizeof(union rtw_dlru_fixtbl));
 
@@ -2130,7 +2160,7 @@ void halbb_test_ru_sta_info(struct bb_info *bb, struct rtw_ru_sta_info *tbl)
 	tbl->ul_swgrp_bitmap = 2;
 }
 
-void halbb_test_ul_sta_ent0_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_ul_sta_ent0_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 122;
@@ -2151,7 +2181,7 @@ void halbb_test_ul_sta_ent0_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru
 
 }
 
-void halbb_test_ul_sta_ent1_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_ul_sta_ent1_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
 {
 
 	sta_ent->mac_id = 1;
@@ -2173,7 +2203,7 @@ void halbb_test_ul_sta_ent1_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru
 
 }
 
-void halbb_test_ul_sta_ent2_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_ul_sta_ent2_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
 {
 	sta_ent->mac_id = 255;
 	sta_ent->ru_pos[0] = 0;
@@ -2193,7 +2223,7 @@ void halbb_test_ul_sta_ent2_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru
 	sta_ent->coding = 1;
 }
 
-void halbb_test_ul_sta_ent3_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_ul_sta_ent3_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
 {
 
 	sta_ent->mac_id = 255;
@@ -2214,7 +2244,7 @@ void halbb_test_ul_sta_ent3_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru
 	sta_ent->coding = 1;
 }
 
-void halbb_test_ul_sta_ent0_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_ul_sta_ent0_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 11;
@@ -2243,7 +2273,7 @@ void halbb_test_ul_sta_ent0_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru
 
 }
 
-void halbb_test_ul_sta_ent1_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_ul_sta_ent1_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 12;
@@ -2271,7 +2301,7 @@ void halbb_test_ul_sta_ent1_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru
 	sta_ent->coding = 1;
 
 }
-void halbb_test_ul_sta_ent2_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_ul_sta_ent2_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 13;
@@ -2299,7 +2329,7 @@ void halbb_test_ul_sta_ent2_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru
 	sta_ent->coding = 1;
 
 }
-void halbb_test_ul_sta_ent3_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_ul_sta_ent3_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 14;
@@ -2328,7 +2358,7 @@ void halbb_test_ul_sta_ent3_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru
 
 }
 
-void halbb_test_ul_fix_tbl(struct bb_info *bb, union rtw_ulru_fixtbl *tbl)
+static void halbb_test_ul_fix_tbl(struct bb_info *bb, union rtw_ulru_fixtbl *tbl)
 {
 	switch (bb->ic_type) {
 		case BB_RTL8852C:
@@ -2378,7 +2408,7 @@ void halbb_test_ul_fix_tbl(struct bb_info *bb, union rtw_ulru_fixtbl *tbl)
 	}
 }
 
-void halbb_test_ulru_gp_tbl(struct bb_info *bb, struct rtw_ul_ru_gp_tbl *tbl)
+static void halbb_test_ulru_gp_tbl(struct bb_info *bb, struct rtw_ul_ru_gp_tbl *tbl)
 {
 	tbl->tbl_hdr.rw = 1; /* write */
 	tbl->tbl_hdr.idx = 0;
@@ -2395,7 +2425,7 @@ void halbb_test_ulru_gp_tbl(struct bb_info *bb, struct rtw_ul_ru_gp_tbl *tbl)
 	tbl->fix_mode_flag= 1;
 }
 
-void halbb_test_ba_tbl(struct bb_info *bb, struct rtw_ba_tbl_info *tbl)
+static void halbb_test_ba_tbl(struct bb_info *bb, struct rtw_ba_tbl_info *tbl)
 {
 	tbl->tbl_hdr.rw = 1;
 	tbl->tbl_hdr.idx = 0;
@@ -2421,7 +2451,7 @@ void halbb_test_ba_tbl(struct bb_info *bb, struct rtw_ba_tbl_info *tbl)
 
 }
 
-void halbb_test_swgrp_hdl(struct bb_info *bb, struct rtw_sw_grp_set *hdl)
+static void halbb_test_swgrp_hdl(struct bb_info *bb, struct rtw_sw_grp_set *hdl)
 {
 	hdl->swgrp_bitmap[0].macid = 3;
 	hdl->swgrp_bitmap[0].en_upd_dl_swgrp = 1;
@@ -2438,7 +2468,7 @@ void halbb_test_swgrp_hdl(struct bb_info *bb, struct rtw_sw_grp_set *hdl)
 	hdl->swgrp_bitmap[1].cmdend = 1;
 }
 
-void halbb_test_dlmacid_cfg(struct bb_info *bb, struct rtw_dl_macid_cfg *cfg)
+static void halbb_test_dlmacid_cfg(struct bb_info *bb, struct rtw_dl_macid_cfg *cfg)
 {
 	cfg->macid = 5;
 	cfg->dl_su_rate_cfg = 1;
@@ -2475,7 +2505,7 @@ void halbb_test_dlmacid_cfg(struct bb_info *bb, struct rtw_dl_macid_cfg *cfg)
 	cfg->he_80m_in_160m_cap = 1;
 }
 
-void halbb_test_ulmacid_cfg(struct bb_info *bb, struct rtw_ul_macid_set *cfg)
+static void halbb_test_ulmacid_cfg(struct bb_info *bb, struct rtw_ul_macid_set *cfg)
 {
 	cfg->ul_macid_cfg[0].macid = 5;
 	cfg->ul_macid_cfg[0].endcmd = 0;
@@ -2524,7 +2554,7 @@ void halbb_test_ulmacid_cfg(struct bb_info *bb, struct rtw_ul_macid_set *cfg)
 }
 
 
-void halbb_test_sta_modify(struct bb_info *bb, struct rtw_dlru_fixtbl_ax4ru *fix_tbl, u8 mcs, u8 ss)
+static void halbb_test_sta_modify(struct bb_info *bb, struct rtw_dlru_fixtbl_ax4ru *fix_tbl, u8 mcs, u8 ss)
 {
 	fix_tbl->max_sta_num = 2;
 	fix_tbl->min_sta_num = 2;
@@ -2594,7 +2624,7 @@ void halbb_test_sta_modify(struct bb_info *bb, struct rtw_dlru_fixtbl_ax4ru *fix
 	fix_tbl->sta[3].pwr_boost_fac=0;
 }
 
-void halbb_test_grppwr_modify(struct bb_info *bb, struct rtw_dl_ru_gp_tbl *tbl, u8 grp_pwr)
+static void halbb_test_grppwr_modify(struct bb_info *bb, struct rtw_dl_ru_gp_tbl *tbl, u8 grp_pwr)
 {
 	tbl->ppdu_bw = CHANNEL_WIDTH_80;
 	tbl->tx_pwr = grp_pwr; /*TODO:get from bb api*/
@@ -2620,14 +2650,14 @@ void halbb_test_grppwr_modify(struct bb_info *bb, struct rtw_dl_ru_gp_tbl *tbl, 
 	tbl->tf.ma_type = 0;
 }
 
-void halbb_test_csiinfo_cfg(struct bb_info *bb, struct rtw_csiinfo_cfg *cfg)
+static void halbb_test_csiinfo_cfg(struct bb_info *bb, struct rtw_csiinfo_cfg *cfg)
 {
 	cfg->macid = 5;
 	cfg->csi_info_bitmap= 99;
 }
 
 
-void halbb_test_cqi_cfg(struct bb_info *bb, struct rtw_cqi_set *cfg)
+static void halbb_test_cqi_cfg(struct bb_info *bb, struct rtw_cqi_set *cfg)
 {
 	u8 i;
 
@@ -2669,12 +2699,12 @@ void halbb_test_cqi_cfg(struct bb_info *bb, struct rtw_cqi_set *cfg)
 
 }
 
-void halbb_test_bbinfo_cfg(struct bb_info *bb, struct rtw_bbinfo_cfg *cfg)
+static void halbb_test_bbinfo_cfg(struct bb_info *bb, struct rtw_bbinfo_cfg *cfg)
 {
 //	cfg->p20_ch_bitmap= 168;
 }
 
-void halbb_test_pbr_tbl_cfg(struct bb_info *bb, struct rtw_pwr_by_rt_tbl *cfg)
+static void halbb_test_pbr_tbl_cfg(struct bb_info *bb, struct rtw_pwr_by_rt_tbl *cfg)
 {
 	u8 i;
 
@@ -2683,7 +2713,7 @@ void halbb_test_pbr_tbl_cfg(struct bb_info *bb, struct rtw_pwr_by_rt_tbl *cfg)
 }
 
 
-u32 halbb_set_rua_tbl(struct bb_info *bb, u8 rua_tbl_idx)
+static u32 halbb_set_rua_tbl(struct bb_info *bb, u8 rua_tbl_idx)
 {
 
 	u32 ret = 0;
@@ -2726,7 +2756,7 @@ u32 halbb_set_rua_tbl(struct bb_info *bb, u8 rua_tbl_idx)
 	return ret;
 }
 
-u32 halbb_set_rua_cfg(struct bb_info *bb, u8 rua_cfg_idx)
+static u32 halbb_set_rua_cfg(struct bb_info *bb, u8 rua_cfg_idx)
 {
 
 	u32 ret = 0;
@@ -2785,7 +2815,7 @@ u32 halbb_set_rua_cfg(struct bb_info *bb, u8 rua_cfg_idx)
 	return ret;
 }
 
-u32 halbb_set_rua_sta_rate_ss(struct bb_info *bb, u8 hdr_type, u8 ent, u8 mcs, u8 ss)
+static u32 halbb_set_rua_sta_rate_ss(struct bb_info *bb, u8 hdr_type, u8 ent, u8 mcs, u8 ss)
 {
 	u32 ret = 0;
 	//struct rtw_dlru_fixtbl_ax4ru dl_ru_fix_t;
@@ -2810,7 +2840,7 @@ u32 halbb_set_rua_sta_rate_ss(struct bb_info *bb, u8 hdr_type, u8 ent, u8 mcs, u
 }
 
 
-u32 halbb_set_rua_grp_pwr(struct bb_info *bb, u8 hdr_type, u8 ent, u8 grp_pwr)
+static u32 halbb_set_rua_grp_pwr(struct bb_info *bb, u8 hdr_type, u8 ent, u8 grp_pwr)
 {
 
 	u32 ret = 0;
@@ -2834,7 +2864,7 @@ u32 halbb_set_rua_grp_pwr(struct bb_info *bb, u8 hdr_type, u8 ent, u8 grp_pwr)
 }
 
 
-u32 halbb_ra_masking_test(
+static u32 halbb_ra_masking_test(
 	struct bb_info *bb,
 	u8 macid_l,
 	u8 macid_m,

--- a/phl/hal_g6/phy/bb/halbb_rua_tbl.c
+++ b/phl/hal_g6/phy/bb/halbb_rua_tbl.c
@@ -26,7 +26,7 @@
 
 #ifdef HALBB_RUA_SUPPORT
 
-u32 halbb_rua_tbl_hdr_cfg(struct bb_info *bb,
+static u32 halbb_rua_tbl_hdr_cfg(struct bb_info *bb,
 		struct rtw_rua_tbl_hdr *rtw_tbl_hdr,
 		struct halbb_rua_tbl_hdr_info *rua_tbl_hdr)
 {
@@ -46,7 +46,7 @@ u32 halbb_rua_tbl_hdr_cfg(struct bb_info *bb,
 	return ret;
 }
 
-void halbb_ru_rate_cfg(struct bb_info *bb,
+static void halbb_ru_rate_cfg(struct bb_info *bb,
 		struct rtw_ru_rate_ent *rate_ent,
 		struct halbb_ru_rate_info *rate)
 {
@@ -56,7 +56,7 @@ void halbb_ru_rate_cfg(struct bb_info *bb,
 	rate->ss = rate_ent->ss;
 }
 
-u32 halbb_dlfix_sta_i_ax4ru_cfg(struct bb_info *bb,
+static u32 halbb_dlfix_sta_i_ax4ru_cfg(struct bb_info *bb,
 		struct rtw_dlfix_sta_i_ax4ru *sta_ent,
 		struct halbb_dl_fix_sta_info *fix_sta_i)
 {
@@ -86,7 +86,7 @@ u32 halbb_dlfix_sta_i_ax4ru_cfg(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_dlfix_sta_i_ax8ru_cfg(struct bb_info *bb,
+static u32 halbb_dlfix_sta_i_ax8ru_cfg(struct bb_info *bb,
 			struct rtw_dlfix_sta_i_ax8ru *sta_ent,
 			struct halbb_dl_fix_sta_info_8ru *fix_sta_i)
 {
@@ -116,7 +116,7 @@ u32 halbb_dlfix_sta_i_ax8ru_cfg(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_dlfix_sta_i_ext_cfg(struct bb_info *bb,
+static u32 halbb_dlfix_sta_i_ext_cfg(struct bb_info *bb,
 		struct rtw_dlfix_sta_i_ext *sta_ent,
 		struct halbb_dlfix_sta_i_ext *fix_sta_i)
 {
@@ -144,7 +144,7 @@ u32 halbb_dlfix_sta_i_ext_cfg(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_ulfix_sta_i_ax4ru_cfg(struct bb_info *bb,
+static u32 halbb_ulfix_sta_i_ax4ru_cfg(struct bb_info *bb,
 		struct rtw_ulfix_sta_i_ax4ru *sta_ent,
 		struct halbb_ul_fix_sta_info *fix_sta_i)
 {
@@ -173,7 +173,7 @@ u32 halbb_ulfix_sta_i_ax4ru_cfg(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_ulfix_sta_i_ax8ru_cfg(struct bb_info *bb,
+static u32 halbb_ulfix_sta_i_ax8ru_cfg(struct bb_info *bb,
 			struct rtw_ulfix_sta_i_ax8ru *sta_ent,
 			struct halbb_ul_fix_sta_info_8ru *fix_sta_i)
 {
@@ -202,7 +202,7 @@ u32 halbb_ulfix_sta_i_ax8ru_cfg(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_ulfix_sta_i_ext_cfg(struct bb_info *bb,
+static u32 halbb_ulfix_sta_i_ext_cfg(struct bb_info *bb,
 		struct rtw_ulfix_sta_i_ext *sta_ent,
 		struct halbb_ulfix_sta_i_ext *fix_sta_i)
 {
@@ -226,7 +226,7 @@ u32 halbb_ulfix_sta_i_ext_cfg(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_ulfix_rupostbl_16ru_cfg(struct bb_info *bb,
+static u32 halbb_ulfix_rupostbl_16ru_cfg(struct bb_info *bb,
 		struct rtw_rupos_fixtbl *rtw_rupos,
 		struct halbb_rupos_fixtbl *halbb_rupos)
 {
@@ -273,7 +273,7 @@ u32 halbb_ulfix_rupostbl_16ru_cfg(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_tf_ba_tbl_info_cfg(struct bb_info *bb,
+static u32 halbb_tf_ba_tbl_info_cfg(struct bb_info *bb,
 			struct rtw_tf_ba_tbl *tf_tbl,
 			struct halbb_tf_ba_tbl_info *tf_i)
 {
@@ -314,7 +314,7 @@ void halbb_rua_tbl_init(struct bb_info *bb)
 }
 
 
-u32 halbb_dlru_fixtbl_ax4ru(struct bb_info *bb,
+static u32 halbb_dlru_fixtbl_ax4ru(struct bb_info *bb,
 			struct rtw_dlru_fixtbl_ax4ru *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -360,7 +360,7 @@ out:
 	return ret;
 }
 
-u32 halbb_dlru_fixtbl_ax8ru(struct bb_info *bb,
+static u32 halbb_dlru_fixtbl_ax8ru(struct bb_info *bb,
 			struct rtw_dlru_fixtbl_ax8ru *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -405,7 +405,7 @@ out:
 	return ret;
 }
 
-u32 halbb_dlru_fixtbl_univrsl(struct bb_info *bb,
+static u32 halbb_dlru_fixtbl_univrsl(struct bb_info *bb,
 			struct rtw_dlru_fixtbl_univrsl *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -507,7 +507,7 @@ u32 halbb_upd_dlru_fixtbl(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_ulru_fixtbl_ax4ru(struct bb_info *bb,
+static u32 halbb_ulru_fixtbl_ax4ru(struct bb_info *bb,
 		struct rtw_ulru_fixtbl_ax4ru *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -553,7 +553,7 @@ out:
 	return ret;
 }
 
-u32 halbb_ulru_fixtbl_ax8ru(struct bb_info *bb,
+static u32 halbb_ulru_fixtbl_ax8ru(struct bb_info *bb,
 		struct rtw_ulru_fixtbl_ax8ru *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -600,7 +600,7 @@ out:
 	return ret;
 }
 
-u32 halbb_ulru_fixtbl_univrsl(struct bb_info *bb,
+static u32 halbb_ulru_fixtbl_univrsl(struct bb_info *bb,
 		struct rtw_ulru_fixtbl_univrsl *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -703,7 +703,7 @@ u32 halbb_upd_ulru_fixtbl(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_dlru_grptbl_ext(struct bb_info *bb,
+static u32 halbb_dlru_grptbl_ext(struct bb_info *bb,
 		struct rtw_dl_ru_gp_tbl *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -743,7 +743,7 @@ out:
 }
 
 
-u32 halbb_dlru_grptbl(struct bb_info *bb,
+static u32 halbb_dlru_grptbl(struct bb_info *bb,
 		struct rtw_dl_ru_gp_tbl *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -831,7 +831,7 @@ u32 halbb_upd_dlru_grptbl(struct bb_info *bb,
 	return ret;
 }
 
-u32 halbb_ulru_grptbl_ext(struct bb_info *bb,
+static u32 halbb_ulru_grptbl_ext(struct bb_info *bb,
 		struct rtw_ul_ru_gp_tbl *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -878,7 +878,7 @@ out:
 	return ret;
 }
 
-u32 halbb_ulru_grptbl(struct bb_info *bb,
+static u32 halbb_ulru_grptbl(struct bb_info *bb,
 		struct rtw_ul_ru_gp_tbl *info)
 {
 	u32 ret = RTW_HAL_STATUS_FAILURE;
@@ -1350,7 +1350,7 @@ u32 halbb_ulmacid_cfg(struct bb_info *bb, struct rtw_ul_macid_set *cfg)
 }
 
 
-u32 halbb_ch_bw_upd(struct bb_info *bb, struct rtw_ch_bw_notif *cfg){
+static u32 halbb_ch_bw_upd(struct bb_info *bb, struct rtw_ch_bw_notif *cfg){
 	u32 ret = RTW_HAL_STATUS_FAILURE;
 
 	u8 band_idx = cfg->band_idx;
@@ -1516,7 +1516,7 @@ u32 halbb_cqi_cfg(struct bb_info *bb, struct rtw_cqi_set *cfg)
 
 }
 
-u32 halbb_rua_rawread(struct bb_info *bb, u8 band, u8 src_sel, u8 id, u8 ofst32){
+static u32 halbb_rua_rawread(struct bb_info *bb, u8 band, u8 src_sel, u8 id, u8 ofst32){
 	u32 ret = RTW_HAL_STATUS_FAILURE;
 
 	u8 *bbinfo_i;
@@ -1549,7 +1549,7 @@ u32 halbb_rua_rawread(struct bb_info *bb, u8 band, u8 src_sel, u8 id, u8 ofst32)
 
 }
 
-u32 halbb_rua_rawwrite(struct bb_info *bb, u8 band, u8 src_sel, u8 id, u8 ofst32, u8 ofst8, u32 w_val){
+static u32 halbb_rua_rawwrite(struct bb_info *bb, u8 band, u8 src_sel, u8 id, u8 ofst32, u8 ofst8, u32 w_val){
 	u32 ret = RTW_HAL_STATUS_FAILURE;
 
 	u8 *bbinfo_i;
@@ -1637,7 +1637,7 @@ u32 halbb_bbinfo_cfg(struct bb_info *bb, struct rtw_bbinfo_cfg *cfg)
 
 }
 
-u8 halbb_path_num(enum rf_path path){
+static u8 halbb_path_num(enum rf_path path){
 	u8 path_num = 0;
 	switch (path) {
 	case RF_PATH_AB:
@@ -1667,7 +1667,7 @@ u8 halbb_path_num(enum rf_path path){
 	return path_num;
 }
 
-u32 halbb_trxpath_upd(struct bb_info *bb, u8 txpath_num, u8 rxpath_num){
+static u32 halbb_trxpath_upd(struct bb_info *bb, u8 txpath_num, u8 rxpath_num){
 	u32 ret = RTW_HAL_STATUS_FAILURE;
 
 	struct rtw_bbinfo_cfg bbinfo_cfg;
@@ -1722,7 +1722,7 @@ u32 halbb_trxpath_notif(struct bb_info *bb, enum rf_path tx_path, enum rf_path r
 	return ret;
 }
 
-u32 halbb_pwrtbl_upd(struct bb_info *bb, struct rtw_pwrtbl_notif *cfg){
+static u32 halbb_pwrtbl_upd(struct bb_info *bb, struct rtw_pwrtbl_notif *cfg){
 	u32 ret = RTW_HAL_STATUS_FAILURE;
 	u8 len = sizeof(struct rtw_pwrtbl_notif);
 	struct halbb_pwrtbl_notif *notif;
@@ -1854,7 +1854,7 @@ u32 halbb_pbr_tbl_cfg(struct bb_info *bb, struct rtw_pwr_by_rt_tbl *cfg)
 }
 
 /* For Test mode */
-void halbb_test_dlru_gp_tbl(struct bb_info *bb, struct rtw_dl_ru_gp_tbl *tbl)
+static void halbb_test_dlru_gp_tbl(struct bb_info *bb, struct rtw_dl_ru_gp_tbl *tbl)
 {
 	tbl->tbl_hdr.rw = 1; /* write */
 	tbl->tbl_hdr.idx = 0;
@@ -1883,7 +1883,7 @@ void halbb_test_dlru_gp_tbl(struct bb_info *bb, struct rtw_dl_ru_gp_tbl *tbl)
 	tbl->tf.ma_type = 0;
 }
 
-void halbb_test_dl_sta_ent0_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_dl_sta_ent0_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 122;
@@ -1901,7 +1901,7 @@ void halbb_test_dl_sta_ent0_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru
 	sta_ent->pwr_boost_fac = 0;
 }
 
-void halbb_test_dl_sta_ent1_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_dl_sta_ent1_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
 {
 	sta_ent->mac_id = 1;
 	sta_ent->ru_pos[0] = 124;
@@ -1919,7 +1919,7 @@ void halbb_test_dl_sta_ent1_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru
 	sta_ent->pwr_boost_fac = 0;
 }
 
-void halbb_test_dl_sta_ent2_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_dl_sta_ent2_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
 {
 	sta_ent->mac_id = 2;
 	sta_ent->ru_pos[0] = 0;
@@ -1937,7 +1937,7 @@ void halbb_test_dl_sta_ent2_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru
 	sta_ent->pwr_boost_fac = 0;
 }
 
-void halbb_test_dl_sta_ent3_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_dl_sta_ent3_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru *sta_ent)
 {
 	sta_ent->mac_id = 255;
 	sta_ent->ru_pos[0] = 0;
@@ -1955,7 +1955,7 @@ void halbb_test_dl_sta_ent3_4ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax4ru
 	sta_ent->pwr_boost_fac = 0;
 }
 
-void halbb_test_dl_sta_ent0_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_dl_sta_ent0_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 11;
@@ -1976,7 +1976,7 @@ void halbb_test_dl_sta_ent0_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru
 	sta_ent->coding = 1;
 	sta_ent->pwr_boost_fac = 0;
 }
-void halbb_test_dl_sta_ent1_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_dl_sta_ent1_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 12;
@@ -1997,7 +1997,7 @@ void halbb_test_dl_sta_ent1_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru
 	sta_ent->coding = 1;
 	sta_ent->pwr_boost_fac = 0;
 }
-void halbb_test_dl_sta_ent2_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_dl_sta_ent2_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 13;
@@ -2018,7 +2018,7 @@ void halbb_test_dl_sta_ent2_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru
 	sta_ent->coding = 1;
 	sta_ent->pwr_boost_fac = 0;
 }
-void halbb_test_dl_sta_ent3_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_dl_sta_ent3_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 14;
@@ -2040,7 +2040,7 @@ void halbb_test_dl_sta_ent3_8ru(struct bb_info *bb, struct rtw_dlfix_sta_i_ax8ru
 	sta_ent->pwr_boost_fac = 0;
 }
 
-void halbb_test_dl_fix_tbl(struct bb_info *bb, union rtw_dlru_fixtbl *tbl)
+static void halbb_test_dl_fix_tbl(struct bb_info *bb, union rtw_dlru_fixtbl *tbl)
 {
 	halbb_mem_set(bb, tbl,0,sizeof(union rtw_dlru_fixtbl));
 
@@ -2088,7 +2088,7 @@ void halbb_test_dl_fix_tbl(struct bb_info *bb, union rtw_dlru_fixtbl *tbl)
 	}
 }
 
-void halbb_test_ru_sta_info(struct bb_info *bb, struct rtw_ru_sta_info *tbl)
+static void halbb_test_ru_sta_info(struct bb_info *bb, struct rtw_ru_sta_info *tbl)
 {
 	halbb_mem_set(bb, tbl,0,sizeof(union rtw_dlru_fixtbl));
 
@@ -2130,7 +2130,7 @@ void halbb_test_ru_sta_info(struct bb_info *bb, struct rtw_ru_sta_info *tbl)
 	tbl->ul_swgrp_bitmap = 2;
 }
 
-void halbb_test_ul_sta_ent0_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_ul_sta_ent0_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 122;
@@ -2151,7 +2151,7 @@ void halbb_test_ul_sta_ent0_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru
 
 }
 
-void halbb_test_ul_sta_ent1_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_ul_sta_ent1_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
 {
 
 	sta_ent->mac_id = 1;
@@ -2173,7 +2173,7 @@ void halbb_test_ul_sta_ent1_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru
 
 }
 
-void halbb_test_ul_sta_ent2_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_ul_sta_ent2_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
 {
 	sta_ent->mac_id = 255;
 	sta_ent->ru_pos[0] = 0;
@@ -2193,7 +2193,7 @@ void halbb_test_ul_sta_ent2_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru
 	sta_ent->coding = 1;
 }
 
-void halbb_test_ul_sta_ent3_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
+static void halbb_test_ul_sta_ent3_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru *sta_ent)
 {
 
 	sta_ent->mac_id = 255;
@@ -2214,7 +2214,7 @@ void halbb_test_ul_sta_ent3_4ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax4ru
 	sta_ent->coding = 1;
 }
 
-void halbb_test_ul_sta_ent0_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_ul_sta_ent0_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 11;
@@ -2243,7 +2243,7 @@ void halbb_test_ul_sta_ent0_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru
 
 }
 
-void halbb_test_ul_sta_ent1_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_ul_sta_ent1_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 12;
@@ -2271,7 +2271,7 @@ void halbb_test_ul_sta_ent1_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru
 	sta_ent->coding = 1;
 
 }
-void halbb_test_ul_sta_ent2_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_ul_sta_ent2_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 13;
@@ -2299,7 +2299,7 @@ void halbb_test_ul_sta_ent2_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru
 	sta_ent->coding = 1;
 
 }
-void halbb_test_ul_sta_ent3_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
+static void halbb_test_ul_sta_ent3_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru *sta_ent)
 {
 	sta_ent->mac_id = 0;
 	sta_ent->ru_pos[0] = 14;
@@ -2328,7 +2328,7 @@ void halbb_test_ul_sta_ent3_8ru(struct bb_info *bb, struct rtw_ulfix_sta_i_ax8ru
 
 }
 
-void halbb_test_ul_fix_tbl(struct bb_info *bb, union rtw_ulru_fixtbl *tbl)
+static void halbb_test_ul_fix_tbl(struct bb_info *bb, union rtw_ulru_fixtbl *tbl)
 {
 	switch (bb->ic_type) {
 		case BB_RTL8852C:
@@ -2378,7 +2378,7 @@ void halbb_test_ul_fix_tbl(struct bb_info *bb, union rtw_ulru_fixtbl *tbl)
 	}
 }
 
-void halbb_test_ulru_gp_tbl(struct bb_info *bb, struct rtw_ul_ru_gp_tbl *tbl)
+static void halbb_test_ulru_gp_tbl(struct bb_info *bb, struct rtw_ul_ru_gp_tbl *tbl)
 {
 	tbl->tbl_hdr.rw = 1; /* write */
 	tbl->tbl_hdr.idx = 0;
@@ -2395,7 +2395,7 @@ void halbb_test_ulru_gp_tbl(struct bb_info *bb, struct rtw_ul_ru_gp_tbl *tbl)
 	tbl->fix_mode_flag= 1;
 }
 
-void halbb_test_ba_tbl(struct bb_info *bb, struct rtw_ba_tbl_info *tbl)
+static void halbb_test_ba_tbl(struct bb_info *bb, struct rtw_ba_tbl_info *tbl)
 {
 	tbl->tbl_hdr.rw = 1;
 	tbl->tbl_hdr.idx = 0;
@@ -2421,7 +2421,7 @@ void halbb_test_ba_tbl(struct bb_info *bb, struct rtw_ba_tbl_info *tbl)
 
 }
 
-void halbb_test_swgrp_hdl(struct bb_info *bb, struct rtw_sw_grp_set *hdl)
+static void halbb_test_swgrp_hdl(struct bb_info *bb, struct rtw_sw_grp_set *hdl)
 {
 	hdl->swgrp_bitmap[0].macid = 3;
 	hdl->swgrp_bitmap[0].en_upd_dl_swgrp = 1;
@@ -2438,7 +2438,7 @@ void halbb_test_swgrp_hdl(struct bb_info *bb, struct rtw_sw_grp_set *hdl)
 	hdl->swgrp_bitmap[1].cmdend = 1;
 }
 
-void halbb_test_dlmacid_cfg(struct bb_info *bb, struct rtw_dl_macid_cfg *cfg)
+static void halbb_test_dlmacid_cfg(struct bb_info *bb, struct rtw_dl_macid_cfg *cfg)
 {
 	cfg->macid = 5;
 	cfg->dl_su_rate_cfg = 1;
@@ -2475,7 +2475,7 @@ void halbb_test_dlmacid_cfg(struct bb_info *bb, struct rtw_dl_macid_cfg *cfg)
 	cfg->he_80m_in_160m_cap = 1;
 }
 
-void halbb_test_ulmacid_cfg(struct bb_info *bb, struct rtw_ul_macid_set *cfg)
+static void halbb_test_ulmacid_cfg(struct bb_info *bb, struct rtw_ul_macid_set *cfg)
 {
 	cfg->ul_macid_cfg[0].macid = 5;
 	cfg->ul_macid_cfg[0].endcmd = 0;
@@ -2524,7 +2524,7 @@ void halbb_test_ulmacid_cfg(struct bb_info *bb, struct rtw_ul_macid_set *cfg)
 }
 
 
-void halbb_test_sta_modify(struct bb_info *bb, struct rtw_dlru_fixtbl_ax4ru *fix_tbl, u8 mcs, u8 ss)
+static void halbb_test_sta_modify(struct bb_info *bb, struct rtw_dlru_fixtbl_ax4ru *fix_tbl, u8 mcs, u8 ss)
 {
 	fix_tbl->max_sta_num = 2;
 	fix_tbl->min_sta_num = 2;
@@ -2594,7 +2594,7 @@ void halbb_test_sta_modify(struct bb_info *bb, struct rtw_dlru_fixtbl_ax4ru *fix
 	fix_tbl->sta[3].pwr_boost_fac=0;
 }
 
-void halbb_test_grppwr_modify(struct bb_info *bb, struct rtw_dl_ru_gp_tbl *tbl, u8 grp_pwr)
+static void halbb_test_grppwr_modify(struct bb_info *bb, struct rtw_dl_ru_gp_tbl *tbl, u8 grp_pwr)
 {
 	tbl->ppdu_bw = CHANNEL_WIDTH_80;
 	tbl->tx_pwr = grp_pwr; /*TODO:get from bb api*/
@@ -2620,14 +2620,14 @@ void halbb_test_grppwr_modify(struct bb_info *bb, struct rtw_dl_ru_gp_tbl *tbl, 
 	tbl->tf.ma_type = 0;
 }
 
-void halbb_test_csiinfo_cfg(struct bb_info *bb, struct rtw_csiinfo_cfg *cfg)
+static void halbb_test_csiinfo_cfg(struct bb_info *bb, struct rtw_csiinfo_cfg *cfg)
 {
 	cfg->macid = 5;
 	cfg->csi_info_bitmap= 99;
 }
 
 
-void halbb_test_cqi_cfg(struct bb_info *bb, struct rtw_cqi_set *cfg)
+static void halbb_test_cqi_cfg(struct bb_info *bb, struct rtw_cqi_set *cfg)
 {
 	u8 i;
 
@@ -2669,12 +2669,12 @@ void halbb_test_cqi_cfg(struct bb_info *bb, struct rtw_cqi_set *cfg)
 
 }
 
-void halbb_test_bbinfo_cfg(struct bb_info *bb, struct rtw_bbinfo_cfg *cfg)
+static void halbb_test_bbinfo_cfg(struct bb_info *bb, struct rtw_bbinfo_cfg *cfg)
 {
 //	cfg->p20_ch_bitmap= 168;
 }
 
-void halbb_test_pbr_tbl_cfg(struct bb_info *bb, struct rtw_pwr_by_rt_tbl *cfg)
+static void halbb_test_pbr_tbl_cfg(struct bb_info *bb, struct rtw_pwr_by_rt_tbl *cfg)
 {
 	u8 i;
 
@@ -2683,7 +2683,7 @@ void halbb_test_pbr_tbl_cfg(struct bb_info *bb, struct rtw_pwr_by_rt_tbl *cfg)
 }
 
 
-u32 halbb_set_rua_tbl(struct bb_info *bb, u8 rua_tbl_idx)
+static u32 halbb_set_rua_tbl(struct bb_info *bb, u8 rua_tbl_idx)
 {
 
 	u32 ret = 0;
@@ -2726,7 +2726,7 @@ u32 halbb_set_rua_tbl(struct bb_info *bb, u8 rua_tbl_idx)
 	return ret;
 }
 
-u32 halbb_set_rua_cfg(struct bb_info *bb, u8 rua_cfg_idx)
+static u32 halbb_set_rua_cfg(struct bb_info *bb, u8 rua_cfg_idx)
 {
 
 	u32 ret = 0;
@@ -2785,7 +2785,7 @@ u32 halbb_set_rua_cfg(struct bb_info *bb, u8 rua_cfg_idx)
 	return ret;
 }
 
-u32 halbb_set_rua_sta_rate_ss(struct bb_info *bb, u8 hdr_type, u8 ent, u8 mcs, u8 ss)
+static u32 halbb_set_rua_sta_rate_ss(struct bb_info *bb, u8 hdr_type, u8 ent, u8 mcs, u8 ss)
 {
 	u32 ret = 0;
 	//struct rtw_dlru_fixtbl_ax4ru dl_ru_fix_t;
@@ -2810,7 +2810,7 @@ u32 halbb_set_rua_sta_rate_ss(struct bb_info *bb, u8 hdr_type, u8 ent, u8 mcs, u
 }
 
 
-u32 halbb_set_rua_grp_pwr(struct bb_info *bb, u8 hdr_type, u8 ent, u8 grp_pwr)
+static u32 halbb_set_rua_grp_pwr(struct bb_info *bb, u8 hdr_type, u8 ent, u8 grp_pwr)
 {
 
 	u32 ret = 0;
@@ -2834,7 +2834,7 @@ u32 halbb_set_rua_grp_pwr(struct bb_info *bb, u8 hdr_type, u8 ent, u8 grp_pwr)
 }
 
 
-u32 halbb_ra_masking_test(
+static u32 halbb_ra_masking_test(
 	struct bb_info *bb,
 	u8 macid_l,
 	u8 macid_m,

--- a/phl/hal_g6/phy/bb/halbb_snif.c
+++ b/phl/hal_g6/phy/bb/halbb_snif.c
@@ -58,7 +58,7 @@ static const u8 he_sigb_n_user [256] = {
 	0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0};
 
-void halbb_sniffer_rpt_reset(struct bb_info *bb)
+static void halbb_sniffer_rpt_reset(struct bb_info *bb)
 {
 	struct bb_snif_info *snif = &bb->bb_cmn_hooker->bb_snif_i;
 
@@ -101,7 +101,7 @@ void halbb_sniffer_mode_en(struct bb_info *bb, bool en)
 	}
 }
 
-bool halbb_sniffer_phy_sts_ie_09(struct bb_info *bb)
+static bool halbb_sniffer_phy_sts_ie_09(struct bb_info *bb)
 {
 	struct bb_snif_info *snif = &bb->bb_cmn_hooker->bb_snif_i;
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
@@ -136,7 +136,7 @@ bool halbb_sniffer_phy_sts_ie_09(struct bb_info *bb)
 	return true;
 }
 
-bool halbb_sniffer_phy_sts_ie_10(struct bb_info *bb)
+static bool halbb_sniffer_phy_sts_ie_10(struct bb_info *bb)
 {
 	struct bb_snif_info *snif = &bb->bb_cmn_hooker->bb_snif_i;
 	struct plcp_hdr_vht_sig_b_info *vht_sig_b = &snif->plcp_hdr_vht_sig_b_i;

--- a/phl/hal_g6/phy/bb/halbb_spur_suppress.c
+++ b/phl/hal_g6/phy/bb/halbb_spur_suppress.c
@@ -25,7 +25,7 @@
 
 #include "halbb_precomp.h"
 
-bool halbb_spur_location(struct bb_info *bb, u8 central_ch,
+static bool halbb_spur_location(struct bb_info *bb, u8 central_ch,
 			 enum channel_width bw, enum band_type band, u32 *intf)
 {
 	bool rpt = false;
@@ -66,7 +66,7 @@ bool halbb_spur_location(struct bb_info *bb, u8 central_ch,
 	return rpt;
 }
 
-bool halbb_spur_location_for_CSI(struct bb_info *bb, u8 central_ch,
+static bool halbb_spur_location_for_CSI(struct bb_info *bb, u8 central_ch,
 				 enum channel_width bw, enum band_type band, u32 *intf)
 {
 	bool rpt = false;

--- a/phl/hal_g6/phy/bb/halbb_statistics.c
+++ b/phl/hal_g6/phy/bb/halbb_statistics.c
@@ -850,7 +850,7 @@ void halbb_ofdm_cnt_statistics(struct bb_info *bb, enum phl_phy_idx phy_idx)
 
 }
 
-void halbb_cck_tx_cnt_statistics(struct bb_info *bb)
+static void halbb_cck_tx_cnt_statistics(struct bb_info *bb)
 {
 	struct bb_stat_info *stat_t = &bb->bb_stat_i;
 	struct bb_tx_cnt_info *tx = &stat_t->bb_tx_cnt_i;
@@ -864,7 +864,7 @@ void halbb_cck_tx_cnt_statistics(struct bb_info *bb)
 	tx->cck_mac_txen = ret_value;
 }
 
-void halbb_ofdm_tx_cnt_statistics(struct bb_info *bb, enum phl_phy_idx phy_idx)
+static void halbb_ofdm_tx_cnt_statistics(struct bb_info *bb, enum phl_phy_idx phy_idx)
 {
 	struct bb_stat_info *stat_t = &bb->bb_stat_i;
 	struct bb_tx_cnt_info *tx = &stat_t->bb_tx_cnt_i;
@@ -1736,7 +1736,7 @@ void halbb_cr_cfg_stat_init(struct bb_info *bb)
 
 #if DVLP_DBCC
 
-void halbb_pmac_cck_tx_cnt(struct bb_info *bb)
+static void halbb_pmac_cck_tx_cnt(struct bb_info *bb)
 {
 	struct bb_stat_info *stat_t = &bb->bb_stat_i;
 	struct bb_tx_cnt_info *tx = &stat_t->bb_tx_cnt_i;
@@ -1747,7 +1747,7 @@ void halbb_pmac_cck_tx_cnt(struct bb_info *bb)
 	tx->cck_mac_txen = halbb_get_reg(bb, cr->ccktxen, cr->ccktxen_m);
 }
 
-void halbb_pmac_cck_cnt(struct bb_info *bb)
+static void halbb_pmac_cck_cnt(struct bb_info *bb)
 {
 	struct bb_stat_info *stat_t = &bb->bb_stat_i;
 	struct bb_fa_info *fa = &stat_t->bb_fa_i;
@@ -1839,7 +1839,7 @@ void halbb_pmac_cck_cnt(struct bb_info *bb)
 	}
 }
 
-void halbb_pmac_ofdm_tx_cnt(struct bb_info *bb)
+static void halbb_pmac_ofdm_tx_cnt(struct bb_info *bb)
 {
 	struct bb_stat_info *stat_t = &bb->bb_stat_i;
 	struct bb_tx_cnt_info *tx = &stat_t->bb_tx_cnt_i;
@@ -1853,7 +1853,7 @@ void halbb_pmac_ofdm_tx_cnt(struct bb_info *bb)
 	tx->ofdm_mac_txen = (ret_value & cr->ofdmtxen_m) >> 16;
 }
 
-void halbb_pmac_ofdm_cnt(struct bb_info *bb)
+static void halbb_pmac_ofdm_cnt(struct bb_info *bb)
 {
 	struct bb_stat_info *stat_t = &bb->bb_stat_i;
 	struct bb_fa_info *fa = &stat_t->bb_fa_i;
@@ -1991,7 +1991,7 @@ void halbb_pmac_ofdm_cnt(struct bb_info *bb)
 	cca->pop_cnt = ret_value;
 }
 
-void halbb_pmac_print_cnt(struct bb_info *bb, bool cck_en)
+static void halbb_pmac_print_cnt(struct bb_info *bb, bool cck_en)
 {
 	struct bb_stat_info *stat_t = &bb->bb_stat_i;
 	struct bb_fa_info *fa = &stat_t->bb_fa_i;
@@ -2110,7 +2110,7 @@ void halbb_pmac_print_cnt(struct bb_info *bb, bool cck_en)
 	BB_DBG(bb, DBG_FA_CNT, " *[DIG] IGI=%d\n", stat_info->igi_fa_rssi);
 }
 
-void halbb_pmac_print_cnt2(struct bb_info *bb)
+static void halbb_pmac_print_cnt2(struct bb_info *bb)
 {
 	struct bb_stat_info *stat_t = &bb->bb_stat_i;
 	struct bb_crc2_info *crc2 = &stat_t->bb_crc2_i;
@@ -2184,7 +2184,7 @@ void halbb_pmac_print_cnt2(struct bb_info *bb)
 #endif
 }
 
-void halbb_pmac_print_cnt3(struct bb_info *bb)
+static void halbb_pmac_print_cnt3(struct bb_info *bb)
 {
 	struct bb_stat_info *stat_t = &bb->bb_stat_i;
 	struct bb_fa_info *fa = &stat_t->bb_fa_i;
@@ -2277,7 +2277,7 @@ void halbb_pmac_print_cnt3(struct bb_info *bb)
 
 }
 
-void halbb_pmac_cnt_reg_reset(struct bb_info *bb, bool cck_en)
+static void halbb_pmac_cnt_reg_reset(struct bb_info *bb, bool cck_en)
 {
 	struct bb_stat_cr_info *cr = &bb->bb_stat_i.bb_stat_cr_i;
 

--- a/phl/hal_g6/phy/rf/halrf.c
+++ b/phl/hal_g6/phy/rf/halrf.c
@@ -389,7 +389,7 @@ enum rtw_hal_status halrf_scan_rx_dck_trigger(void *rf_void,
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
-enum rtw_hal_status halrf_rx_dck_tracking(void *rf_void)
+static enum rtw_hal_status halrf_rx_dck_tracking(void *rf_void)
 {
 	struct rf_info *rf = (struct rf_info *)rf_void;
 	struct rtw_hal_com_t *hal_i = rf->hal_com;
@@ -523,7 +523,7 @@ void halrf_lck_trigger(void *rf_void)
 		}
 }
 
-void halrf_lck_tracking(void *rf_void)
+static void halrf_lck_tracking(void *rf_void)
 {
 	struct rf_info *rf = (struct rf_info *)rf_void;
 	struct rtw_hal_com_t *hal_i = rf->hal_com;
@@ -635,7 +635,7 @@ void halrf_op5k_trigger_by_bw(void *rf_void, enum channel_width bw)
 #endif
 }
 
-void halrf_op5k_tracking(void *rf_void)
+static void halrf_op5k_tracking(void *rf_void)
 {
 	struct rf_info *rf = (struct rf_info *)rf_void;
 	struct rtw_hal_com_t *hal_i = rf->hal_com;
@@ -878,7 +878,7 @@ enum rtw_hal_status halrf_tssi_tracking_clean(void *rf_void, s16 power_dbm)
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
-enum rtw_hal_status halrf_tssi_ant_open(void *rf_void)
+static enum rtw_hal_status halrf_tssi_ant_open(void *rf_void)
 {
 	struct rf_info *rf = (struct rf_info *)rf_void;
 	struct rtw_hal_com_t *hal_i = rf->hal_com;
@@ -1559,7 +1559,7 @@ void halrf_kfree_get_info(void *rf_void, char input[][16], u32 *_used,
 	}
 }
 
-void halrf_txgapk_init(void *rf_void)
+static void halrf_txgapk_init(void *rf_void)
 {
 	struct rf_info *rf = (struct rf_info *)rf_void;
 	struct rtw_hal_com_t *hal_i = rf->hal_com;

--- a/phl/hal_g6/phy/rf/halrf_8852b/halrf_8852b.c
+++ b/phl/hal_g6/phy/rf/halrf_8852b/halrf_8852b.c
@@ -31,7 +31,7 @@ void halrf_adc_fifo_rst_8852b(struct rf_info *rf, enum phl_phy_idx phy_idx, u8 p
 	halrf_wreg(rf, 0x20fc, 0xffff0000, 0x3333);
 }
 
-bool halrf_bw_setting_8852b(struct rf_info *rf, enum rf_path path, enum channel_width bw, bool is_dav)
+static bool halrf_bw_setting_8852b(struct rf_info *rf, enum rf_path path, enum channel_width bw, bool is_dav)
 {
 	u32 rf_reg18 = 0;
 	u32 reg_reg18_addr = 0x0;
@@ -142,7 +142,7 @@ void halrf_lck_check_8852b(struct rf_info *rf)
 }
 #endif
 	
-bool halrf_set_s0_arfc18_8852b(struct rf_info *rf, u32 val)
+static bool halrf_set_s0_arfc18_8852b(struct rf_info *rf, u32 val)
 {
 	u32 temp, c = 1000;
 	bool timeout = false;
@@ -180,7 +180,7 @@ bool halrf_set_s0_arfc18_8852b(struct rf_info *rf, u32 val)
 	return timeout;
 }
 
-void halrf_lck_check_8852b(struct rf_info *rf)
+static void halrf_lck_check_8852b(struct rf_info *rf)
 {
 	u32 temp;
 
@@ -237,7 +237,7 @@ void halrf_lck_check_8852b(struct rf_info *rf)
 }
 
 
-void halrf_set_ch_8852b(struct rf_info *rf, u32 val) {
+static void halrf_set_ch_8852b(struct rf_info *rf, u32 val) {
 	bool timeout;
 	
 	timeout = halrf_set_s0_arfc18_8852b(rf, val);
@@ -245,7 +245,7 @@ void halrf_set_ch_8852b(struct rf_info *rf, u32 val) {
 		halrf_lck_check_8852b(rf);
 }
 
-bool halrf_ch_setting_8852b(struct rf_info *rf,   enum rf_path path, u8 central_ch,
+static bool halrf_ch_setting_8852b(struct rf_info *rf,   enum rf_path path, u8 central_ch,
 			    bool *is_2g_ch, bool is_dav)
 {
 	u32 rf_reg18 = 0;	
@@ -312,7 +312,7 @@ bool halrf_ctrl_ch_8852b(struct rf_info *rf,  u8 central_ch)
 	return true;
 }
 
-void halrf_set_lo_8852b(struct rf_info *rf, bool is_on, enum rf_path path)
+static void halrf_set_lo_8852b(struct rf_info *rf, bool is_on, enum rf_path path)
 {
 	if (is_on) {
 		halrf_rf_direct_cntrl_8852b(rf, path, false);
@@ -379,7 +379,7 @@ u8 halrf_kpath_8852b(struct rf_info *rf, enum phl_phy_idx phy_idx) {
 	}
 }
 
-void _rx_dck_info_8852b(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path, bool is_afe)
+static void _rx_dck_info_8852b(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path, bool is_afe)
 {
 	struct halrf_rx_dck_info *rx_dck = &rf->rx_dck;
 
@@ -486,7 +486,7 @@ void halrf_set_rx_dck_8852b(struct rf_info *rf, enum phl_phy_idx phy, enum rf_pa
 #endif
 }
 
-bool halrf_rx_dck_check_8852b(struct rf_info *rf, enum rf_path path)
+static bool halrf_rx_dck_check_8852b(struct rf_info *rf, enum rf_path path)
 {
 	u8 addr;
 	bool is_fail = false;
@@ -624,7 +624,7 @@ void halrf_rck_8852b(struct rf_info *rf, enum rf_path path)
 	       halrf_rrf(rf, path, 0x1b, MASKRF));
 }
 
-void iqk_backup_8852b(struct rf_info *rf, enum rf_path path) 
+static void iqk_backup_8852b(struct rf_info *rf, enum rf_path path) 
 {
 	return;
 }
@@ -662,7 +662,7 @@ void halrf_bf_config_rf_8852b(struct rf_info *rf)
 	halrf_wrf(rf, RF_PATH_B, 0xef, BIT(19), 0x0);
 }
 
-void halrf_set_dpd_backoff_8852b(struct rf_info *rf, enum phl_phy_idx phy)
+static void halrf_set_dpd_backoff_8852b(struct rf_info *rf, enum phl_phy_idx phy)
 {
 	struct halrf_dpk_info *dpk = &rf->dpk;
 	u8 tx_scale, ofdm_bkof, path, kpath;
@@ -689,7 +689,7 @@ void halrf_dpk_init_8852b(struct rf_info *rf)
 	halrf_set_dpd_backoff_8852b(rf, HW_PHY_0);
 }
 
-void halrf_set_rxbb_bw_8852b(struct rf_info *rf, enum channel_width bw, enum rf_path path)
+static void halrf_set_rxbb_bw_8852b(struct rf_info *rf, enum channel_width bw, enum rf_path path)
 {
 	halrf_write_fwofld_start(rf);
 

--- a/phl/hal_g6/phy/rf/halrf_8852b/halrf_8852b_api.c
+++ b/phl/hal_g6/phy/rf/halrf_8852b/halrf_8852b_api.c
@@ -374,7 +374,7 @@ void halrf_rxck_force_8852b(struct rf_info *rf, enum rf_path path, bool force, e
 }
 
 
-void halrf_arfc_si_reset_8852b(struct rf_info *rf, bool is_reset)
+static void halrf_arfc_si_reset_8852b(struct rf_info *rf, bool is_reset)
 {
 	u8 val;
 

--- a/phl/hal_g6/phy/rf/halrf_8852b/halrf_dack_8852b.c
+++ b/phl/hal_g6/phy/rf/halrf_8852b/halrf_dack_8852b.c
@@ -18,7 +18,7 @@
 #define t_avg 100
 
 
-void halrf_afe_init_8852b(struct rf_info *rf)
+static void halrf_afe_init_8852b(struct rf_info *rf)
 {
 	halrf_write_fwofld_start(rf);		/*FW Offload Start*/
 
@@ -36,11 +36,11 @@ void halrf_afe_init_8852b(struct rf_info *rf)
 
 	halrf_write_fwofld_end(rf);		/*FW Offload End*/
 }
-void halrf_dack_init_8852b(struct rf_info *rf)
+static void halrf_dack_init_8852b(struct rf_info *rf)
 {
 }
 
-void halrf_drck_8852b(struct rf_info *rf)
+static void halrf_drck_8852b(struct rf_info *rf)
 {
 	u32 c = 10000;
 	u32 rck_d;
@@ -82,7 +82,7 @@ void halrf_drck_8852b(struct rf_info *rf)
 	RF_DBG(rf, DBG_RF_DACK, "[DACK]0xc0cc = 0x%x\n", halrf_rreg(rf, 0xc0cc, MASKDWORD));
 }
 
-void halrf_addck_backup_8852b(struct rf_info *rf)
+static void halrf_addck_backup_8852b(struct rf_info *rf)
 {
 	struct halrf_dack_info *dack = &rf->dack;
 
@@ -95,7 +95,7 @@ void halrf_addck_backup_8852b(struct rf_info *rf)
 	dack->addck_d[1][1] = (u16)halrf_rreg(rf, 0xc1fc,0x003ff) ;
 }
 
-void halrf_addck_reload_8852b(struct rf_info *rf)
+static void halrf_addck_reload_8852b(struct rf_info *rf)
 {
 	struct halrf_dack_info *dack = &rf->dack;
 
@@ -117,7 +117,7 @@ void halrf_addck_reload_8852b(struct rf_info *rf)
 	halrf_write_fwofld_end(rf);		/*FW Offload End*/
 }
 
-void halrf_dack_backup_s0_8852b(struct rf_info *rf)
+static void halrf_dack_backup_s0_8852b(struct rf_info *rf)
 {
 	struct halrf_dack_info *dack = &rf->dack;
 	u8 i;
@@ -161,7 +161,7 @@ void halrf_dack_backup_s0_8852b(struct rf_info *rf)
 	dack->dadck_d[0][1] = (u8)halrf_rreg(rf, 0xc084, 0xff000000);
 }
 
-void halrf_dack_backup_s1_8852b(struct rf_info *rf)
+static void halrf_dack_backup_s1_8852b(struct rf_info *rf)
 {
 	struct halrf_dack_info *dack = &rf->dack;
 	u8 i;
@@ -204,7 +204,7 @@ void halrf_dack_backup_s1_8852b(struct rf_info *rf)
 	dack->dadck_d[1][1] = (u8)halrf_rreg(rf, 0xc184, 0xff000000);
 }
 
-void halrf_dack_reload_by_path_8852b(struct rf_info *rf, enum rf_path path)
+static void halrf_dack_reload_by_path_8852b(struct rf_info *rf, enum rf_path path)
 {
 	struct halrf_dack_info *dack = &rf->dack;
 	u8 i;
@@ -230,7 +230,7 @@ void halrf_dack_reload_by_path_8852b(struct rf_info *rf, enum rf_path path)
 	/*DADCK*/
 }
 
-void halrf_dack_reload_8852b(struct rf_info *rf, enum rf_path path)
+static void halrf_dack_reload_8852b(struct rf_info *rf, enum rf_path path)
 {
 	u32 oft;
 
@@ -248,7 +248,7 @@ void halrf_dack_reload_8852b(struct rf_info *rf, enum rf_path path)
 	halrf_wreg(rf, 0xc024 + oft, 0x3, 0x0);
 }
 
-void halrf_check_addc_8852b(struct rf_info *rf, enum rf_path path)
+static void halrf_check_addc_8852b(struct rf_info *rf, enum rf_path path)
 {
 	u32 temp, dc_re, dc_im;
 	u32 i, m, p, t;
@@ -338,7 +338,7 @@ void halrf_check_addc_8852b(struct rf_info *rf, enum rf_path path)
 		path, dc_re, dc_im);
 }
 
-void halrf_addck_8852b(struct rf_info *rf)
+static void halrf_addck_8852b(struct rf_info *rf)
 {
 	struct halrf_dack_info *dack = &rf->dack;
 	u32 c = 10000;
@@ -480,7 +480,7 @@ void halrf_addck_8852b(struct rf_info *rf)
 #endif
 }
 
-void halrf_check_dadc_8852b(struct rf_info *rf, enum rf_path path)
+static void halrf_check_dadc_8852b(struct rf_info *rf, enum rf_path path)
 {
 	halrf_write_fwofld_start(rf);		/*FW Offload Start*/
 
@@ -518,7 +518,7 @@ void halrf_check_dadc_8852b(struct rf_info *rf, enum rf_path path)
 	halrf_write_fwofld_end(rf);		/*FW Offload End*/
 }
 
-void halrf_dack_8852b_s0(struct rf_info *rf)
+static void halrf_dack_8852b_s0(struct rf_info *rf)
 {
 	struct halrf_dack_info *dack = &rf->dack;
 	u32 c = 10000;
@@ -622,7 +622,7 @@ void halrf_dack_8852b_s0(struct rf_info *rf)
 	halrf_wreg(rf, 0x12b8, BIT(30), 0x0);
 }
 
-void halrf_dack_8852b_s1(struct rf_info *rf)
+static void halrf_dack_8852b_s1(struct rf_info *rf)
 {
 	struct halrf_dack_info *dack = &rf->dack;
 	u32 c = 10000;
@@ -732,7 +732,7 @@ void halrf_dack_8852b(struct rf_info *rf)
 	halrf_dack_8852b_s1(rf);
 }
 
-void halrf_dack_dump_8852b(struct rf_info *rf)
+static void halrf_dack_dump_8852b(struct rf_info *rf)
 {
 	struct halrf_dack_info *dack = &rf->dack;
 	u8 i;

--- a/phl/hal_g6/phy/rf/halrf_8852b/halrf_dpk_8852b.c
+++ b/phl/hal_g6/phy/rf/halrf_8852b/halrf_dpk_8852b.c
@@ -27,7 +27,7 @@
 
 /*8852B DPK ver:0xf 2022902*/
 
-void _dpk_bkup_kip_8852b(
+static void _dpk_bkup_kip_8852b(
 	struct rf_info *rf,
 	u32 *reg,
 	u32 reg_bkup[][DPK_KIP_REG_NUM_8852B],
@@ -42,7 +42,7 @@ void _dpk_bkup_kip_8852b(
 	}
 }
 
-void _dpk_bkup_bb_8852b(
+static void _dpk_bkup_bb_8852b(
 	struct rf_info *rf,
 	u32 *reg,
 	u32 reg_bkup[DPK_BB_REG_NUM_8852B])
@@ -56,7 +56,7 @@ void _dpk_bkup_bb_8852b(
 	}
 }
 
-void _dpk_bkup_rf_8852b(
+static void _dpk_bkup_rf_8852b(
 	struct rf_info *rf,
 	u32 *rf_reg,
 	u32 rf_bkup[][DPK_RF_REG_NUM_8852B],
@@ -72,7 +72,7 @@ void _dpk_bkup_rf_8852b(
 	}
 }
 
-void _dpk_reload_kip_8852b(
+static void _dpk_reload_kip_8852b(
 	struct rf_info *rf,
 	u32 *reg,
 	u32 reg_bkup[][DPK_KIP_REG_NUM_8852B],
@@ -88,7 +88,7 @@ void _dpk_reload_kip_8852b(
 	}
 }
 
-void _dpk_reload_bb_8852b(
+static void _dpk_reload_bb_8852b(
 	struct rf_info *rf,
 	u32 *reg,
 	u32 reg_bkup[DPK_BB_REG_NUM_8852B]) 
@@ -103,7 +103,7 @@ void _dpk_reload_bb_8852b(
 	}
 }
 
-void _dpk_reload_rf_8852b(
+static void _dpk_reload_rf_8852b(
 	struct rf_info *rf,
 	u32 *rf_reg,
 	u32 rf_bkup[][DPK_RF_REG_NUM_8852B],
@@ -119,7 +119,7 @@ void _dpk_reload_rf_8852b(
 	}
 }
 
-u8 _dpk_one_shot_8852b(
+static u8 _dpk_one_shot_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path,
@@ -186,7 +186,7 @@ u8 _dpk_one_shot_8852b(
 		return 0;
 }
 
-void _dpk_information_8852b(
+static void _dpk_information_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path)
@@ -209,7 +209,7 @@ void _dpk_information_8852b(
 	        (rf->hal_com->dev_hw_cap.nb_config == CHANNEL_WIDTH_5 ? "5M" : "20M"))));
 }
 
-void _dpk_bb_afe_setting_8852b(
+static void _dpk_bb_afe_setting_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path,
@@ -264,7 +264,7 @@ void _dpk_bb_afe_setting_8852b(
 	//halrf_write_fwofld_end(rf);		/*FW Offload End*/
 }
 
-void _dpk_bb_afe_restore_8852b(
+static void _dpk_bb_afe_restore_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path,
@@ -304,7 +304,7 @@ void _dpk_bb_afe_restore_8852b(
 	}
 }
 
-void _dpk_tssi_pause_8852b(
+static void _dpk_tssi_pause_8852b(
 	struct rf_info *rf,
 	enum rf_path path,
 	bool is_pause)
@@ -315,7 +315,7 @@ void _dpk_tssi_pause_8852b(
 	       is_pause ? "pause" : "resume");
 }
 
-void _dpk_rx_dck_8852b(
+static void _dpk_rx_dck_8852b(
 	struct rf_info *rf,
 	enum rf_path path)
 {
@@ -330,7 +330,7 @@ void _dpk_rx_dck_8852b(
 	RF_DBG(rf, DBG_RF_DPK, "[DPK] S%d RXDCK\n", path);
 }
 
-void _dpk_tpg_sel_8852b(
+static void _dpk_tpg_sel_8852b(
 	struct rf_info *rf,
 	enum rf_path path,
 	u8 kidx)
@@ -349,7 +349,7 @@ void _dpk_tpg_sel_8852b(
 	       (dpk->bp[path][kidx].bw == CHANNEL_WIDTH_40 ? "40M" : "20M"));
 }
 
-void _dpk_kip_pwr_clk_on_8852b(
+static void _dpk_kip_pwr_clk_on_8852b(
 	struct rf_info *rf,
 	enum rf_path path)
 {
@@ -362,7 +362,7 @@ void _dpk_kip_pwr_clk_on_8852b(
 	//RF_DBG(rf, DBG_RF_DPK, "[DPK] KIP Power/CLK on\n");
 }
 
-void _dpk_kip_preset_8852b(
+static void _dpk_kip_preset_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path,
@@ -372,7 +372,7 @@ void _dpk_kip_preset_8852b(
 	_dpk_one_shot_8852b(rf, phy, path, KIP_PRESET);
 }
 
-void _dpk_kip_restore_8852b(
+static void _dpk_kip_restore_8852b(
 	struct rf_info *rf,
 	enum rf_path path)
 {
@@ -391,7 +391,7 @@ void _dpk_kip_restore_8852b(
 	RF_DBG(rf, DBG_RF_DPK, "[DPK] S%d restore KIP\n", path);
 }
 
-void _dpk_kip_set_txagc_8852b(
+static void _dpk_kip_set_txagc_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path,
@@ -409,7 +409,7 @@ void _dpk_kip_set_txagc_8852b(
 	RF_DBG(rf, DBG_RF_DPK, "[DPK] set TXAGC = 0x%x\n", txagc);
 }
 
-void _dpk_kip_set_rxagc_8852b(
+static void _dpk_kip_set_rxagc_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path)
@@ -428,7 +428,7 @@ void _dpk_kip_set_rxagc_8852b(
 #endif
 }
 
-void _dpk_read_rxsram_8852b(
+static void _dpk_read_rxsram_8852b(
 	struct rf_info *rf)
 {
 	u32 addr;
@@ -446,7 +446,7 @@ void _dpk_read_rxsram_8852b(
 	halrf_wreg(rf, 0x8074, BIT(31), 0x0);	/*rxsram_ctrl_sel*/
 }
 
-void _dpk_lbk_rxiqk_8852b(
+static void _dpk_lbk_rxiqk_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path,
@@ -507,7 +507,7 @@ void _dpk_lbk_rxiqk_8852b(
 //	halrf_write_fwofld_end(rf);		/*FW Offload End*/
 }
 
-void _dpk_get_thermal_8852b(struct rf_info *rf, u8 kidx, enum rf_path path)
+static void _dpk_get_thermal_8852b(struct rf_info *rf, u8 kidx, enum rf_path path)
 {
 	struct halrf_dpk_info *dpk = &rf->dpk;
 
@@ -520,7 +520,7 @@ void _dpk_get_thermal_8852b(struct rf_info *rf, u8 kidx, enum rf_path path)
 	RF_DBG(rf, DBG_RF_DPK, "[DPK] thermal@DPK (by RFC)= 0x%x\n", dpk->bp[path][kidx].ther_dpk);
 }
 
-void _dpk_tx_mapping_8852b(
+static void _dpk_tx_mapping_8852b(
 	struct rf_info *rf,
 	enum rf_path path,
 	u8 kidx,
@@ -546,7 +546,7 @@ void _dpk_tx_mapping_8852b(
 	halrf_wrf(rf, path, 0x11, MASKRF, tx_gain);
 }
 
-void _dpk_rf_setting_8852b(
+static void _dpk_rf_setting_8852b(
 	struct rf_info *rf,
 	u8 gain,
 	enum rf_path path,
@@ -589,7 +589,7 @@ void _dpk_rf_setting_8852b(
 #endif
 }
 
-void _dpk_manual_txcfir_8852b(
+static void _dpk_manual_txcfir_8852b(
 	struct rf_info *rf,
 	enum rf_path path,
 	bool is_manual)
@@ -620,7 +620,7 @@ void _dpk_manual_txcfir_8852b(
 	}
 }
 
-void _dpk_bypass_rxcfir_8852b(
+static void _dpk_bypass_rxcfir_8852b(
 	struct rf_info *rf,
 	enum rf_path path,
 	bool is_bypass)
@@ -647,7 +647,7 @@ void _dpk_bypass_rxcfir_8852b(
 //	halrf_write_fwofld_end(rf);		/*FW Offload End*/
 }
 
-void _dpk_table_select_8852b(
+static void _dpk_table_select_8852b(
 	struct rf_info *rf,
 	enum rf_path path,
 	u8 kidx,
@@ -663,7 +663,7 @@ void _dpk_table_select_8852b(
 		kidx, gain, val);
 }
 
-bool _dpk_sync_check_8852b(
+static bool _dpk_sync_check_8852b(
 	struct rf_info *rf,
 	enum rf_path path,
 	u8 kidx)
@@ -708,7 +708,7 @@ bool _dpk_sync_check_8852b(
 		return false;
 }
 
-void _dpk_sync_8852b(
+static void _dpk_sync_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path,
@@ -723,7 +723,7 @@ void _dpk_sync_8852b(
 //	return _dpk_sync_check_8852b(rf, path, kidx); /*1= fail*/
 }
 
-u16 _dpk_dgain_read_8852b(
+static u16 _dpk_dgain_read_8852b(
 	struct rf_info *rf)
 {
 	u16 dgain = 0x0;
@@ -737,7 +737,7 @@ u16 _dpk_dgain_read_8852b(
 	return dgain;
 }
 
-s8 _dpk_dgain_mapping_8852b(
+static s8 _dpk_dgain_mapping_8852b(
 	struct rf_info *rf,
 	u16 dgain)
 {
@@ -786,7 +786,7 @@ s8 _dpk_dgain_mapping_8852b(
 	return offset;
 }
 
-u8 _dpk_pas_check_8852b(
+static u8 _dpk_pas_check_8852b(
 	struct rf_info *rf)
 {
 	u8 fail = 0;
@@ -804,7 +804,7 @@ u8 _dpk_pas_check_8852b(
 	return fail;
 }
 
-u8 _dpk_gainloss_read_8852b(
+static u8 _dpk_gainloss_read_8852b(
 	struct rf_info *rf)
 {
 	u8 result;
@@ -819,7 +819,7 @@ u8 _dpk_gainloss_read_8852b(
 	return result;
 }
 
-void _dpk_gainloss_8852b(
+static void _dpk_gainloss_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path,
@@ -838,7 +838,7 @@ void _dpk_gainloss_8852b(
 //	halrf_write_fwofld_end(rf);		/*FW Offload End*/
 }
 
-u8 _dpk_set_offset_8852b(
+static u8 _dpk_set_offset_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path,
@@ -867,7 +867,7 @@ u8 _dpk_set_offset_8852b(
 	return txagc;
 }
 
-u8 _dpk_pas_read_8852b(
+static u8 _dpk_pas_read_8852b(
 	struct rf_info *rf,
 	u8 is_check)
 {
@@ -914,7 +914,7 @@ u8 _dpk_pas_read_8852b(
 		return 0;
 }
 
-u8 _dpk_agc_8852b(
+static u8 _dpk_agc_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path,
@@ -1079,7 +1079,7 @@ u8 _dpk_agc_8852b(
 	return tmp_txagc;
 }
 
-void _dpk_set_mdpd_para_8852b(
+static void _dpk_set_mdpd_para_8852b(
 	struct rf_info *rf,
 	enum rf_path path,
 	u8 order)
@@ -1116,7 +1116,7 @@ void _dpk_set_mdpd_para_8852b(
 		(order == 0x1 ? "(5,3,0)" : "(5,0,0)"));
 }
 
-void _dpk_idl_mpa_8852b(
+static void _dpk_idl_mpa_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path,
@@ -1140,7 +1140,7 @@ void _dpk_idl_mpa_8852b(
 	//halrf_write_fwofld_end(rf);		/*FW Offload End*/
 }
 
-u8 _dpk_order_convert_8852b(
+static u8 _dpk_order_convert_8852b(
 	struct rf_info *rf)
 {
 	u8 val;
@@ -1158,7 +1158,7 @@ u8 _dpk_order_convert_8852b(
 	return val;
 }
 
-u8 _dpk_pwsf_addr_cal_8852b(
+static u8 _dpk_pwsf_addr_cal_8852b(
 	struct rf_info *rf,
 	u8 t1,
 	u8 t2)
@@ -1173,7 +1173,7 @@ u8 _dpk_pwsf_addr_cal_8852b(
 	return addr;
 }
 
-void _dpk_gs_normalize_8852b(
+static void _dpk_gs_normalize_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path,
@@ -1218,7 +1218,7 @@ void _dpk_gs_normalize_8852b(
 
 }
 
-void _dpk_fill_result_8852b(
+static void _dpk_fill_result_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path,
@@ -1331,7 +1331,7 @@ void _dpk_fill_result_8852b(
 	//_dpk_gs_normalize_8852b(rf, path, txagc, gs, pwsf);
 }
 
-void _dpk_coef_read_8852b(
+static void _dpk_coef_read_8852b(
 	struct rf_info *rf,
 	enum rf_path path,
 	u8 kidx,
@@ -1355,7 +1355,7 @@ void _dpk_coef_read_8852b(
 	halrf_wreg(rf, 0x81d8 + (path << 8), MASKDWORD, 0x00000000);
 }
 
-bool _dpk_reload_check_8852b(
+static bool _dpk_reload_check_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path)
@@ -1380,7 +1380,7 @@ bool _dpk_reload_check_8852b(
 	return is_reload;
 }
 
-void _dpk_main_8852b(
+static void _dpk_main_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	enum rf_path path,
@@ -1454,7 +1454,7 @@ _error:
 //	halrf_write_fwofld_end(rf);		/*FW Offload End*/
 }
 
-void _dpk_cal_select_8852b(
+static void _dpk_cal_select_8852b(
 	struct rf_info *rf,
 	bool force,
 	enum phl_phy_idx phy,
@@ -1520,7 +1520,7 @@ void _dpk_cal_select_8852b(
 	halrf_write_fwofld_end(rf);		/*FW Offload End*/
 }
 
-u8 _dpk_bypass_check_8852b(
+static u8 _dpk_bypass_check_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy)
 {
@@ -1543,7 +1543,7 @@ u8 _dpk_bypass_check_8852b(
 	return result;
 }
 
-void _dpk_force_bypass_8852b(
+static void _dpk_force_bypass_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy)
 {

--- a/phl/hal_g6/phy/rf/halrf_8852b/halrf_hwimg_8852b.c
+++ b/phl/hal_g6/phy/rf/halrf_8852b/halrf_hwimg_8852b.c
@@ -26,7 +26,7 @@
 #include "halrf_hwimg_raw_data_8852b.h"
 #include "halrf_hwimg_nctl_raw_data_8852b.h"
 
-bool halrf_check_cond_8852b(struct rf_info *rf, u32 para_opt)
+static bool halrf_check_cond_8852b(struct rf_info *rf, u32 para_opt)
 {
 	struct rtw_hal_com_t *hal = rf->hal_com;
 	u32 cv_ver = (hal->cv == CAV) ? 15 : hal->cv;
@@ -67,7 +67,7 @@ halrf_get_8852b_radio_reg_ver(void)
 	return RF_RELEASE_VERSION_8852B;
 }
 
-void halrf_config_8852b_store_radio_a_reg(struct rf_info *rf,
+static void halrf_config_8852b_store_radio_a_reg(struct rf_info *rf,
 					u32 addr, u32 data)
 {
 	struct halrf_radio_info *radio = &rf->radio_info;
@@ -100,7 +100,7 @@ void halrf_config_8852b_store_radio_a_reg(struct rf_info *rf,
 	radio->write_times_a++;
 }
 
-void halrf_config_8852b_store_radio_b_reg(struct rf_info *rf,
+static void halrf_config_8852b_store_radio_b_reg(struct rf_info *rf,
 					u32 addr, u32 data)
 {
 	struct halrf_radio_info *radio = &rf->radio_info;
@@ -135,7 +135,7 @@ void halrf_config_8852b_store_radio_b_reg(struct rf_info *rf,
 }
 
 
-void halrf_config_8852b_write_radio_a_reg_to_fw(struct rf_info *rf)
+static void halrf_config_8852b_write_radio_a_reg_to_fw(struct rf_info *rf)
 {
 	struct halrf_radio_info *radio = &rf->radio_info;
 	u8 page = (u8)(radio->write_times_a / RADIO_TO_FW_DATA_SIZE);
@@ -155,7 +155,7 @@ void halrf_config_8852b_write_radio_a_reg_to_fw(struct rf_info *rf)
 	RF_DBG(rf, DBG_RF_INIT, "page=%d   len=%d\n", i, len / 4);
 }
 
-void halrf_config_8852b_write_radio_b_reg_to_fw(struct rf_info *rf)
+static void halrf_config_8852b_write_radio_b_reg_to_fw(struct rf_info *rf)
 {
 	struct halrf_radio_info *radio = &rf->radio_info;
 	u8 page = (u8)(radio->write_times_b / RADIO_TO_FW_DATA_SIZE);
@@ -220,7 +220,7 @@ void halrf_config_8852b_nctl_reg(struct rf_info *rf)
 
 }
 
-bool halrf_sel_headline_8852b(struct rf_info *rf, u32 *array, u32 array_len,
+static bool halrf_sel_headline_8852b(struct rf_info *rf, u32 *array, u32 array_len,
 			      u8 *headline_size, u8 *headline_idx)
 {
 	bool case_match = false;
@@ -330,7 +330,7 @@ bool halrf_sel_headline_8852b(struct rf_info *rf, u32 *array, u32 array_len,
 	return false;
 }
 
-void halrf_flag_2_default_8852b(bool *is_matched, bool *find_target)
+static void halrf_flag_2_default_8852b(bool *is_matched, bool *find_target)
 {
 	*is_matched = true;
 	*find_target = false;
@@ -1190,7 +1190,7 @@ halrf_config_8852b_store_pwr_track(struct rf_info *rf,
 	}
 }
 
-void
+static void
 _halrf_config_rfe_xtal_track_table_8852b(struct rf_info *rf)
 {
 #if 0

--- a/phl/hal_g6/phy/rf/halrf_8852b/halrf_iqk_8852b.c
+++ b/phl/hal_g6/phy/rf/halrf_8852b/halrf_iqk_8852b.c
@@ -90,7 +90,7 @@ const u32 array_restore_nondbcc_path01_8852b[] = {
 };
 
 __iram_func__
-void iqk_backup_rf0_8852b(
+static void iqk_backup_rf0_8852b(
 	struct rf_info *rf, u8 path,
 	u32 backup_rf0[rf_reg_num_8852b],
 	u32 backup_rf_reg0[rf_reg_num_8852b])
@@ -108,7 +108,7 @@ void iqk_backup_rf0_8852b(
 }
 
 __iram_func__
-void iqk_backup_rf1_8852b(
+static void iqk_backup_rf1_8852b(
 	struct rf_info *rf, u8 path,
 	u32 backup_rf1[rf_reg_num_8852b],
 	u32 backup_rf_reg1[rf_reg_num_8852b])
@@ -127,7 +127,7 @@ void iqk_backup_rf1_8852b(
 }
 
 __iram_func__
-void iqk_restore_rf0_8852b(
+static void iqk_restore_rf0_8852b(
 	struct rf_info *rf, u8 path,
 	u32 backup_rf0[rf_reg_num_8852b],
 	u32 backup_rf_reg0[rf_reg_num_8852b])
@@ -147,7 +147,7 @@ void iqk_restore_rf0_8852b(
 }
 
 __iram_func__
-void iqk_restore_rf1_8852b(
+static void iqk_restore_rf1_8852b(
 	struct rf_info *rf, u8 path,
 	u32 backup_rf1[rf_reg_num_8852b],
 	u32 backup_rf_reg1[rf_reg_num_8852b])

--- a/phl/hal_g6/phy/rf/halrf_8852b/halrf_kfree_8852b.c
+++ b/phl/hal_g6/phy/rf/halrf_8852b/halrf_kfree_8852b.c
@@ -16,7 +16,7 @@
 
 #ifdef RF_8852B_SUPPORT
 
-void _halrf_get_total_efuse_8852b(struct rf_info *rf,
+static void _halrf_get_total_efuse_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy)
 {
 	struct halrf_kfree_info *kfree = &rf->kfree_info;
@@ -36,7 +36,7 @@ void _halrf_get_total_efuse_8852b(struct rf_info *rf,
 			__func__, i + HIDE_EFUSE_START_ADDR_8852B, kfree->efuse_content[i]);
 }
 
-u8 _halrf_get_1byte_efuse_8852b(struct rf_info *rf, u32 addr, u8 *value)
+static u8 _halrf_get_1byte_efuse_8852b(struct rf_info *rf, u32 addr, u8 *value)
 {
 	struct halrf_kfree_info *kfree = &rf->kfree_info;
 
@@ -51,7 +51,7 @@ u8 _halrf_get_1byte_efuse_8852b(struct rf_info *rf, u32 addr, u8 *value)
 	return *value;
 }
 
-s8 _halrf_efuse_exchange_8852b(struct rf_info *rf, u8 value, u8 mask)
+static s8 _halrf_efuse_exchange_8852b(struct rf_info *rf, u8 value, u8 mask)
 {
 	s8 tmp = 0;
 
@@ -70,7 +70,7 @@ s8 _halrf_efuse_exchange_8852b(struct rf_info *rf, u8 value, u8 mask)
 	return tmp;
 }
 
-void _halrf_set_thermal_trim_8852b(struct rf_info *rf,
+static void _halrf_set_thermal_trim_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy)
 {
 	u8 thermal_a = 0xff, thermal_b = 0xff, tmp = 0;
@@ -108,7 +108,7 @@ void _halrf_set_thermal_trim_8852b(struct rf_info *rf,
 	halrf_wrf(rf, RF_PATH_B, 0x43, 0x000f0000, thermal_b & 0xf);
 }
 
-void _halrf_set_pa_bias_trim_8852b(struct rf_info *rf,
+static void _halrf_set_pa_bias_trim_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy)
 {
 	u8 pa_bias_a = 0xff, pa_bias_b = 0xff, tmp = 0;
@@ -153,7 +153,7 @@ void _halrf_set_pa_bias_trim_8852b(struct rf_info *rf,
 	halrf_wrf(rf, RF_PATH_B, 0x60, 0x000f0000, pa_bias_b_5g);
 }
 
-void _halrf_get_tssi_trim_8852b(struct rf_info *rf,
+static void _halrf_get_tssi_trim_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy)
 {
 	struct halrf_tssi_info *tssi = &rf->tssi;

--- a/phl/hal_g6/phy/rf/halrf_8852b/halrf_ops_rtl8852b.h
+++ b/phl/hal_g6/phy/rf/halrf_8852b/halrf_ops_rtl8852b.h
@@ -23,7 +23,7 @@
  *
  *****************************************************************************/
 #ifndef __HALRF_OPS_RTL8852B_H__
-#define __HALRF_OPS_RTL8852B__
+#define __HALRF_OPS_RTL8852B_H__
 #ifdef RF_8852B_SUPPORT
 
 

--- a/phl/hal_g6/phy/rf/halrf_8852b/halrf_psd_8852b.c
+++ b/phl/hal_g6/phy/rf/halrf_8852b/halrf_psd_8852b.c
@@ -16,7 +16,7 @@
 
 #ifdef RF_8852B_SUPPORT
 
-void _halrf_psd_backup_bb_registers_8852b(
+static void _halrf_psd_backup_bb_registers_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	u32 *reg,
@@ -33,7 +33,7 @@ void _halrf_psd_backup_bb_registers_8852b(
 	}
 }
 
-void _halrf_psd_reload_bb_registers_8852b(
+static void _halrf_psd_reload_bb_registers_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	u32 *reg,

--- a/phl/hal_g6/phy/rf/halrf_8852b/halrf_set_pwr_table_8852b.c
+++ b/phl/hal_g6/phy/rf/halrf_8852b/halrf_set_pwr_table_8852b.c
@@ -16,7 +16,7 @@
 
 #ifdef RF_8852B_SUPPORT
 
-s8 _halrf_avg_power_8852b(struct rf_info *rf, enum phl_phy_idx phy, s8 *value, s8 n)
+static s8 _halrf_avg_power_8852b(struct rf_info *rf, enum phl_phy_idx phy, s8 *value, s8 n)
 {
 	u8 i;
 	s16 total = 0;
@@ -33,7 +33,7 @@ s8 _halrf_avg_power_8852b(struct rf_info *rf, enum phl_phy_idx phy, s8 *value, s
 	return (s8)total;
 }
 
-void _halrf_bub_sort_8852b(struct rf_info *rf, enum phl_phy_idx phy, s8 *data, u32 n)
+static void _halrf_bub_sort_8852b(struct rf_info *rf, enum phl_phy_idx phy, s8 *data, u32 n)
 {
 	s32 i, j, sp;
 	s8 temp;
@@ -60,7 +60,7 @@ void _halrf_bub_sort_8852b(struct rf_info *rf, enum phl_phy_idx phy, s8 *data, u
 		RF_DBG(rf, DBG_RF_POWER, "<=== %s  After data[%d]=%d\n", __func__, k, data[k]);
 }
 
-bool halrf_set_power_by_rate_to_struct_8852b(struct rf_info *rf, enum phl_phy_idx phy)
+static bool halrf_set_power_by_rate_to_struct_8852b(struct rf_info *rf, enum phl_phy_idx phy)
 {
 	struct rtw_tpu_info *tpu = &rf->hal_com->band[phy].rtw_tpu_i;
 	struct rtw_tpu_pwr_by_rate_info *rate = &tpu->rtw_tpu_pwr_by_rate_i;
@@ -179,7 +179,7 @@ void halrf_set_fix_power_to_struct_8852b(struct rf_info *rf, enum phl_phy_idx ph
 	halrf_mac_write_pwr_limit_rua_reg(rf, phy);
 }
 
-void halrf_get_power_limit_to_struct_20m_8852b(struct rf_info *rf, enum phl_phy_idx phy)
+static void halrf_get_power_limit_to_struct_20m_8852b(struct rf_info *rf, enum phl_phy_idx phy)
 {
 	struct rtw_tpu_pwr_imt_info *lmt = &rf->hal_com->band[phy].rtw_tpu_i.rtw_tpu_pwr_imt_i;
 	struct rtw_hal_com_t *hal = rf->hal_com;
@@ -254,7 +254,7 @@ void halrf_get_power_limit_to_struct_20m_8852b(struct rf_info *rf, enum phl_phy_
 		halrf_get_power_limit(rf, phy, RF_PATH_A, RTW_DATA_RATE_HE_NSS1_MCS7, PW_LMT_BW_20M, PW_LMT_BF, PW_LMT_PH_2T, ch) / 2;
 }
 
-void halrf_get_power_limit_to_struct_40m_8852b(struct rf_info *rf, enum phl_phy_idx phy)
+static void halrf_get_power_limit_to_struct_40m_8852b(struct rf_info *rf, enum phl_phy_idx phy)
 {
 	struct rtw_tpu_pwr_imt_info *lmt = &rf->hal_com->band[phy].rtw_tpu_i.rtw_tpu_pwr_imt_i;
 	struct rtw_hal_com_t *hal = rf->hal_com;
@@ -358,7 +358,7 @@ void halrf_get_power_limit_to_struct_40m_8852b(struct rf_info *rf, enum phl_phy_
 		halrf_get_power_limit(rf, phy, RF_PATH_A, RTW_DATA_RATE_HE_NSS1_MCS7, PW_LMT_BW_40M, PW_LMT_BF, PW_LMT_PH_2T, ch) / 2;
 }
 
-void halrf_get_power_limit_to_struct_80m_8852b(struct rf_info *rf, enum phl_phy_idx phy)
+static void halrf_get_power_limit_to_struct_80m_8852b(struct rf_info *rf, enum phl_phy_idx phy)
 {
 	struct rtw_tpu_pwr_imt_info *lmt = &rf->hal_com->band[phy].rtw_tpu_i.rtw_tpu_pwr_imt_i;
 	struct rtw_hal_com_t *hal = rf->hal_com;
@@ -523,7 +523,7 @@ void halrf_get_power_limit_to_struct_80m_8852b(struct rf_info *rf, enum phl_phy_
 	lmt->pwr_lmt_40m_0p5[PW_LMT_PH_2T][PW_LMT_BF] = tmp;
 }
 
-bool halrf_set_power_limit_to_struct_8852b(struct rf_info *rf, enum phl_phy_idx phy)
+static bool halrf_set_power_limit_to_struct_8852b(struct rf_info *rf, enum phl_phy_idx phy)
 {
 	struct rtw_tpu_pwr_imt_info *lmt = &rf->hal_com->band[phy].rtw_tpu_i.rtw_tpu_pwr_imt_i;
 	u8 bw = rf->hal_com->band[phy].cur_chandef.bw;
@@ -588,7 +588,7 @@ bool halrf_set_power_limit_to_struct_8852b(struct rf_info *rf, enum phl_phy_idx 
 	return true;
 }
 
-void halrf_get_power_limit_ru_to_struct_20m_8852b(struct rf_info *rf, enum phl_phy_idx phy)
+static void halrf_get_power_limit_ru_to_struct_20m_8852b(struct rf_info *rf, enum phl_phy_idx phy)
 {
 	struct rtw_tpu_info *tpu = &rf->hal_com->band[phy].rtw_tpu_i;
 	struct rtw_hal_com_t *hal = rf->hal_com;
@@ -623,7 +623,7 @@ void halrf_get_power_limit_ru_to_struct_20m_8852b(struct rf_info *rf, enum phl_p
 		halrf_get_power_limit_ru(rf, phy, RF_PATH_A, RTW_DATA_RATE_HE_NSS1_MCS7, PW_LMT_RU_BW_RU106, PW_LMT_PH_2T, ch) / 2;
 }
 
-void halrf_get_power_limit_ru_to_struct_40m_8852b(struct rf_info *rf, enum phl_phy_idx phy)
+static void halrf_get_power_limit_ru_to_struct_40m_8852b(struct rf_info *rf, enum phl_phy_idx phy)
 {
 	struct rtw_tpu_info *tpu = &rf->hal_com->band[phy].rtw_tpu_i;
 	struct rtw_hal_com_t *hal = rf->hal_com;
@@ -676,7 +676,7 @@ void halrf_get_power_limit_ru_to_struct_40m_8852b(struct rf_info *rf, enum phl_p
 		halrf_get_power_limit_ru(rf, phy, RF_PATH_A, RTW_DATA_RATE_HE_NSS1_MCS7, PW_LMT_RU_BW_RU106, PW_LMT_PH_2T, ch + 2) / 2;
 }
 
-void halrf_get_power_limit_ru_to_struct_80m_8852b(struct rf_info *rf, enum phl_phy_idx phy)
+static void halrf_get_power_limit_ru_to_struct_80m_8852b(struct rf_info *rf, enum phl_phy_idx phy)
 {
 	struct rtw_tpu_info *tpu = &rf->hal_com->band[phy].rtw_tpu_i;
 	struct rtw_hal_com_t *hal = rf->hal_com;
@@ -765,7 +765,7 @@ void halrf_get_power_limit_ru_to_struct_80m_8852b(struct rf_info *rf, enum phl_p
 		halrf_get_power_limit_ru(rf, phy, RF_PATH_A, RTW_DATA_RATE_HE_NSS1_MCS7, PW_LMT_RU_BW_RU106, PW_LMT_PH_2T, ch + 6) / 2;
 }
 
-bool halrf_set_power_limit_ru_to_struct_8852b(struct rf_info *rf, enum phl_phy_idx phy)
+static bool halrf_set_power_limit_ru_to_struct_8852b(struct rf_info *rf, enum phl_phy_idx phy)
 {
 	struct rtw_tpu_info *tpu = &rf->hal_com->band[phy].rtw_tpu_i;
 	u8 bw = rf->hal_com->band[phy].cur_chandef.bw;
@@ -800,7 +800,7 @@ bool halrf_set_power_limit_ru_to_struct_8852b(struct rf_info *rf, enum phl_phy_i
 	return true;
 }
 
-void _halrf_set_tx_shape_8852b(struct rf_info *rf, enum phl_phy_idx phy)
+static void _halrf_set_tx_shape_8852b(struct rf_info *rf, enum phl_phy_idx phy)
 {
 	struct halrf_pwr_info *pwr = &rf->pwr_info;
 	struct rtw_tpu_info *tpu = &rf->hal_com->band[phy].rtw_tpu_i;
@@ -881,7 +881,7 @@ void _halrf_set_tx_shape_8852b(struct rf_info *rf, enum phl_phy_idx phy)
 	}
 }
 
-bool _halrf_set_power_8852b(struct rf_info *rf, enum phl_phy_idx phy,
+static bool _halrf_set_power_8852b(struct rf_info *rf, enum phl_phy_idx phy,
 	enum phl_pwr_table pwr_table)
 {
 	struct halrf_pwr_info *pwr = &rf->pwr_info;
@@ -967,7 +967,7 @@ bool _halrf_set_power_8852b(struct rf_info *rf, enum phl_phy_idx phy,
 	return true;
 }
 
-void _halrf_set_ext_power_diff_8852b(struct rf_info *rf, enum phl_phy_idx phy)
+static void _halrf_set_ext_power_diff_8852b(struct rf_info *rf, enum phl_phy_idx phy)
 {
 #ifdef SPF_PHL_RF_019_SAR
 	struct rtw_tpu_info *tpu = &rf->hal_com->band[phy].rtw_tpu_i;

--- a/phl/hal_g6/phy/rf/halrf_8852b/halrf_tssi_8852b.c
+++ b/phl/hal_g6/phy/rf/halrf_8852b/halrf_tssi_8852b.c
@@ -16,7 +16,7 @@
 
 #ifdef RF_8852B_SUPPORT
 
-void _tssi_backup_bb_registers_8852b(
+static void _tssi_backup_bb_registers_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	u32 *reg,
@@ -33,7 +33,7 @@ void _tssi_backup_bb_registers_8852b(
 	}
 }
 
-void _tssi_reload_bb_registers_8852b(
+static void _tssi_reload_bb_registers_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	u32 *reg,
@@ -51,7 +51,7 @@ void _tssi_reload_bb_registers_8852b(
 	}
 }
 
-u8 _halrf_ch_to_idx_8852b(struct rf_info *rf, u8 channel)
+static u8 _halrf_ch_to_idx_8852b(struct rf_info *rf, u8 channel)
 {
 	u8	channelIndex;
 
@@ -69,7 +69,7 @@ u8 _halrf_ch_to_idx_8852b(struct rf_info *rf, u8 channel)
 	return channelIndex;
 }
 
-u8 _halrf_idx_to_ch_8852b(struct rf_info *rf, u8 idx)
+static u8 _halrf_idx_to_ch_8852b(struct rf_info *rf, u8 idx)
 {
 	u8 channelIndex;
 
@@ -110,7 +110,7 @@ void _halrf_tssi_hw_tx_8852b(struct rf_info *rf,
 	halrf_set_pmac_tx(rf, phy, path, &tx_info, enable, false);
 }
 
-void _halrf_tssi_rf_setting_8852b(struct rf_info *rf,
+static void _halrf_tssi_rf_setting_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	u8 channel = rf->hal_com->band[phy].cur_chandef.center_ch;
@@ -123,7 +123,7 @@ void _halrf_tssi_rf_setting_8852b(struct rf_info *rf,
 		halrf_wrf(rf, path, 0x7f, 0x00100, 0x1);
 }
 
-void _halrf_tssi_set_sys_8852b(struct rf_info *rf,
+static void _halrf_tssi_set_sys_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	u8 channel = rf->hal_com->band[phy].cur_chandef.center_ch;
@@ -175,7 +175,7 @@ void _halrf_tssi_set_sys_8852b(struct rf_info *rf,
 	}
 }
 
-void _halrf_tssi_ini_txpwr_ctrl_bb_8852b(struct rf_info *rf,
+static void _halrf_tssi_ini_txpwr_ctrl_bb_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	RF_DBG(rf, DBG_RF_TX_PWR_TRACK, "======>%s   path=%d\n", __func__, path);
@@ -308,7 +308,7 @@ void _halrf_tssi_ini_txpwr_ctrl_bb_8852b(struct rf_info *rf,
 
 }
 
-void _halrf_tssi_ini_txpwr_ctrl_bb_he_tb_8852b(struct rf_info *rf,
+static void _halrf_tssi_ini_txpwr_ctrl_bb_he_tb_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	RF_DBG(rf, DBG_RF_TX_PWR_TRACK, "======>%s   path=%d\n", __func__, path);
@@ -322,7 +322,7 @@ void _halrf_tssi_ini_txpwr_ctrl_bb_he_tb_8852b(struct rf_info *rf,
 	}
 }
 
-void _halrf_tssi_set_dck_8852b(struct rf_info *rf,
+static void _halrf_tssi_set_dck_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	RF_DBG(rf, DBG_RF_TX_PWR_TRACK, "======>%s   path=%d\n", __func__, path);
@@ -338,7 +338,7 @@ void _halrf_tssi_set_dck_8852b(struct rf_info *rf,
 	}
 }
 
-void _halrf_tssi_set_bbgain_split_8852b(struct rf_info *rf,
+static void _halrf_tssi_set_bbgain_split_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	RF_DBG(rf, DBG_RF_TX_PWR_TRACK, "======>%s   path=%d\n", __func__, path);
@@ -356,7 +356,7 @@ void _halrf_tssi_set_bbgain_split_8852b(struct rf_info *rf,
 	}
 }
 
-void _halrf_tssi_set_tmeter_tbl_8852b(struct rf_info *rf,
+static void _halrf_tssi_set_tmeter_tbl_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_pwr_track_info *pwr_trk = &rf->pwr_track;
@@ -593,7 +593,7 @@ void _halrf_tssi_set_tmeter_tbl_8852b(struct rf_info *rf,
 
 }
 
-void _halrf_tssi_set_tmeter_tbl_zere_8852b(struct rf_info *rf,
+static void _halrf_tssi_set_tmeter_tbl_zere_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	u8 i;
@@ -629,7 +629,7 @@ void _halrf_tssi_set_tmeter_tbl_zere_8852b(struct rf_info *rf,
 
 }
 
-void _halrf_tssi_set_dac_gain_tbl_8852b(struct rf_info *rf,
+static void _halrf_tssi_set_dac_gain_tbl_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	RF_DBG(rf, DBG_RF_TX_PWR_TRACK, "======>%s   path=%d\n", __func__, path);
@@ -743,7 +743,7 @@ void _halrf_tssi_set_dac_gain_tbl_8852b(struct rf_info *rf,
 
 }
 
-void _halrf_tssi_slope_cal_org_8852b(struct rf_info *rf,
+static void _halrf_tssi_slope_cal_org_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	u8 channel = rf->hal_com->band[phy].cur_chandef.center_ch;
@@ -811,7 +811,7 @@ void _halrf_tssi_slope_cal_org_8852b(struct rf_info *rf,
 }
 
 
-void _halrf_tssi_slope_cal_8852b(struct rf_info *rf,
+static void _halrf_tssi_slope_cal_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	u8 channel = rf->hal_com->band[phy].cur_chandef.center_ch;
@@ -941,7 +941,7 @@ void _halrf_tssi_slope_cal_8852b(struct rf_info *rf,
 	}
 }
 
-void _halrf_tssi_alignment_default_8852b(struct rf_info *rf,
+static void _halrf_tssi_alignment_default_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path, bool all)
 {
 	u8 channel = rf->hal_com->band[phy].cur_chandef.center_ch;
@@ -1104,7 +1104,7 @@ void _halrf_tssi_alignment_default_8852b(struct rf_info *rf,
 		0x5644 + (path << 13), halrf_rreg(rf, 0x5644 + (path << 13), 0xffffffff));
 }
 
-void _halrf_tssi_run_slope_8852b(struct rf_info *rf,
+static void _halrf_tssi_run_slope_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	RF_DBG(rf, DBG_RF_TX_PWR_TRACK, "======>%s   path=%d\n", __func__, path);
@@ -1118,7 +1118,7 @@ void _halrf_tssi_run_slope_8852b(struct rf_info *rf,
 	}
 }
 
-void _halrf_tssi_set_tssi_slope_8852b(struct rf_info *rf,
+static void _halrf_tssi_set_tssi_slope_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	RF_DBG(rf, DBG_RF_TX_PWR_TRACK, "======>%s   path=%d\n", __func__, path);
@@ -1134,7 +1134,7 @@ void _halrf_tssi_set_tssi_slope_8852b(struct rf_info *rf,
 	}
 }
 
-void _halrf_tssi_set_tssi_track_8852b(struct rf_info *rf,
+static void _halrf_tssi_set_tssi_track_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	RF_DBG(rf, DBG_RF_TX_PWR_TRACK, "======>%s   path=%d\n", __func__, path);
@@ -1146,7 +1146,7 @@ void _halrf_tssi_set_tssi_track_8852b(struct rf_info *rf,
 	}
 }
 
-void _halrf_tssi_set_txagc_offset_mv_avg_8852b(struct rf_info *rf,
+static void _halrf_tssi_set_txagc_offset_mv_avg_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	RF_DBG(rf, DBG_RF_TX_PWR_TRACK, "======>%s   path=%d\n", __func__, path);
@@ -1158,7 +1158,7 @@ void _halrf_tssi_set_txagc_offset_mv_avg_8852b(struct rf_info *rf,
 	}
 }
 
-u32 _halrf_tssi_get_cck_efuse_group_8852b(struct rf_info *rf,
+static u32 _halrf_tssi_get_cck_efuse_group_8852b(struct rf_info *rf,
 						enum phl_phy_idx phy)
 {
 	u8 channel = rf->hal_com->band[phy].cur_chandef.center_ch;
@@ -1180,7 +1180,7 @@ u32 _halrf_tssi_get_cck_efuse_group_8852b(struct rf_info *rf,
 	return offset_index;
 }
 
-u32 _halrf_tssi_get_ofdm_efuse_group_8852b(struct rf_info *rf,
+static u32 _halrf_tssi_get_ofdm_efuse_group_8852b(struct rf_info *rf,
 						enum phl_phy_idx phy)
 {
 	u8 channel = rf->hal_com->band[phy].cur_chandef.center_ch;
@@ -1253,7 +1253,7 @@ u32 _halrf_tssi_get_ofdm_efuse_group_8852b(struct rf_info *rf,
 	return offset_index;
 }
 
-s8 _halrf_tssi_get_ofdm_efuse_tssi_de_8852b(struct rf_info *rf,
+static s8 _halrf_tssi_get_ofdm_efuse_tssi_de_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_tssi_info *tssi_info = &rf->tssi;
@@ -1293,7 +1293,7 @@ s8 _halrf_tssi_get_ofdm_efuse_tssi_de_8852b(struct rf_info *rf,
 }
 
 
-u32 _halrf_tssi_get_tssi_trim_efuse_group_8852b(struct rf_info *rf,
+static u32 _halrf_tssi_get_tssi_trim_efuse_group_8852b(struct rf_info *rf,
 						enum phl_phy_idx phy)
 {
 	u8 channel = rf->hal_com->band[phy].cur_chandef.center_ch;
@@ -1328,7 +1328,7 @@ u32 _halrf_tssi_get_tssi_trim_efuse_group_8852b(struct rf_info *rf,
 	return group_index;
 }
 
-s8 _halrf_tssi_get_ofdm_tssi_trim_de_8852b(struct rf_info *rf,
+static s8 _halrf_tssi_get_ofdm_tssi_trim_de_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_tssi_info *tssi_info = &rf->tssi;
@@ -1368,7 +1368,7 @@ s8 _halrf_tssi_get_ofdm_tssi_trim_de_8852b(struct rf_info *rf,
 	return final_de;
 }
 
-void _halrf_tssi_alimentk_8852b(struct rf_info *rf,
+static void _halrf_tssi_alimentk_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_tssi_info *tssi_info = &rf->tssi;
@@ -1767,7 +1767,7 @@ void _halrf_tssi_alimentk_8852b(struct rf_info *rf,
 		HALRF_ABS(finish_time, start_time) % 1000);
 }
 
-void _halrf_tssi_alimentk_done_8852b(struct rf_info *rf,
+static void _halrf_tssi_alimentk_done_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_tssi_info *tssi_info = &rf->tssi;

--- a/phl/hal_g6/phy/rf/halrf_8852b/halrf_txgapk_8852b.c
+++ b/phl/hal_g6/phy/rf/halrf_8852b/halrf_txgapk_8852b.c
@@ -25,7 +25,7 @@
 #include "../halrf_precomp.h"
 #ifdef RF_8852B_SUPPORT
 
-void _txgapk_backup_bb_registers_8852b(
+static void _txgapk_backup_bb_registers_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	u32 *reg,
@@ -42,7 +42,7 @@ void _txgapk_backup_bb_registers_8852b(
 	}
 }
 
-void _txgapk_reload_bb_registers_8852b(
+static void _txgapk_reload_bb_registers_8852b(
 	struct rf_info *rf,
 	enum phl_phy_idx phy,
 	u32 *reg,
@@ -60,7 +60,7 @@ void _txgapk_reload_bb_registers_8852b(
 	}
 }
 
-void _halrf_txgapk_bkup_rf_8852b(
+static void _halrf_txgapk_bkup_rf_8852b(
 	struct rf_info *rf,
 	u32 *rf_reg,
 	u32 rf_bkup[][TXGAPK_RF_REG_NUM_8852B],
@@ -76,7 +76,7 @@ void _halrf_txgapk_bkup_rf_8852b(
 	}
 }
 
-void _halrf_txgapk_reload_rf_8852b(
+static void _halrf_txgapk_reload_rf_8852b(
 	struct rf_info *rf,
 	u32 *rf_reg,
 	u32 rf_bkup[][TXGAPK_RF_REG_NUM_8852B],
@@ -93,7 +93,7 @@ void _halrf_txgapk_reload_rf_8852b(
 }
 
 
-void _halrf_txgapk_bb_afe_by_mode_8852b(struct rf_info *rf,
+static void _halrf_txgapk_bb_afe_by_mode_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path, bool is_dbcc)
 {
 	RF_DBG(rf, DBG_RF_TXGAPK, "[TXGAPK]======> %s\n", __func__);
@@ -261,7 +261,7 @@ void _halrf_txgapk_bb_afe_by_mode_8852b(struct rf_info *rf,
 
 
 
-void _halrf_txgapk_iqk_preset_by_mode_8852b(struct rf_info *rf,
+static void _halrf_txgapk_iqk_preset_by_mode_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy, enum rf_path path, bool is_dbcc)
 {
 	RF_DBG(rf, DBG_RF_TXGAPK, "[TXGAPK]======> %s\n", __func__);
@@ -302,7 +302,7 @@ void _halrf_txgapk_iqk_preset_by_mode_8852b(struct rf_info *rf,
 
 
 
-void _halrf_txgapk_clk_setting_dac960mhz_by_mode_8852b
+static void _halrf_txgapk_clk_setting_dac960mhz_by_mode_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path, bool is_dbcc)
 {
 	RF_DBG(rf, DBG_RF_TXGAPK, "[TXGAPK]======> %s\n", __func__);
@@ -333,7 +333,7 @@ void _halrf_txgapk_clk_setting_dac960mhz_by_mode_8852b
 	
 }
 
-void _halrf_txgapk_before_one_shot_enable_8852b
+static void _halrf_txgapk_before_one_shot_enable_8852b
 	(struct rf_info *rf)
 {
 	RF_DBG(rf, DBG_RF_TXGAPK, "[TXGAPK]======> %s\n", __func__);
@@ -345,7 +345,7 @@ void _halrf_txgapk_before_one_shot_enable_8852b
 	RF_DBG(rf, DBG_RF_TXGAPK, "[TXGAPK]======> before set one-shot bit, 0x%x= 0x%x\n", 0x8010, halrf_rreg(rf, 0x8010, MASKDWORD));
 }
 
-void _halrf_txgapk_one_shot_nctl_done_check_8852b
+static void _halrf_txgapk_one_shot_nctl_done_check_8852b
 	(struct rf_info *rf, enum txgapk_id id, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -424,7 +424,7 @@ void _halrf_txgapk_one_shot_nctl_done_check_8852b
 }
 
 
-void _halrf_txgapk_track_table_nctl_2g_8852b
+static void _halrf_txgapk_track_table_nctl_2g_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -735,7 +735,7 @@ void _halrf_txgapk_track_table_nctl_2g_8852b
 }
 
 
-void _halrf_txgapk_track_table_nctl_5g_8852b
+static void _halrf_txgapk_track_table_nctl_5g_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -1043,7 +1043,7 @@ void _halrf_txgapk_track_table_nctl_5g_8852b
 }
 
 
-void _halrf_txgapk_track_table_nctl_8852b
+static void _halrf_txgapk_track_table_nctl_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	u8 channel = rf->hal_com->band[phy].cur_chandef.center_ch;
@@ -1054,7 +1054,7 @@ void _halrf_txgapk_track_table_nctl_8852b
 		_halrf_txgapk_track_table_nctl_5g_8852b(rf, phy, path);
 }
 
-void _halrf_txgapk_write_track_table_default_2g_8852b
+static void _halrf_txgapk_write_track_table_default_2g_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -1093,7 +1093,7 @@ void _halrf_txgapk_write_track_table_default_2g_8852b
 	halrf_wrf(rf, path, TXGAPK_DEBUGMASK_8852B, 0x08000, 0x0); /* exit debug mode after write */
 }
 
-void _halrf_txgapk_write_track_table_default_5gl_8852b
+static void _halrf_txgapk_write_track_table_default_5gl_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -1131,7 +1131,7 @@ void _halrf_txgapk_write_track_table_default_5gl_8852b
 	halrf_wrf(rf, path, TXGAPK_DEBUGMASK_8852B, 0x08000, 0x0); /* exit debug mode after write */
 }
 
-void _halrf_txgapk_write_track_table_default_5gm_8852b
+static void _halrf_txgapk_write_track_table_default_5gm_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -1169,7 +1169,7 @@ void _halrf_txgapk_write_track_table_default_5gm_8852b
 	halrf_wrf(rf, path, TXGAPK_DEBUGMASK_8852B, 0x08000, 0x0); /* exit debug mode after write */
 }
 
-void _halrf_txgapk_write_track_table_default_5gh_8852b
+static void _halrf_txgapk_write_track_table_default_5gh_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -1207,7 +1207,7 @@ void _halrf_txgapk_write_track_table_default_5gh_8852b
 	halrf_wrf(rf, path, TXGAPK_DEBUGMASK_8852B, 0x08000, 0x0); /* exit debug mode after write */
 }
 
-void _halrf_txgapk_write_track_table_default_8852b
+static void _halrf_txgapk_write_track_table_default_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	u8 channel = rf->hal_com->band[phy].cur_chandef.center_ch;
@@ -1222,7 +1222,7 @@ void _halrf_txgapk_write_track_table_default_8852b
 		_halrf_txgapk_write_track_table_default_5gh_8852b(rf, phy, path);
 }
 
-void _halrf_txgapk_write_track_table_2g_8852b
+static void _halrf_txgapk_write_track_table_2g_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -1280,7 +1280,7 @@ void _halrf_txgapk_write_track_table_2g_8852b
 	halrf_wrf(rf, path, TXGAPK_DEBUGMASK_8852B, 0x08000, 0x0); /* exit debug mode after write */
 }
 
-void _halrf_txgapk_write_track_table_5gl_8852b
+static void _halrf_txgapk_write_track_table_5gl_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -1327,7 +1327,7 @@ void _halrf_txgapk_write_track_table_5gl_8852b
 
 }
 
-void _halrf_txgapk_write_track_table_5gm_8852b
+static void _halrf_txgapk_write_track_table_5gm_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -1374,7 +1374,7 @@ void _halrf_txgapk_write_track_table_5gm_8852b
 
 }
 
-void _halrf_txgapk_write_track_table_5gh_8852b
+static void _halrf_txgapk_write_track_table_5gh_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -1421,7 +1421,7 @@ void _halrf_txgapk_write_track_table_5gh_8852b
 	halrf_wrf(rf, path, TXGAPK_DEBUGMASK_8852B, 0x08000, 0x0); /* exit debug mode after write */
 }
 
-void _halrf_txgapk_write_track_table_8852b
+static void _halrf_txgapk_write_track_table_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	u8 channel = rf->hal_com->band[phy].cur_chandef.center_ch;
@@ -1436,7 +1436,7 @@ void _halrf_txgapk_write_track_table_8852b
 		_halrf_txgapk_write_track_table_5gh_8852b(rf, phy, path);
 }
 
-void _halrf_txgapk_power_table_nctl_2g_8852b
+static void _halrf_txgapk_power_table_nctl_2g_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -1716,7 +1716,7 @@ void _halrf_txgapk_power_table_nctl_2g_8852b
 }
 
 
-void _halrf_txgapk_power_table_nctl_5g_8852b
+static void _halrf_txgapk_power_table_nctl_5g_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -1994,7 +1994,7 @@ void _halrf_txgapk_power_table_nctl_5g_8852b
 }
 
 
-void _halrf_txgapk_power_table_nctl_8852b
+static void _halrf_txgapk_power_table_nctl_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	u8 channel = rf->hal_com->band[phy].cur_chandef.center_ch;
@@ -2006,7 +2006,7 @@ void _halrf_txgapk_power_table_nctl_8852b
 
 }
 
-void _halrf_txgapk_write_power_table_default_2g_8852b
+static void _halrf_txgapk_write_power_table_default_2g_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -2036,7 +2036,7 @@ void _halrf_txgapk_write_power_table_default_2g_8852b
 	halrf_wrf(rf, path, TXGAPK_DEBUGMASK_8852B, 0x40000, 0x0); /* exit debug mode after write */
 }
 
-void _halrf_txgapk_write_power_table_default_5gl_8852b
+static void _halrf_txgapk_write_power_table_default_5gl_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -2065,7 +2065,7 @@ void _halrf_txgapk_write_power_table_default_5gl_8852b
 	halrf_wrf(rf, path, TXGAPK_DEBUGMASK_8852B, 0x40000, 0x0); /* exit debug mode after write */
 }
 
-void _halrf_txgapk_write_power_table_default_5gm_8852b
+static void _halrf_txgapk_write_power_table_default_5gm_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -2095,7 +2095,7 @@ void _halrf_txgapk_write_power_table_default_5gm_8852b
 	halrf_wrf(rf, path, TXGAPK_DEBUGMASK_8852B, 0x40000, 0x0); /* exit debug mode after write */
 }
 
-void _halrf_txgapk_write_power_table_default_5gh_8852b
+static void _halrf_txgapk_write_power_table_default_5gh_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -2124,7 +2124,7 @@ void _halrf_txgapk_write_power_table_default_5gh_8852b
 	halrf_wrf(rf, path, TXGAPK_DEBUGMASK_8852B, 0x40000, 0x0); /* exit debug mode after write */
 }
 
-void _halrf_txgapk_write_power_table_default_8852b
+static void _halrf_txgapk_write_power_table_default_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	u8 channel = rf->hal_com->band[phy].cur_chandef.center_ch;
@@ -2139,7 +2139,7 @@ void _halrf_txgapk_write_power_table_default_8852b
 		_halrf_txgapk_write_power_table_default_5gh_8852b(rf, phy, path);
 }
 
-void _halrf_txgapk_write_power_table_2g_8852b
+static void _halrf_txgapk_write_power_table_2g_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -2185,7 +2185,7 @@ void _halrf_txgapk_write_power_table_2g_8852b
 	halrf_wrf(rf, path, TXGAPK_DEBUGMASK_8852B, 0x40000, 0x0); /* exit debug mode after write */
 }
 
-void _halrf_txgapk_write_power_table_5gl_8852b
+static void _halrf_txgapk_write_power_table_5gl_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -2239,7 +2239,7 @@ void _halrf_txgapk_write_power_table_5gl_8852b
 	halrf_wrf(rf, path, TXGAPK_DEBUGMASK_8852B, 0x40000, 0x0); /* exit debug mode after write */
 }
 
-void _halrf_txgapk_write_power_table_5gm_8852b
+static void _halrf_txgapk_write_power_table_5gm_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -2294,7 +2294,7 @@ void _halrf_txgapk_write_power_table_5gm_8852b
 	halrf_wrf(rf, path, TXGAPK_DEBUGMASK_8852B, 0x40000, 0x0); /* exit debug mode after write */
 }
 
-void _halrf_txgapk_write_power_table_5gh_8852b
+static void _halrf_txgapk_write_power_table_5gh_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -2349,7 +2349,7 @@ void _halrf_txgapk_write_power_table_5gh_8852b
 	halrf_wrf(rf, path, TXGAPK_DEBUGMASK_8852B, 0x40000, 0x0); /* exit debug mode after write */
 }
 
-void _halrf_txgapk_write_power_table_8852b
+static void _halrf_txgapk_write_power_table_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path)
 {
 	u8 channel = rf->hal_com->band[phy].cur_chandef.center_ch;
@@ -2364,7 +2364,7 @@ void _halrf_txgapk_write_power_table_8852b
 		_halrf_txgapk_write_power_table_5gh_8852b(rf, phy, path);
 }
 
-void _halrf_txgapk_iqk_bk_reg_by_mode_8852b
+static void _halrf_txgapk_iqk_bk_reg_by_mode_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path, bool is_dbcc)
 {
 	u32 path_setting[2] = {0x0e19, 0x0e29};
@@ -2416,7 +2416,7 @@ void _halrf_txgapk_iqk_bk_reg_by_mode_8852b
 
 
 
-void _halrf_txgapk_afe_bk_reg_by_mode_8852b
+static void _halrf_txgapk_afe_bk_reg_by_mode_8852b
 	(struct rf_info *rf, enum phl_phy_idx phy, enum rf_path path, bool is_dbcc)
 {
 	RF_DBG(rf, DBG_RF_TXGAPK, "[TXGAPK]======> %s\n", __func__);
@@ -2490,7 +2490,7 @@ void _halrf_txgapk_afe_bk_reg_by_mode_8852b
 
 
 
-void _halrf_do_non_dbcc_txgapk_8852b(struct rf_info *rf,
+static void _halrf_do_non_dbcc_txgapk_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy)
 {
 	u8 i;
@@ -2613,7 +2613,7 @@ void _halrf_do_non_dbcc_txgapk_8852b(struct rf_info *rf,
 					backup_num);
 	halrf_write_fwofld_end(rf); 	/*FW Offload End*/
 }
-void _halrf_do_dbcc_txgapk_8852b(struct rf_info *rf,
+static void _halrf_do_dbcc_txgapk_8852b(struct rf_info *rf,
 					enum phl_phy_idx phy)
 {
 	u32 bb_reg[1] = {0x2344};
@@ -2715,7 +2715,7 @@ void _halrf_do_dbcc_txgapk_8852b(struct rf_info *rf,
 #endif
 	
 }
-void _halrf_txgapk_get_ch_info_8852b(struct rf_info *rf, enum phl_phy_idx phy)
+static void _halrf_txgapk_get_ch_info_8852b(struct rf_info *rf, enum phl_phy_idx phy)
 {
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
 	

--- a/phl/hal_g6/phy/rf/halrf_api.c
+++ b/phl/hal_g6/phy/rf/halrf_api.c
@@ -127,7 +127,7 @@ void halrf_reload_bkprf(struct rf_info *rf,
 	}
 }
 
-void halrf_wait_rx_mode(struct rf_info *rf, u8 kpath)
+static void halrf_wait_rx_mode(struct rf_info *rf, u8 kpath)
 {
 	u8 path, rf_mode = 0;
 	u16 count = 0;
@@ -884,7 +884,7 @@ void halrf_ops_txgapk_init(struct rf_info *rf)
 
 }
 
-u32 halrf_c2h_rfk_parsing(struct rf_info *rf, u8 cmdid, u16 len, u8 *c2h)
+static u32 halrf_c2h_rfk_parsing(struct rf_info *rf, u8 cmdid, u16 len, u8 *c2h)
 {
 	u32 i;
 

--- a/phl/hal_g6/phy/rf/halrf_dbg.c
+++ b/phl/hal_g6/phy/rf/halrf_dbg.c
@@ -306,7 +306,7 @@ void halrf_dump_rfk_reg(struct rf_info *rf, char input[][16], u32 *_used,
 	*_out_len = out_len;
 }
 
-void _halrf_dpk_info(struct rf_info *rf, char input[][16], u32 *_used,
+static void _halrf_dpk_info(struct rf_info *rf, char input[][16], u32 *_used,
 			 char *output, u32 *_out_len)
 {
 	struct rtw_hal_com_t *hal_i = rf->hal_com;
@@ -467,7 +467,7 @@ void _halrf_dpk_info(struct rf_info *rf, char input[][16], u32 *_used,
 
 }
 
-void halrf_dpk_read_rc_mtx(struct rf_info *rf, char input[][16], u32 *_used,
+static void halrf_dpk_read_rc_mtx(struct rf_info *rf, char input[][16], u32 *_used,
 			 char *output, u32 *_out_len, u32 path)
 {
 	struct rtw_hal_com_t *hal_i = rf->hal_com;
@@ -512,7 +512,7 @@ void halrf_dpk_read_rc_mtx(struct rf_info *rf, char input[][16], u32 *_used,
 	*_out_len = out_len;
 }
 
-void halrf_dpk_read_rx_sram(struct rf_info *rf, char input[][16], u32 *_used,
+static void halrf_dpk_read_rx_sram(struct rf_info *rf, char input[][16], u32 *_used,
 			 char *output, u32 *_out_len, u32 path)
 {
 	struct rtw_hal_com_t *hal_i = rf->hal_com;
@@ -555,7 +555,7 @@ void halrf_dpk_read_rx_sram(struct rf_info *rf, char input[][16], u32 *_used,
 	*_out_len = out_len;
 }
 
-void halrf_dpk_read_coef(struct rf_info *rf, char input[][16], u32 *_used,
+static void halrf_dpk_read_coef(struct rf_info *rf, char input[][16], u32 *_used,
 			 char *output, u32 *_out_len, u32 path, bool is_first)
 {
 	struct rtw_hal_com_t *hal_i = rf->hal_com;
@@ -830,7 +830,7 @@ void halrf_rx_dck_info(struct rf_info *rf, char input[][16], u32 *_used,
 	*_out_len = out_len;
 }
 
-void halrf_get_rx_dck_value(struct rf_info *rf, char input[][16], u32 *_used,
+static void halrf_get_rx_dck_value(struct rf_info *rf, char input[][16], u32 *_used,
 			 char *output, u32 *_out_len)
 {
 	u32 val_1 = 0, val_2 = 0;
@@ -913,7 +913,7 @@ void halrf_rx_dck_dbg_cmd(struct rf_info *rf, char input[][16], u32 *_used,
 	*_out_len = out_len;
 }
 
-void halrf_dack_dbg_info(struct rf_info *rf, char input[][16], u32 *_used,
+static void halrf_dack_dbg_info(struct rf_info *rf, char input[][16], u32 *_used,
 			 char *output, u32 *_out_len)
 {
 	struct rtw_hal_com_t *hal_i = rf->hal_com;
@@ -1047,7 +1047,7 @@ void halrf_dack_dbg_cmd(struct rf_info *rf, char input[][16], u32 *_used,
 #endif
 }
 
-void _halrf_tssi_info(struct rf_info *rf, char input[][16], u32 *_used,
+static void _halrf_tssi_info(struct rf_info *rf, char input[][16], u32 *_used,
 			 char *output, u32 *_out_len)
 {
 	struct rtw_hal_com_t *hal_i = rf->hal_com;
@@ -1874,7 +1874,7 @@ void halrf_test_cmd(struct rf_info *rf, char input[][16], u32 *_used,
 #endif
 }
 
-void _halrf_gapk_info(struct rf_info *rf, char input[][16], u32 *_used,
+static void _halrf_gapk_info(struct rf_info *rf, char input[][16], u32 *_used,
 			 char *output, u32 *_out_len)
 {
 	struct rtw_hal_com_t *hal_i = rf->hal_com;
@@ -2523,7 +2523,7 @@ void halrf_chl_rfk_dbg_cmd(struct rf_info *rf, char input[][16], u32 *_used,
 	*_out_len = out_len;
 }
 
-void _halrf_op5k_info(struct rf_info *rf, char input[][16], u32 *_used,
+static void _halrf_op5k_info(struct rf_info *rf, char input[][16], u32 *_used,
 			 char *output, u32 *_out_len)
 {
 	struct halrf_op5k_info *op5k = &rf->op5k_info;

--- a/phl/hal_g6/phy/rf/halrf_dbg_cmd.c
+++ b/phl/hal_g6/phy/rf/halrf_dbg_cmd.c
@@ -325,7 +325,7 @@ s32 halrf_cmd(struct rf_info *rf, char *input, char *output, u32 out_len)
 	return 0;
 }
 
-u32 halrf_get_multiple(u8 pow, u8 base)
+static u32 halrf_get_multiple(u8 pow, u8 base)
 {
 	u8 i;
 	u32 return_value = 1;
@@ -336,7 +336,7 @@ u32 halrf_get_multiple(u8 pow, u8 base)
 	return	return_value;
 }
 
-u32 halrf_str_2_dec(u8 val)
+static u32 halrf_str_2_dec(u8 val)
 {
 	if (val >= 0x30 && val <= 0x39) /*0~9*/
 		return	(val - 0x30);

--- a/phl/hal_g6/phy/rf/halrf_hw_cfg.c
+++ b/phl/hal_g6/phy/rf/halrf_hw_cfg.c
@@ -522,7 +522,7 @@ bool halrf_config_radio(void *rf_void, enum phl_phy_idx phy)
 	return result;
 }
 
-bool halrf_config_power_by_rate(void *rf_void, enum phl_phy_idx phy)
+static bool halrf_config_power_by_rate(void *rf_void, enum phl_phy_idx phy)
 {
 	struct rf_info *rf = (struct rf_info *)rf_void;
 	struct rtw_hal_com_t *hal_com = rf->hal_com;
@@ -757,7 +757,7 @@ bool halrf_config_power_limit_ru_6g(void *rf_void, enum phl_phy_idx phy)
 	return result;
 }
 
-bool halrf_config_power_track(void *rf_void, enum phl_phy_idx phy)
+static bool halrf_config_power_track(void *rf_void, enum phl_phy_idx phy)
 {
 	struct rf_info *rf = (struct rf_info *)rf_void;
 	struct rtw_hal_com_t *hal_com = rf->hal_com;
@@ -813,7 +813,7 @@ bool halrf_config_power_track(void *rf_void, enum phl_phy_idx phy)
 	return result;
 }
 
-bool halrf_config_xtal_track(void *rf_void, enum phl_phy_idx phy)
+static bool halrf_config_xtal_track(void *rf_void, enum phl_phy_idx phy)
 {
 	struct rf_info *rf = (struct rf_info *)rf_void;
 	struct rtw_hal_com_t *hal_com = rf->hal_com;
@@ -857,7 +857,7 @@ bool halrf_config_xtal_track(void *rf_void, enum phl_phy_idx phy)
 	return result;
 }
 
-void halrf_config_limit_default(void *rf_void)
+static void halrf_config_limit_default(void *rf_void)
 {
 	struct rf_info *rf = (struct rf_info *)rf_void;
 	struct halrf_pwr_info *pwr = &rf->pwr_info;

--- a/phl/hal_g6/phy/rf/halrf_init.c
+++ b/phl/hal_g6/phy/rf/halrf_init.c
@@ -128,7 +128,7 @@ void halrf_cmn_info_self_init(struct rf_info *rf)
 	}
 }
 
-void halrf_rfk_self_init(struct rf_info *rf)
+static void halrf_rfk_self_init(struct rf_info *rf)
 {
 	struct halrf_iqk_info *iqk_info = &rf->iqk;
 	struct halrf_gapk_info *txgapk_info = &rf->gapk;
@@ -536,7 +536,7 @@ void halrf_set_rfability(struct rf_info *rf)
 	       rf->ic_type, rf->phl_com->drv_mode, rf->hw_rf_ability);
 }
 
-void halrf_set_final_rfability(struct rf_info *rf)
+static void halrf_set_final_rfability(struct rf_info *rf)
 {
 
 #if 0
@@ -559,7 +559,7 @@ void halrf_set_final_rfability(struct rf_info *rf)
 	       rf->ic_type, rf->phl_com->drv_mode, rf->support_ability);
 }
 
-void halrf_rfe_init(struct rf_info *rf)
+static void halrf_rfe_init(struct rf_info *rf)
 {
 	u8 rfe_type = rf->phl_com->dev_cap.rfe_type;
 
@@ -598,7 +598,7 @@ void halrf_rfe_init(struct rf_info *rf)
 	}
 }
 
-void halrf_rfe_type_gpio_setting(struct rf_info *rf)
+static void halrf_rfe_type_gpio_setting(struct rf_info *rf)
 {
 	u32 band = rf->hal_com->band[HW_PHY_0].cur_chandef.band;
 

--- a/phl/hal_g6/phy/rf/halrf_iqk.c
+++ b/phl/hal_g6/phy/rf/halrf_iqk.c
@@ -30,7 +30,7 @@ void iqk_restore(struct rf_info *rf, u8 path)
 	return;
 }
 
-void iqk_backup_mac_reg(struct rf_info *rf, u32 *backup_mac_reg_val)
+static void iqk_backup_mac_reg(struct rf_info *rf, u32 *backup_mac_reg_val)
 {
 	struct rfk_iqk_info *iqk_info = rf->rfk_iqk_info;
 	u32 i;
@@ -49,7 +49,7 @@ void iqk_backup_mac_reg(struct rf_info *rf, u32 *backup_mac_reg_val)
 	}
 }
 
-void iqk_backup_bb_reg(struct rf_info *rf, u32 *backup_bb_reg_val)
+static void iqk_backup_bb_reg(struct rf_info *rf, u32 *backup_bb_reg_val)
 {
 	struct rfk_iqk_info *iqk_info = rf->rfk_iqk_info;
 	u32 i;
@@ -68,7 +68,7 @@ void iqk_backup_bb_reg(struct rf_info *rf, u32 *backup_bb_reg_val)
 	}
 }
 
-void iqk_backup_rf_reg(struct rf_info *rf, u32 *backup_rf_reg_val, u8 rf_path)
+static void iqk_backup_rf_reg(struct rf_info *rf, u32 *backup_rf_reg_val, u8 rf_path)
 {
 	struct rfk_iqk_info *iqk_info = rf->rfk_iqk_info;
 	u32 i;
@@ -88,7 +88,7 @@ void iqk_backup_rf_reg(struct rf_info *rf, u32 *backup_rf_reg_val, u8 rf_path)
 	}
 }
 
-void iqk_restore_mac_reg(struct rf_info *rf, u32 *backup_mac_reg_val)
+static void iqk_restore_mac_reg(struct rf_info *rf, u32 *backup_mac_reg_val)
 {
 	struct rfk_iqk_info *iqk_info = rf->rfk_iqk_info;
 	u32 i;
@@ -108,7 +108,7 @@ void iqk_restore_mac_reg(struct rf_info *rf, u32 *backup_mac_reg_val)
 	}
 }
 
-void iqk_restore_bb_reg(struct rf_info *rf, u32 *backup_bb_reg_val)
+static void iqk_restore_bb_reg(struct rf_info *rf, u32 *backup_bb_reg_val)
 {
 	struct rfk_iqk_info *iqk_info = rf->rfk_iqk_info;
 	u32 i;
@@ -127,7 +127,7 @@ void iqk_restore_bb_reg(struct rf_info *rf, u32 *backup_bb_reg_val)
 	}
 }
 
-void iqk_restore_rf_reg(struct rf_info *rf, u32 *backup_rf_reg_val, u8 rf_path)
+static void iqk_restore_rf_reg(struct rf_info *rf, u32 *backup_rf_reg_val, u8 rf_path)
 {
 	struct rfk_iqk_info *iqk_info = rf->rfk_iqk_info;
 	u32 i;
@@ -266,7 +266,7 @@ void halrf_iqk_init(struct rf_info *rf)
 return;
 }
 
-void halrf_doiqk(struct rf_info *rf, bool force, enum phl_phy_idx phy_idx,
+static void halrf_doiqk(struct rf_info *rf, bool force, enum phl_phy_idx phy_idx,
 		 u8 path)
 {
 	struct halrf_iqk_info *iqk_info = &rf->iqk;
@@ -316,7 +316,7 @@ void halrf_doiqk(struct rf_info *rf, bool force, enum phl_phy_idx phy_idx,
 	return;
 }
 
-void halrf_drv_iqk(struct rf_info *rf, enum phl_phy_idx phy_idx, bool force) {
+static void halrf_drv_iqk(struct rf_info *rf, enum phl_phy_idx phy_idx, bool force) {
 
 	/*drv_iqk*/ 	
 	RF_DBG(rf, DBG_RF_IQK, "[IQK]====  DRV IQK ==== \n");
@@ -367,7 +367,7 @@ bool halrf_check_fwiqk_done(struct rf_info *rf)
 		return isfail;
 }
 
-void halrf_iqk_get_ch_info(struct rf_info *rf, enum phl_phy_idx phy_idx, u8 path)
+static void halrf_iqk_get_ch_info(struct rf_info *rf, enum phl_phy_idx phy_idx, u8 path)
 {
 	struct rtw_hal_com_t *hal_i = rf->hal_com;
 
@@ -394,7 +394,7 @@ void halrf_iqk_get_ch_info(struct rf_info *rf, enum phl_phy_idx phy_idx, u8 path
 	return;
 }
 
-void halrf_iqk_set_info(struct rf_info *rf, enum phl_phy_idx phy_idx, u8 path)
+static void halrf_iqk_set_info(struct rf_info *rf, enum phl_phy_idx phy_idx, u8 path)
 {
 		struct rtw_hal_com_t *hal_i = rf->hal_com;
 	
@@ -422,7 +422,7 @@ void halrf_iqk_set_info(struct rf_info *rf, enum phl_phy_idx phy_idx, u8 path)
 			return;
 }
 
-u8 halrf_get_fw_iqk_times(struct rf_info *rf)
+static u8 halrf_get_fw_iqk_times(struct rf_info *rf)
 {
 	struct halrf_iqk_info *iqk_info = &rf->iqk;
 	struct rtw_hal_com_t *hal_i = rf->hal_com;
@@ -452,7 +452,7 @@ u8 halrf_get_fw_iqk_times(struct rf_info *rf)
 }
 
 
-bool halrf_fw_iqk(struct rf_info *rf, enum phl_phy_idx phy_idx, bool force) {
+static bool halrf_fw_iqk(struct rf_info *rf, enum phl_phy_idx phy_idx, bool force) {
 	
 	struct halrf_iqk_info *iqk_info = &rf->iqk;
 	u32 data_to_fw[2] = {0};

--- a/phl/hal_g6/phy/rf/halrf_pmac.c
+++ b/phl/hal_g6/phy/rf/halrf_pmac.c
@@ -33,7 +33,7 @@ void halrf_set_pseudo_cw(struct rf_info *rf, enum rf_path path,
 		       "[RFK] Set S%d Pseudo_CW off!!\n", path);
 }
 
-void halrf_set_plcp_usr_info(struct rf_info *rf, struct halbb_plcp_info *plcp,
+static void halrf_set_plcp_usr_info(struct rf_info *rf, struct halbb_plcp_info *plcp,
 				struct rf_pmac_tx_info *tx_info)
 {
 	plcp->usr[0].mcs = tx_info->mcs;
@@ -55,7 +55,7 @@ void halrf_set_plcp_usr_info(struct rf_info *rf, struct halbb_plcp_info *plcp,
 	       tx_info->mcs, tx_info->length, tx_info->nss);
 }
 
-void halrf_set_plcp_para_info(struct rf_info *rf, struct halbb_plcp_info *plcp,
+static void halrf_set_plcp_para_info(struct rf_info *rf, struct halbb_plcp_info *plcp,
 				struct rf_pmac_tx_info *tx_info)
 {
 	plcp->dbw = tx_info->bw; /*0:BW20, 1:BW40, 2:BW80, 3:BW160/BW80+80*/
@@ -109,7 +109,7 @@ void halrf_set_plcp_para_info(struct rf_info *rf, struct halbb_plcp_info *plcp,
 	       tx_info->bw, tx_info->long_preamble_en, tx_info->gi ,tx_info->ppdu);
 }
 
-void halrf_set_pmac_plcp_gen(struct rf_info *rf, enum phl_phy_idx phy_idx,
+static void halrf_set_pmac_plcp_gen(struct rf_info *rf, enum phl_phy_idx phy_idx,
 			struct rf_pmac_tx_info *tx_info)
 {
 	struct halbb_plcp_info plcp = {0};

--- a/phl/hal_g6/phy/rf/halrf_pwr_table.c
+++ b/phl/hal_g6/phy/rf/halrf_pwr_table.c
@@ -84,7 +84,7 @@ bool halrf_reg_tbl_exist(struct rf_info *rf, u8 band, u8 reg)
 	return pwr->regulation[band][reg];
 }
 
-u8 halrf_get_regulation_info_force(struct rf_info *rf, u8 band)
+static u8 halrf_get_regulation_info_force(struct rf_info *rf, u8 band)
 {
 	struct halrf_pwr_info *pwr = &rf->pwr_info;
 	enum halrf_pw_lmt_regulation_type pw_lmt_type = PW_LMT_REGU_NULL;
@@ -177,7 +177,7 @@ reg_tbl_chk:
 	return pw_lmt_type;
 }
 
-void _halrf_calc_intersect_pwr_limit_tbl(struct rf_info *rf,
+static void _halrf_calc_intersect_pwr_limit_tbl(struct rf_info *rf,
 	u8 reg_2g[], u8 reg_2g_len, u8 reg_5g[], u8 reg_5g_len, u8 reg_6g[], u8 reg_6g_len)
 {
 	struct halrf_pwr_info *pwr = &rf->pwr_info;
@@ -575,7 +575,7 @@ void halrf_power_by_rate_store_to_array(struct rf_info *rf,
 	}
 }
 
-u8 halrf_get_ch_idx_to_limit_array(struct rf_info *rf, u8 channel)
+static u8 halrf_get_ch_idx_to_limit_array(struct rf_info *rf, u8 channel)
 {
 	u8	channelIndex;
 
@@ -593,7 +593,7 @@ u8 halrf_get_ch_idx_to_limit_array(struct rf_info *rf, u8 channel)
 	return channelIndex;
 }
 
-u8 halrf_get_ch_idx_to_6g_limit_array(struct rf_info *rf, u8 channel)
+static u8 halrf_get_ch_idx_to_6g_limit_array(struct rf_info *rf, u8 channel)
 {
 	u8	channelIndex;
 
@@ -661,7 +661,7 @@ u8 halrf_get_limit_ch_idx_to_ch_idx(struct rf_info *rf, u8 band, u8 channel)
 	return channelIndex;
 }
 
-u16 halrf_hw_rate_to_pwr_by_rate(struct rf_info *rf, u16 rate)
+static u16 halrf_hw_rate_to_pwr_by_rate(struct rf_info *rf, u16 rate)
 {
 	u16 ret_rate = HALRF_DATA_RATE_OFDM6;
 
@@ -807,7 +807,7 @@ u16 halrf_hw_rate_to_pwr_by_rate(struct rf_info *rf, u16 rate)
 	return ret_rate;
 }
 
-u16 halrf_get_dcm_offset_pwr_by_rate(struct rf_info *rf, u16 rate,
+static u16 halrf_get_dcm_offset_pwr_by_rate(struct rf_info *rf, u16 rate,
 						u8 dcm, u8 offset)
 {
 	u16 rate_tmp = 0;
@@ -852,7 +852,7 @@ u16 halrf_get_dcm_offset_pwr_by_rate(struct rf_info *rf, u16 rate,
 
 }
 
-u8 halrf_hw_rate_to_limit_rate_tx_num(struct rf_info *rf, u16 rate)
+static u8 halrf_hw_rate_to_limit_rate_tx_num(struct rf_info *rf, u16 rate)
 {
 	if (rate >= RTW_DATA_RATE_CCK1 && rate <= RTW_DATA_RATE_CCK11)
 		return PW_LMT_RS_CCK;
@@ -1134,7 +1134,7 @@ void halrf_power_limit_ru_set_worldwide(struct rf_info *rf)
 
 }
 
-void halrf_set_ext_power_limit_table(struct rf_info *rf,
+static void halrf_set_ext_power_limit_table(struct rf_info *rf,
 							enum phl_phy_idx phy)
 {
 #ifdef SPF_PHL_RF_019_SAR
@@ -1470,7 +1470,7 @@ void halrf_set_ext_power_limit_table(struct rf_info *rf,
 #endif
 }
 
-void halrf_set_ext_power_limit_ru_table(struct rf_info *rf,
+static void halrf_set_ext_power_limit_ru_table(struct rf_info *rf,
 							enum phl_phy_idx phy)
 {
 #ifdef SPF_PHL_RF_019_SAR
@@ -2591,14 +2591,14 @@ bool halrf_control_tx_rate_power (void *rf_void, enum phl_phy_idx phy_idx, s32 m
 	return true;
 }
 
-void halrf_set_tpe_default_control(struct rf_info *rf, enum phl_phy_idx phy)
+static void halrf_set_tpe_default_control(struct rf_info *rf, enum phl_phy_idx phy)
 {
 	RF_DBG(rf, DBG_RF_POWER, "[TPE] ======>%s\n", __func__);
 
 	halrf_set_power(rf, phy, PWR_LIMIT | PWR_LIMIT_RU);
 }
 
-void halrf_set_eirp_tpe_control(struct rf_info *rf, enum phl_phy_idx phy, s8 *power, u8 valid_tpe_cnt)
+static void halrf_set_eirp_tpe_control(struct rf_info *rf, enum phl_phy_idx phy, s8 *power, u8 valid_tpe_cnt)
 {
 	struct rtw_tpu_pwr_imt_info *lmt = &rf->hal_com->band[phy].rtw_tpu_i.rtw_tpu_pwr_imt_i;
 	struct rtw_hal_com_t *hal = rf->hal_com;
@@ -2741,7 +2741,7 @@ void halrf_set_eirp_tpe_control(struct rf_info *rf, enum phl_phy_idx phy, s8 *po
 	}
 }
 
-void halrf_set_eirp_psd_special_tpe_control(struct rf_info *rf, enum phl_phy_idx phy, s8 power)
+static void halrf_set_eirp_psd_special_tpe_control(struct rf_info *rf, enum phl_phy_idx phy, s8 power)
 {
 	struct rtw_tpu_pwr_imt_info *lmt = &rf->hal_com->band[phy].rtw_tpu_i.rtw_tpu_pwr_imt_i;
 	struct rtw_hal_com_t *hal = rf->hal_com;
@@ -2846,7 +2846,7 @@ void halrf_set_eirp_psd_special_tpe_control(struct rf_info *rf, enum phl_phy_idx
 	}
 }
 
-void halrf_set_eirp_psd_tpe_control(struct rf_info *rf, enum phl_phy_idx phy, s8* power, u8 valid_tpe_cnt)
+static void halrf_set_eirp_psd_tpe_control(struct rf_info *rf, enum phl_phy_idx phy, s8* power, u8 valid_tpe_cnt)
 {
 	struct rtw_tpu_pwr_imt_info *lmt = &rf->hal_com->band[phy].rtw_tpu_i.rtw_tpu_pwr_imt_i;
 	struct rtw_hal_com_t *hal = rf->hal_com;

--- a/phl/hal_g6/phy/rf/halrf_pwr_table.c
+++ b/phl/hal_g6/phy/rf/halrf_pwr_table.c
@@ -84,7 +84,7 @@ bool halrf_reg_tbl_exist(struct rf_info *rf, u8 band, u8 reg)
 	return pwr->regulation[band][reg];
 }
 
-u8 halrf_get_regulation_info_force(struct rf_info *rf, u8 band)
+static u8 halrf_get_regulation_info_force(struct rf_info *rf, u8 band)
 {
 	struct halrf_pwr_info *pwr = &rf->pwr_info;
 	enum halrf_pw_lmt_regulation_type pw_lmt_type = PW_LMT_REGU_NULL;
@@ -177,7 +177,7 @@ reg_tbl_chk:
 	return pw_lmt_type;
 }
 
-void _halrf_calc_intersect_pwr_limit_tbl(struct rf_info *rf,
+static void _halrf_calc_intersect_pwr_limit_tbl(struct rf_info *rf,
 	u8 reg_2g[], u8 reg_2g_len, u8 reg_5g[], u8 reg_5g_len, u8 reg_6g[], u8 reg_6g_len)
 {
 	struct halrf_pwr_info *pwr = &rf->pwr_info;
@@ -575,7 +575,7 @@ void halrf_power_by_rate_store_to_array(struct rf_info *rf,
 	}
 }
 
-u8 halrf_get_ch_idx_to_limit_array(struct rf_info *rf, u8 channel)
+static u8 halrf_get_ch_idx_to_limit_array(struct rf_info *rf, u8 channel)
 {
 	u8	channelIndex;
 
@@ -593,7 +593,7 @@ u8 halrf_get_ch_idx_to_limit_array(struct rf_info *rf, u8 channel)
 	return channelIndex;
 }
 
-u8 halrf_get_ch_idx_to_6g_limit_array(struct rf_info *rf, u8 channel)
+static u8 halrf_get_ch_idx_to_6g_limit_array(struct rf_info *rf, u8 channel)
 {
 	u8	channelIndex;
 
@@ -661,7 +661,7 @@ u8 halrf_get_limit_ch_idx_to_ch_idx(struct rf_info *rf, u8 band, u8 channel)
 	return channelIndex;
 }
 
-u16 halrf_hw_rate_to_pwr_by_rate(struct rf_info *rf, u16 rate)
+static u16 halrf_hw_rate_to_pwr_by_rate(struct rf_info *rf, u16 rate)
 {
 	u16 ret_rate = HALRF_DATA_RATE_OFDM6;
 
@@ -807,7 +807,7 @@ u16 halrf_hw_rate_to_pwr_by_rate(struct rf_info *rf, u16 rate)
 	return ret_rate;
 }
 
-u16 halrf_get_dcm_offset_pwr_by_rate(struct rf_info *rf, u16 rate,
+static u16 halrf_get_dcm_offset_pwr_by_rate(struct rf_info *rf, u16 rate,
 						u8 dcm, u8 offset)
 {
 	u16 rate_tmp = 0;
@@ -852,7 +852,7 @@ u16 halrf_get_dcm_offset_pwr_by_rate(struct rf_info *rf, u16 rate,
 
 }
 
-u8 halrf_hw_rate_to_limit_rate_tx_num(struct rf_info *rf, u16 rate)
+static u8 halrf_hw_rate_to_limit_rate_tx_num(struct rf_info *rf, u16 rate)
 {
 	if (rate >= RTW_DATA_RATE_CCK1 && rate <= RTW_DATA_RATE_CCK11)
 		return PW_LMT_RS_CCK;
@@ -1134,7 +1134,8 @@ void halrf_power_limit_ru_set_worldwide(struct rf_info *rf)
 
 }
 
-void halrf_set_ext_power_limit_table(struct rf_info *rf,
+#ifdef SPF_PHL_RF_019_SAR
+static void halrf_set_ext_power_limit_table(struct rf_info *rf,
 							enum phl_phy_idx phy)
 {
 #ifdef SPF_PHL_RF_019_SAR
@@ -1470,7 +1471,7 @@ void halrf_set_ext_power_limit_table(struct rf_info *rf,
 #endif
 }
 
-void halrf_set_ext_power_limit_ru_table(struct rf_info *rf,
+static void halrf_set_ext_power_limit_ru_table(struct rf_info *rf,
 							enum phl_phy_idx phy)
 {
 #ifdef SPF_PHL_RF_019_SAR
@@ -1793,6 +1794,7 @@ void halrf_set_ext_power_limit_ru_table(struct rf_info *rf,
 	RF_DBG(rf, DBG_RF_INIT, "<======%s finish!!!\n", __func__);
 #endif
 }
+#endif /* SPF_PHL_RF_019_SAR */
 
 void halrf_power_limit_set_ext_pwr_limit_table(struct rf_info *rf,
 							enum phl_phy_idx phy)
@@ -2591,14 +2593,14 @@ bool halrf_control_tx_rate_power (void *rf_void, enum phl_phy_idx phy_idx, s32 m
 	return true;
 }
 
-void halrf_set_tpe_default_control(struct rf_info *rf, enum phl_phy_idx phy)
+static void halrf_set_tpe_default_control(struct rf_info *rf, enum phl_phy_idx phy)
 {
 	RF_DBG(rf, DBG_RF_POWER, "[TPE] ======>%s\n", __func__);
 
 	halrf_set_power(rf, phy, PWR_LIMIT | PWR_LIMIT_RU);
 }
 
-void halrf_set_eirp_tpe_control(struct rf_info *rf, enum phl_phy_idx phy, s8 *power, u8 valid_tpe_cnt)
+static void halrf_set_eirp_tpe_control(struct rf_info *rf, enum phl_phy_idx phy, s8 *power, u8 valid_tpe_cnt)
 {
 	struct rtw_tpu_pwr_imt_info *lmt = &rf->hal_com->band[phy].rtw_tpu_i.rtw_tpu_pwr_imt_i;
 	struct rtw_hal_com_t *hal = rf->hal_com;
@@ -2741,7 +2743,7 @@ void halrf_set_eirp_tpe_control(struct rf_info *rf, enum phl_phy_idx phy, s8 *po
 	}
 }
 
-void halrf_set_eirp_psd_special_tpe_control(struct rf_info *rf, enum phl_phy_idx phy, s8 power)
+static void halrf_set_eirp_psd_special_tpe_control(struct rf_info *rf, enum phl_phy_idx phy, s8 power)
 {
 	struct rtw_tpu_pwr_imt_info *lmt = &rf->hal_com->band[phy].rtw_tpu_i.rtw_tpu_pwr_imt_i;
 	struct rtw_hal_com_t *hal = rf->hal_com;
@@ -2846,7 +2848,7 @@ void halrf_set_eirp_psd_special_tpe_control(struct rf_info *rf, enum phl_phy_idx
 	}
 }
 
-void halrf_set_eirp_psd_tpe_control(struct rf_info *rf, enum phl_phy_idx phy, s8* power, u8 valid_tpe_cnt)
+static void halrf_set_eirp_psd_tpe_control(struct rf_info *rf, enum phl_phy_idx phy, s8* power, u8 valid_tpe_cnt)
 {
 	struct rtw_tpu_pwr_imt_info *lmt = &rf->hal_com->band[phy].rtw_tpu_i.rtw_tpu_pwr_imt_i;
 	struct rtw_hal_com_t *hal = rf->hal_com;

--- a/phl/hal_g6/rtl8852b/hal_trx_8852b.c
+++ b/phl/hal_g6/rtl8852b/hal_trx_8852b.c
@@ -423,7 +423,7 @@ _hal_parsing_rx_wd_8852b(struct hal_info_t *hal,
  * 	rxwd : rx desc
  */
 
-enum rtw_hal_status
+static enum rtw_hal_status
 hal_parsing_rx_wd_8852b(struct rtw_phl_com_t *phl_com,
 				struct hal_info_t *hal,
 				u8 *buf, u8 **pkt, u16 *pkt_len,

--- a/phl/hal_g6/rtl8852b/rtl8852b_halinit.c
+++ b/phl/hal_g6/rtl8852b/rtl8852b_halinit.c
@@ -192,7 +192,7 @@ void init_default_value_8852b(struct hal_info_t *hal)
 {
 }
 
-u32 _hal_cfg_rom_fw_8852b(enum rtw_fw_type fw_type, struct rtw_fw_info_t *fw_info,
+static u32 _hal_cfg_rom_fw_8852b(enum rtw_fw_type fw_type, struct rtw_fw_info_t *fw_info,
 			  char *ic_name)
 {
 	char *hal_phy_folder = FW_FILE_CONFIG_PATH;
@@ -232,7 +232,7 @@ u32 _hal_cfg_rom_fw_8852b(enum rtw_fw_type fw_type, struct rtw_fw_info_t *fw_inf
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
-u32 _hal_cfg_intnal_fw_8852b(struct rtw_phl_com_t *phl_com,enum rtw_fw_type fw_type,struct rtw_fw_info_t *fw_info)
+static u32 _hal_cfg_intnal_fw_8852b(struct rtw_phl_com_t *phl_com,enum rtw_fw_type fw_type,struct rtw_fw_info_t *fw_info)
 {
 	/* any related to fw from header can be defined here */
 	return RTW_HAL_STATUS_SUCCESS;

--- a/phl/hal_g6/rtl8852b/sdio/rtl8852bs_ops.c
+++ b/phl/hal_g6/rtl8852b/sdio/rtl8852bs_ops.c
@@ -95,7 +95,7 @@ static u8 hal_mapping_hw_tx_chnl_8852bs(struct hal_info_t *hal,
 	return dma_ch;
 }
 
-u16 hal_get_avail_page_8852bs(struct rtw_hal_com_t *hal_com, u8 dma_ch,
+static u16 hal_get_avail_page_8852bs(struct rtw_hal_com_t *hal_com, u8 dma_ch,
 			u16 *host_idx, u16 *hw_idx)
 {
 	enum rtw_hal_status hstatus = RTW_HAL_STATUS_FAILURE;
@@ -106,7 +106,7 @@ static void hal_trx_deinit_8852bs(struct hal_info_t *hal)
 {
 }
 
-enum rtw_hal_status hal_trx_init_8852bs(struct hal_info_t *hal)
+static enum rtw_hal_status hal_trx_init_8852bs(struct hal_info_t *hal)
 {
 	enum rtw_hal_status hstatus = RTW_HAL_STATUS_FAILURE;
 

--- a/phl/hal_g6/rtl8852b/sdio/rtl8852bs_ops.c
+++ b/phl/hal_g6/rtl8852b/sdio/rtl8852bs_ops.c
@@ -15,6 +15,7 @@
 #define _RTL8852BS_OPS_C_
 #include "../rtl8852b_hal.h"
 #include "rtl8852bs.h"
+#include "../../hal_sdio.h"
 
 void hal_set_ops_8852bs(struct rtw_phl_com_t *phl_com,
 					struct hal_info_t *hal)

--- a/phl/hal_g6/test/mp/hal_test_mp_cal.c
+++ b/phl/hal_g6/test/mp/hal_test_mp_cal.c
@@ -15,6 +15,7 @@
 #define _HAL_TEST_MP_CAL_C_
 #include "../../hal_headers.h"
 #include "../../../test/mp/phl_test_mp_def.h"
+#include "hal_test_mp_api.h"
 
 #ifdef CONFIG_HAL_TEST_MP
 enum rtw_hal_status rtw_hal_mp_cal_trigger(

--- a/phl/hal_g6/test/mp/hal_test_mp_config.c
+++ b/phl/hal_g6/test/mp/hal_test_mp_config.c
@@ -271,7 +271,7 @@ enum rtw_hal_status rtw_hal_mp_config_set_mac_addr(
 	return hal_status;
 }
 
-u8 hal_mp_primary_channel_decision(u8 cent_ch, enum channel_width bw, u8 tx_sc)
+static u8 hal_mp_primary_channel_decision(u8 cent_ch, enum channel_width bw, u8 tx_sc)
 {
 	u8 pri_ch = 0;
 
@@ -326,7 +326,7 @@ u8 hal_mp_primary_channel_decision(u8 cent_ch, enum channel_width bw, u8 tx_sc)
 	return pri_ch;
 }
 
-enum chan_offset
+static enum chan_offset
 hal_mp_chan_offset_decision(u8 pri_ch, u8 cent_ch, enum channel_width bw)
 {
 	enum chan_offset offset = CHAN_OFFSET_NO_EXT;

--- a/phl/hal_g6/test/mp/hal_test_mp_config.c
+++ b/phl/hal_g6/test/mp/hal_test_mp_config.c
@@ -15,6 +15,7 @@
 #define _HAL_TEST_MP_CONFIG_C_
 #include "../../hal_headers.h"
 #include "../../../test/mp/phl_test_mp_def.h"
+#include "hal_test_mp_api.h"
 
 #ifdef CONFIG_HAL_TEST_MP
 enum rtw_hal_status rtw_hal_mp_config_start_dut(

--- a/phl/hal_g6/test/mp/hal_test_mp_efuse.c
+++ b/phl/hal_g6/test/mp/hal_test_mp_efuse.c
@@ -15,6 +15,7 @@
 #define _HAL_TEST_MP_EFUSE_C_
 #include "../../hal_headers.h"
 #include "../../../test/mp/phl_test_mp_def.h"
+#include "hal_test_mp_api.h"
 
 #ifdef CONFIG_HAL_TEST_MP
 

--- a/phl/hal_g6/test/mp/hal_test_mp_reg.c
+++ b/phl/hal_g6/test/mp/hal_test_mp_reg.c
@@ -15,6 +15,7 @@
 #define _HAL_TEST_MP_REG_C_
 #include "../../hal_headers.h"
 #include "../../../test/mp/phl_test_mp_def.h"
+#include "hal_test_mp_api.h"
 
 #ifdef CONFIG_HAL_TEST_MP
 enum rtw_hal_status rtw_hal_mp_reg_read_macreg(

--- a/phl/hal_g6/test/mp/hal_test_mp_rx.c
+++ b/phl/hal_g6/test/mp/hal_test_mp_rx.c
@@ -15,6 +15,7 @@
 #define _HAL_TEST_MP_RX_C_
 #include "../../hal_headers.h"
 #include "../../../test/mp/phl_test_mp_def.h"
+#include "hal_test_mp_api.h"
 
 #ifdef CONFIG_HAL_TEST_MP
 enum rtw_hal_status rtw_hal_mp_rx_phy_crc_ok(

--- a/phl/hal_g6/test/mp/hal_test_mp_tx.c
+++ b/phl/hal_g6/test/mp/hal_test_mp_tx.c
@@ -19,7 +19,7 @@
 
 #ifdef CONFIG_HAL_TEST_MP
 
-void
+static void
 _mp_get_plcp_common_info(struct mp_context *mp,
                             struct mp_tx_arg *arg,
                             struct halbb_plcp_info *plcp_tx_struct)
@@ -164,7 +164,7 @@ _mp_get_plcp_common_info(struct mp_context *mp,
 	}
 }
 
-void
+static void
 _mp_get_plcp_user_info(struct mp_context *mp,
                         struct usr_plcp_gen_in *plcp_user_struct)
 {

--- a/phl/hal_g6/test/mp/hal_test_mp_tx.c
+++ b/phl/hal_g6/test/mp/hal_test_mp_tx.c
@@ -16,6 +16,7 @@
 #include "../../hal_headers.h"
 #include "../../../test/mp/phl_test_mp_def.h"
 #include "../../../test/mp/phl_test_mp_watchdog.h"
+#include "hal_test_mp_api.h"
 
 #ifdef CONFIG_HAL_TEST_MP
 

--- a/phl/hal_g6/test/mp/hal_test_mp_txpwr.c
+++ b/phl/hal_g6/test/mp/hal_test_mp_txpwr.c
@@ -15,6 +15,7 @@
 #define _PHL_TEST_MP_TXPWR_C_
 #include "../../hal_headers.h"
 #include "../../../test/mp/phl_test_mp_def.h"
+#include "hal_test_mp_api.h"
 
 #ifdef CONFIG_HAL_TEST_MP
 enum rtw_hal_status rtw_hal_mp_txpwr_read_table(

--- a/phl/hci/phl_trx_sdio.c
+++ b/phl/hci/phl_trx_sdio.c
@@ -764,7 +764,7 @@ static enum rtw_phl_status phl_recycle_rx_buf_sdio(struct phl_info_t *phl,
 
 	return RTW_PHL_STATUS_SUCCESS;
 }
-void phl_rx_handle_normal(struct phl_info_t *phl,
+static void phl_rx_handle_normal(struct phl_info_t *phl,
 					 struct rtw_phl_rx_pkt *phl_rx)
 {
  	enum rtw_phl_status pstatus = RTW_PHL_STATUS_FAILURE;
@@ -1623,7 +1623,7 @@ static void *phl_get_rxbd_buf_sdio(struct phl_info_t *phl)
 	return NULL;
 }
 
-void phl_recycle_rx_pkt_sdio(struct phl_info_t *phl_info,
+static void phl_recycle_rx_pkt_sdio(struct phl_info_t *phl_info,
 				struct rtw_phl_rx_pkt *phl_rx)
 {
 	if (phl_rx->r.os_priv)
@@ -1636,7 +1636,7 @@ void phl_recycle_rx_pkt_sdio(struct phl_info_t *phl_info,
 }
 
 
-void phl_tx_watchdog_sdio(struct phl_info_t *phl_info)
+static void phl_tx_watchdog_sdio(struct phl_info_t *phl_info)
 {
 
 }

--- a/phl/phl_api_drv.c
+++ b/phl/phl_api_drv.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _PHL_API_DRV_C_
 #include "phl_headers.h"
+#include "phl_api_drv.h"
 
 void *rtw_phl_get_txbd_buf(struct rtw_phl_com_t *phl_com)
 {

--- a/phl/phl_cmd_btc.c
+++ b/phl/phl_cmd_btc.c
@@ -1014,13 +1014,13 @@ bool rtw_phl_btc_send_cmd(struct rtw_phl_com_t *phl_com,
 #endif /*CONFIG_PHL_CMD_BTC*/
 
 #ifndef CONFIG_FSM
-int rtw_phl_btc_notify(void *phl, enum RTW_PHL_BTC_NOTIFY notify,
+static int rtw_phl_btc_notify(void *phl, enum RTW_PHL_BTC_NOTIFY notify,
 				struct rtw_phl_btc_ntfy *ntfy)
 {
 	PHL_ERR("CMD_BTC not support :%s\n", __func__);
 	return 0;
 }
-void rtw_phl_btc_role_notify(void *phl, u8 role_id, enum role_state rstate)
+static void rtw_phl_btc_role_notify(void *phl, u8 role_id, enum role_state rstate)
 {
 	struct rtw_phl_btc_ntfy ntfy = {0};
 	struct rtw_phl_btc_role_info_param *prinfo = &ntfy.u.rinfo;
@@ -1036,7 +1036,7 @@ void rtw_phl_btc_role_notify(void *phl, u8 role_id, enum role_state rstate)
 	rtw_phl_btc_notify(phl, ntfy.notify, &ntfy);
 }
 
-void rtw_phl_btc_hub_msg_hdl(void *phl, struct phl_msg *msg)
+static void rtw_phl_btc_hub_msg_hdl(void *phl, struct phl_msg *msg)
 {
 }
 #endif

--- a/phl/phl_cmd_btc.c
+++ b/phl/phl_cmd_btc.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _PHL_CMD_BTC_C_
 #include "phl_headers.h"
+#include "phl_api_drv.h"
 
 #ifdef CONFIG_BTCOEX
 #ifdef CONFIG_PHL_CMD_BTC

--- a/phl/phl_cmd_dispatch_engine.c
+++ b/phl/phl_cmd_dispatch_engine.c
@@ -26,7 +26,7 @@ enum rtw_phl_status _disp_eng_get_dispr_by_idx(struct phl_info_t *phl,
                                                u8 band_idx,
                                                void **dispr);
 #if !defined(CONFIG_CMD_DISP_SOLO_MODE)
-int share_thread_hdl(void *param)
+static int share_thread_hdl(void *param)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)param;
 	void *d = phl_to_drvpriv(phl_info);

--- a/phl/phl_cmd_dispatcher.c
+++ b/phl/phl_cmd_dispatcher.c
@@ -392,7 +392,7 @@ static void push_back_wait_msg(struct cmd_dispatcher *obj,
 	notify_dispr_thread(obj);
 }
 
- u8 is_higher_priority(void *d, void *priv,_os_list *input, _os_list *obj)
+ static u8 is_higher_priority(void *d, void *priv,_os_list *input, _os_list *obj)
  {
 	struct phl_dispr_msg_ex *ex_input = (struct phl_dispr_msg_ex *)input;
 	struct phl_dispr_msg_ex *ex_obj = (struct phl_dispr_msg_ex *)obj;
@@ -531,7 +531,7 @@ static bool is_msg_canceled(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex 
 	return false;
 }
 
-void init_dispr_msg_pool(struct cmd_dispatcher *obj)
+static void init_dispr_msg_pool(struct cmd_dispatcher *obj)
 {
 	u16 i = 0;
 	void *d = phl_to_drvpriv(obj->phl_info);
@@ -551,7 +551,7 @@ void init_dispr_msg_pool(struct cmd_dispatcher *obj)
 	SET_STATUS_FLAG(obj->status, DISPR_MSGQ_INIT);
 }
 
-void deinit_dispr_msg_pool(struct cmd_dispatcher *obj)
+static void deinit_dispr_msg_pool(struct cmd_dispatcher *obj)
 {
 	void *d = phl_to_drvpriv(obj->phl_info);
 
@@ -564,7 +564,7 @@ void deinit_dispr_msg_pool(struct cmd_dispatcher *obj)
 	pq_deinit(d, &(obj->msg_pend_q));
 }
 
-void cancel_msg(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex)
+static void cancel_msg(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex)
 {
 	void *d = phl_to_drvpriv(obj->phl_info);
 
@@ -577,7 +577,7 @@ void cancel_msg(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex)
 	SET_STATUS_FLAG(ex->status, MSG_STATUS_CANCEL);
 }
 
-void cancel_running_msg(struct cmd_dispatcher *obj)
+static void cancel_running_msg(struct cmd_dispatcher *obj)
 {
 	u16 i = 0;
 
@@ -586,7 +586,7 @@ void cancel_running_msg(struct cmd_dispatcher *obj)
 			cancel_msg(obj, &(obj->msg_ex_pool[i]));
 	}
 }
-void set_msg_bitmap(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex, u8 mdl_id)
+static void set_msg_bitmap(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex, u8 mdl_id)
 {
 	void *d = phl_to_drvpriv(obj->phl_info);
 
@@ -622,7 +622,7 @@ static void set_msg_custom_bitmap(struct cmd_dispatcher *obj, struct phl_dispr_m
 	}
 }
 
-u8 *get_msg_bitmap(struct phl_dispr_msg_ex *ex)
+static u8 *get_msg_bitmap(struct phl_dispr_msg_ex *ex)
 {
 	if (TEST_STATUS_FLAG(ex->status, MSG_STATUS_PRE_PHASE)) {
 		SET_MSG_INDC_FIELD(ex->msg.msg_id, MSG_INDC_PRE_PHASE);
@@ -634,7 +634,7 @@ u8 *get_msg_bitmap(struct phl_dispr_msg_ex *ex)
 }
 
 
-void init_dispr_mdl_mgnt_info(struct cmd_dispatcher *obj)
+static void init_dispr_mdl_mgnt_info(struct cmd_dispatcher *obj)
 {
 	u8 i = 0;
 
@@ -728,7 +728,7 @@ static void clear_wating_req(struct cmd_dispatcher *obj)
 	}
 }
 
-void deregister_cur_cmd_req(struct cmd_dispatcher *obj, u8 notify)
+static void deregister_cur_cmd_req(struct cmd_dispatcher *obj, u8 notify)
 {
 	struct phl_cmd_token_req *req = NULL;
 	void *d = phl_to_drvpriv(obj->phl_info);
@@ -774,7 +774,7 @@ void deregister_cur_cmd_req(struct cmd_dispatcher *obj, u8 notify)
 	PHL_TRACE(COMP_PHL_CMDDISP, _PHL_INFO_, "%s[%d]\n", __func__, obj->idx);
 }
 
-u8 register_cur_cmd_req(struct cmd_dispatcher *obj,
+static u8 register_cur_cmd_req(struct cmd_dispatcher *obj,
 			  struct phl_cmd_token_req_ex *req)
 {
 	void *d = phl_to_drvpriv(obj->phl_info);
@@ -802,7 +802,7 @@ u8 register_cur_cmd_req(struct cmd_dispatcher *obj,
 	}
 }
 
-void cancel_all_cmd_req(struct cmd_dispatcher *obj)
+static void cancel_all_cmd_req(struct cmd_dispatcher *obj)
 {
 	u8 i = 0;
 	struct phl_cmd_token_req_ex* req_ex = NULL;
@@ -814,7 +814,7 @@ void cancel_all_cmd_req(struct cmd_dispatcher *obj)
 	}
 }
 
-void init_cmd_req_pool(struct cmd_dispatcher *obj)
+static void init_cmd_req_pool(struct cmd_dispatcher *obj)
 {
 	u8 i = 0;
 	void *d = phl_to_drvpriv(obj->phl_info);
@@ -834,7 +834,7 @@ void init_cmd_req_pool(struct cmd_dispatcher *obj)
 	SET_STATUS_FLAG(obj->status, DISPR_REQ_INIT);
 }
 
-void deinit_cmd_req_pool(struct cmd_dispatcher *obj)
+static void deinit_cmd_req_pool(struct cmd_dispatcher *obj)
 {
 	void *d = phl_to_drvpriv(obj->phl_info);
 
@@ -848,7 +848,7 @@ void deinit_cmd_req_pool(struct cmd_dispatcher *obj)
 	pq_deinit(d, &(obj->token_op_q));
 }
 
-u8 chk_module_ops(struct phl_bk_module_ops *ops)
+static u8 chk_module_ops(struct phl_bk_module_ops *ops)
 {
 	if (ops == NULL ||
 	    ops->init == NULL ||
@@ -862,7 +862,7 @@ u8 chk_module_ops(struct phl_bk_module_ops *ops)
 	return true;
 }
 
-u8 chk_cmd_req_ops(struct phl_cmd_token_req *req)
+static u8 chk_cmd_req_ops(struct phl_cmd_token_req *req)
 {
 	if (req == NULL ||
 	    req->module_id < PHL_FG_MDL_START ||
@@ -911,7 +911,7 @@ static u8 push_back_token_op_info(struct cmd_dispatcher *obj,
 	return true;
 }
 
-void _handle_token_op_info(struct cmd_dispatcher *obj, struct phl_token_op_info *op_info)
+static void _handle_token_op_info(struct cmd_dispatcher *obj, struct phl_token_op_info *op_info)
 {
 	struct phl_cmd_token_req_ex *req_ex = NULL;
 	void *d = phl_to_drvpriv(obj->phl_info);
@@ -954,7 +954,7 @@ void _handle_token_op_info(struct cmd_dispatcher *obj, struct phl_token_op_info 
 	}
 }
 
-void token_op_hanler(struct cmd_dispatcher *obj)
+static void token_op_hanler(struct cmd_dispatcher *obj)
 {
 	struct phl_token_op_info *info = NULL;
 	void *d = phl_to_drvpriv(obj->phl_info);
@@ -985,7 +985,7 @@ dispr_enqueue_token_op_info(struct cmd_dispatcher *obj,
 	return push_back_token_op_info(obj, op_info, type, data);
 }
 
-u8 bk_module_init(struct cmd_dispatcher *obj, struct phl_bk_module *module)
+static u8 bk_module_init(struct cmd_dispatcher *obj, struct phl_bk_module *module)
 {
 	if (TEST_STATUS_FLAG(module->status, MDL_INIT)) {
 		PHL_TRACE(COMP_PHL_CMDDISP, _PHL_ERR_, "%s[%d] module_id:%d already init\n",
@@ -1004,14 +1004,14 @@ u8 bk_module_init(struct cmd_dispatcher *obj, struct phl_bk_module *module)
 	}
 }
 
-void bk_module_deinit(struct cmd_dispatcher *obj, struct phl_bk_module *module)
+static void bk_module_deinit(struct cmd_dispatcher *obj, struct phl_bk_module *module)
 {
 	if (TEST_STATUS_FLAG(module->status, MDL_INIT))
 		module->ops.deinit((void*)obj, module->priv);
 	CLEAR_STATUS_FLAG(module->status, MDL_INIT);
 }
 
-u8 bk_module_start(struct cmd_dispatcher *obj, struct phl_bk_module *module)
+static u8 bk_module_start(struct cmd_dispatcher *obj, struct phl_bk_module *module)
 {
 	if (!TEST_STATUS_FLAG(module->status, MDL_INIT) ||
 	    TEST_STATUS_FLAG(module->status, MDL_STARTED)) {
@@ -1033,7 +1033,7 @@ u8 bk_module_start(struct cmd_dispatcher *obj, struct phl_bk_module *module)
 	}
 }
 
-u8 bk_module_stop(struct cmd_dispatcher *obj, struct phl_bk_module *module)
+static u8 bk_module_stop(struct cmd_dispatcher *obj, struct phl_bk_module *module)
 {
 	if (!TEST_STATUS_FLAG(module->status, MDL_STARTED))
 		return false;
@@ -1050,7 +1050,7 @@ u8 bk_module_stop(struct cmd_dispatcher *obj, struct phl_bk_module *module)
 	}
 }
 
-void cur_req_hdl(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex)
+static void cur_req_hdl(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex)
 {
 	struct phl_cmd_token_req_ex *cur_req = obj->cur_cmd_req;
 
@@ -1064,7 +1064,7 @@ void cur_req_hdl(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex)
 	cur_req->req.msg_hdlr((void*)obj, cur_req->req.priv, &(ex->msg));
 }
 
-void notify_msg_fail(struct cmd_dispatcher *obj,
+static void notify_msg_fail(struct cmd_dispatcher *obj,
                      struct phl_dispr_msg_ex *ex,
                      enum phl_mdl_ret_code ret)
 {
@@ -1088,7 +1088,7 @@ void notify_msg_fail(struct cmd_dispatcher *obj,
 	}
 }
 
-enum phl_mdl_ret_code feed_mdl_msg(struct cmd_dispatcher *obj,
+static enum phl_mdl_ret_code feed_mdl_msg(struct cmd_dispatcher *obj,
 				   struct phl_bk_module *mdl,
 				   struct phl_dispr_msg_ex *ex)
 {
@@ -1116,7 +1116,7 @@ enum phl_mdl_ret_code feed_mdl_msg(struct cmd_dispatcher *obj,
 	return ret;
 }
 
-void msg_pre_phase_hdl(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex)
+static void msg_pre_phase_hdl(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex)
 {
 	s8 i = 0;
 	void *d = phl_to_drvpriv(obj->phl_info);
@@ -1158,7 +1158,7 @@ void msg_pre_phase_hdl(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex)
 	}
 }
 
-void msg_post_phase_hdl(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex)
+static void msg_post_phase_hdl(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex)
 {
 	s8 i = 0;
 	void *d = phl_to_drvpriv(obj->phl_info);
@@ -1198,7 +1198,7 @@ void msg_post_phase_hdl(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex)
 	}
 }
 
-u8 get_cur_cmd_req_id(struct cmd_dispatcher *obj, u32 *req_status)
+static u8 get_cur_cmd_req_id(struct cmd_dispatcher *obj, u32 *req_status)
 {
 	struct phl_cmd_token_req_ex *cur_req = obj->cur_cmd_req;
 
@@ -1225,7 +1225,7 @@ u8 get_cur_cmd_req_id(struct cmd_dispatcher *obj, u32 *req_status)
 	if (TEST_STATUS_FLAG(ex->status, MSG_STATUS_PENDING)) \
 		goto reschedule;
 
-void msg_dispatch(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex)
+static void msg_dispatch(struct cmd_dispatcher *obj, struct phl_dispr_msg_ex *ex)
 {
 	u8 *bitmap = get_msg_bitmap(ex);
 	void *d = phl_to_drvpriv(obj->phl_info);
@@ -1284,7 +1284,7 @@ recycle:
 	push_back_idle_msg(obj, ex);
 }
 
-void dispr_thread_loop_hdl(struct cmd_dispatcher *obj)
+static void dispr_thread_loop_hdl(struct cmd_dispatcher *obj)
 {
 	struct phl_dispr_msg_ex *ex = NULL;
 
@@ -1312,7 +1312,7 @@ void dispr_thread_loop_hdl(struct cmd_dispatcher *obj)
 	}
 }
 
-void dispr_thread_leave_hdl(struct cmd_dispatcher *obj)
+static void dispr_thread_leave_hdl(struct cmd_dispatcher *obj)
 {
 	deregister_cur_cmd_req(obj, true);
 	/* clear remaining pending & waiting msg */
@@ -1342,7 +1342,7 @@ int background_thread_hdl(void *param)
 	return 0;
 }
 #endif
-u8 search_mdl(void *d, void *mdl, void *priv)
+static u8 search_mdl(void *d, void *mdl, void *priv)
 {
 	enum phl_module_id id = *(enum phl_module_id *)priv;
 	struct phl_bk_module *module = NULL;
@@ -1356,7 +1356,7 @@ u8 search_mdl(void *d, void *mdl, void *priv)
 		return false;
 }
 
-u8 get_module_by_id(struct cmd_dispatcher *obj, enum phl_module_id id,
+static u8 get_module_by_id(struct cmd_dispatcher *obj, enum phl_module_id id,
 		    struct phl_bk_module **mdl)
 {
 	void *d = phl_to_drvpriv(obj->phl_info);
@@ -1474,7 +1474,7 @@ void _notify_dispr_controller(struct cmd_dispatcher *obj, struct phl_dispr_msg_e
 
 }
 
-void dispr_thread_stop_prior_hdl(struct cmd_dispatcher *obj)
+static void dispr_thread_stop_prior_hdl(struct cmd_dispatcher *obj)
 {
 	if (!TEST_STATUS_FLAG(obj->status, DISPR_STARTED))
 		return;
@@ -1485,7 +1485,7 @@ void dispr_thread_stop_prior_hdl(struct cmd_dispatcher *obj)
 	cancel_running_msg(obj);
 }
 
-void dispr_thread_stop_post_hdl(struct cmd_dispatcher *obj)
+static void dispr_thread_stop_post_hdl(struct cmd_dispatcher *obj)
 {
 	void *d = phl_to_drvpriv(obj->phl_info);
 

--- a/phl/phl_cmd_dispr_controller.c
+++ b/phl/phl_cmd_dispr_controller.c
@@ -43,7 +43,7 @@ struct cmd_controller {
  * phl mgnt status : stop/surprise remove/cannot io
 */
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_resume_io_ctrl(struct phl_info_t *phl_info,
                       struct phl_msg *msg)
 {
@@ -83,7 +83,7 @@ _dispr_resume_io_ctrl(struct phl_info_t *phl_info,
 }
 
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_cannot_io_ctrl(struct phl_info_t *phl_info,
                       struct phl_msg *msg)
 {
@@ -106,7 +106,7 @@ _dispr_cannot_io_ctrl(struct phl_info_t *phl_info,
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_hw_trx_rst_resume_ctrl(struct phl_info_t *phl_info,
                               struct phl_msg *msg)
 {
@@ -129,7 +129,7 @@ _dispr_hw_trx_rst_resume_ctrl(struct phl_info_t *phl_info,
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_hw_trx_pause_ctrl(struct phl_info_t *phl_info,
                          struct phl_msg *msg)
 {
@@ -152,7 +152,7 @@ _dispr_hw_trx_pause_ctrl(struct phl_info_t *phl_info,
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_sw_tx_resume_ctrl(struct phl_info_t *phl_info,
                          struct phl_msg *msg)
 {
@@ -182,7 +182,7 @@ _dispr_sw_tx_resume_ctrl(struct phl_info_t *phl_info,
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_sw_rx_resume_ctrl(struct phl_info_t *phl_info,
                          struct phl_msg *msg)
 {
@@ -212,7 +212,7 @@ _dispr_sw_rx_resume_ctrl(struct phl_info_t *phl_info,
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_sw_tx_pause_ctrl(struct phl_info_t *phl_info,
                         struct phl_msg *msg)
 {
@@ -235,7 +235,7 @@ _dispr_sw_tx_pause_ctrl(struct phl_info_t *phl_info,
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_sw_rx_pause_ctrl(struct phl_info_t *phl_info,
                         struct phl_msg *msg)
 {
@@ -258,7 +258,7 @@ _dispr_sw_rx_pause_ctrl(struct phl_info_t *phl_info,
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_sw_tx_reset_ctrl(struct phl_info_t *phl_info,
                         struct phl_msg *msg)
 {
@@ -281,7 +281,7 @@ _dispr_sw_tx_reset_ctrl(struct phl_info_t *phl_info,
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_sw_rx_reset_ctrl(struct phl_info_t *phl_info,
                         struct phl_msg *msg)
 {
@@ -304,7 +304,7 @@ _dispr_sw_rx_reset_ctrl(struct phl_info_t *phl_info,
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_trx_sw_pause_ctrl(struct phl_info_t *phl_info,
                          struct phl_msg *msg)
 {
@@ -327,7 +327,7 @@ _dispr_trx_sw_pause_ctrl(struct phl_info_t *phl_info,
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_trx_sw_resume_ctrl(struct phl_info_t *phl_info,
                           struct phl_msg *msg)
 {
@@ -350,7 +350,7 @@ _dispr_trx_sw_resume_ctrl(struct phl_info_t *phl_info,
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_trx_pause_w_rst_ctrl(struct phl_info_t *phl_info,
                             struct phl_msg *msg)
 {
@@ -373,7 +373,7 @@ _dispr_trx_pause_w_rst_ctrl(struct phl_info_t *phl_info,
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_trx_resume_w_rst_ctrl(struct phl_info_t *phl_info,
                              struct phl_msg *msg)
 {
@@ -396,7 +396,7 @@ _dispr_trx_resume_w_rst_ctrl(struct phl_info_t *phl_info,
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_mdl_stop_ctrl(struct phl_info_t *phl_info,
 	struct cmd_controller *cmd_ctrl)
 {
@@ -408,7 +408,7 @@ _dispr_mdl_stop_ctrl(struct phl_info_t *phl_info,
 	}
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_ctrl_init(void *phl,
                  void *dispr,
                  void **priv)
@@ -433,7 +433,7 @@ _dispr_ctrl_init(void *phl,
 	return MDL_RET_SUCCESS;
 }
 
-void _dispr_ctrl_deinit(void *dispr, void *priv)
+static void _dispr_ctrl_deinit(void *dispr, void *priv)
 {
 	struct cmd_controller *cmd_ctrl = (struct cmd_controller *)priv;
 	void *drv = phl_to_drvpriv(cmd_ctrl->phl_info);
@@ -443,7 +443,7 @@ void _dispr_ctrl_deinit(void *dispr, void *priv)
 	PHL_INFO("%s(): \n", __func__);
 }
 
-enum phl_mdl_ret_code _dispr_ctrl_start(void *dispr, void *priv)
+static enum phl_mdl_ret_code _dispr_ctrl_start(void *dispr, void *priv)
 {
 	enum phl_mdl_ret_code ret = MDL_RET_SUCCESS;
 	struct cmd_controller *cmd_ctrl = (struct cmd_controller *)priv;
@@ -458,7 +458,7 @@ enum phl_mdl_ret_code _dispr_ctrl_start(void *dispr, void *priv)
 	return ret;
 }
 
-enum phl_mdl_ret_code _dispr_ctrl_stop(void *dispr, void *priv)
+static enum phl_mdl_ret_code _dispr_ctrl_stop(void *dispr, void *priv)
 {
 	enum phl_mdl_ret_code ret = MDL_RET_SUCCESS;
 
@@ -623,7 +623,7 @@ _external_msg_hdlr(void *dispr,
 
 	return ret;
 }
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_ctrl_msg_hdlr(void *dispr,
                      void *priv,
                      struct phl_msg *msg)
@@ -649,7 +649,7 @@ _dispr_ctrl_msg_hdlr(void *dispr,
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_ctrl_set_info(void *dispr,
                      void *priv,
                      struct phl_module_op_info *info)
@@ -659,7 +659,7 @@ _dispr_ctrl_set_info(void *dispr,
 	return MDL_RET_IGNORE;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _dispr_ctrl_query_info(void *dispr, void *priv,
 			   struct phl_module_op_info *info)
 {

--- a/phl/phl_cmd_ps.c
+++ b/phl/phl_cmd_ps.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _PHL_CMD_PS_C_
 #include "phl_headers.h"
+#include "phl_api_drv.h"
 #ifdef CONFIG_POWER_SAVE
 /* structure of a power request */
 struct pwr_req {

--- a/phl/phl_cmd_ps.c
+++ b/phl/phl_cmd_ps.c
@@ -96,7 +96,7 @@ struct _ps_time_info {
 
 #define case_defer_rson(src) \
 		case PS_DEFER_##src: return #src
-const char *_defer_rson_to_str(u8 defer_rson)
+static const char *_defer_rson_to_str(u8 defer_rson)
 {
 	switch (defer_rson) {
 	case_defer_rson(DHCP_PKT);
@@ -192,7 +192,7 @@ static bool _chk_rssi_diff_reach_thld(struct cmd_ps *ps)
  * return true if beacon offset changed
  * @ps: see cmd_ps
  */
-bool _chk_bcn_offset_changed(struct cmd_ps *ps)
+static bool _chk_bcn_offset_changed(struct cmd_ps *ps)
 {
 	struct phl_info_t *phl_info = ps->phl_info;
 	u8 ridx = MAX_WIFI_ROLE_NUMBER;
@@ -353,7 +353,7 @@ static void _ps_cofig_pvb_wait_rx(struct cmd_ps *ps, bool pvb_wait_rx)
  * @leave_proto: whether to leave protocol
  * @rson: the reason of leaving power saving
  */
-enum rtw_phl_status _leave_ps(struct cmd_ps *ps, bool leave_proto, char *rson)
+static enum rtw_phl_status _leave_ps(struct cmd_ps *ps, bool leave_proto, char *rson)
 {
 	struct phl_info_t *phl_info = ps->phl_info;
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
@@ -505,7 +505,7 @@ _exit:
  * @macid: target macid to enter lps
  * @rson: the reason of entering power saving
  */
-enum rtw_phl_status _enter_ps(struct cmd_ps *ps, u8 ps_mode, u16 macid, bool sw_only, char *rson)
+static enum rtw_phl_status _enter_ps(struct cmd_ps *ps, u8 ps_mode, u16 macid, bool sw_only, char *rson)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
 	struct ps_cfg cfg = {0};
@@ -1516,7 +1516,7 @@ static enum phl_mdl_ret_code _ps_cancel_pwr_req_cmn(struct cmd_ps *ps, struct ph
 
 #define case_pkt_evt(src) \
 	case PKT_EVT_##src: return #src
-const char *_ps_pkt_evt_to_str(u8 pkt_evt)
+static const char *_ps_pkt_evt_to_str(u8 pkt_evt)
 {
 	switch (pkt_evt) {
 	case_pkt_evt(DHCP);

--- a/phl/phl_cmd_scan.c
+++ b/phl/phl_cmd_scan.c
@@ -18,6 +18,7 @@
 #include "phl_headers.h"
 #include "phl_scan.h"
 #include "phl_scanofld.h"
+#include "phl_api_drv.h"
 
 #define param_to_phlcom(_param)        (_param->wifi_role->phl_com)
 #define wrole_to_phl(_wrole)           ((struct phl_info_t *)(_wrole->phl_com->phl_priv))

--- a/phl/phl_cmd_scan.c
+++ b/phl/phl_cmd_scan.c
@@ -325,7 +325,7 @@ next_ch:
 }
 
 /* Notification complete */
-void _cmd_scan_timer_notify_cb(void *priv, struct phl_msg *msg)
+static void _cmd_scan_timer_notify_cb(void *priv, struct phl_msg *msg)
 {
 	struct cmd_scan_ctrl *sctrl = (struct cmd_scan_ctrl *)priv;
 
@@ -376,7 +376,7 @@ static void _cmd_scan_timer(void *context)
 }
 
 /* Notification complete */
-void _cmd_swch_done_notify_cb(
+static void _cmd_swch_done_notify_cb(
 	void *drv, struct phl_msg *msg)
 {
 	if (msg->inbuf) {
@@ -384,7 +384,7 @@ void _cmd_swch_done_notify_cb(
 	}
 }
 
-enum rtw_phl_status _cmd_swch_done_notify(
+static enum rtw_phl_status _cmd_swch_done_notify(
 	void *dispr, void *drv, struct rtw_phl_scan_param *param, u8 sctrl_idx)
 {
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_SUCCESS;
@@ -425,7 +425,7 @@ enum rtw_phl_status _cmd_swch_done_notify(
 	return pstatus;
 }
 
-void _cmd_scan_end(
+static void _cmd_scan_end(
 	void *drv, struct rtw_phl_scan_param *param,
 	u8 band_idx)
 {
@@ -492,7 +492,7 @@ error:
 }
 
 /* Notification complete */
-void _cmd_abort_notify_cb(
+static void _cmd_abort_notify_cb(
 	void *drv, struct phl_msg *msg)
 {
 	struct rtw_phl_scan_param *param = (struct rtw_phl_scan_param *)msg->inbuf;
@@ -503,7 +503,7 @@ void _cmd_abort_notify_cb(
 	_cmd_scan_end(drv, param, msg->band_idx);
 }
 
-void _cmd_abort_notify(void *dispr, void *drv,
+static void _cmd_abort_notify(void *dispr, void *drv,
 	struct rtw_phl_scan_param *param, bool abort)
 {
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_SUCCESS;
@@ -578,7 +578,7 @@ void _cmd_abort_notify(void *dispr, void *drv,
 	}
 }
 
-enum phl_mdl_ret_code _cmd_scan_fail_ev_hdlr(
+static enum phl_mdl_ret_code _cmd_scan_fail_ev_hdlr(
 	void* dispr, void* priv, struct phl_msg* msg)
 {
 	struct rtw_phl_scan_param *param = (struct rtw_phl_scan_param*)priv;
@@ -640,7 +640,7 @@ enum phl_mdl_ret_code _cmd_scan_fail_ev_hdlr(
 	return MDL_RET_SUCCESS;
 }
 
-enum phl_mdl_ret_code _cmd_scan_hdl_external_evt(
+static enum phl_mdl_ret_code _cmd_scan_hdl_external_evt(
 	void* dispr, void* priv, struct phl_msg* msg)
 {
 	PHL_DBG("%s :: From others MDL =%d , EVT_ID=%d\n", __func__,
@@ -727,7 +727,7 @@ static bool _handle_probing(void *d, struct rtw_phl_scan_param *param, u8 sctrl_
 	return true;
 }
 
-void
+static void
 _cmd_scan_start(struct phl_info_t *phl_info,
 		struct cmd_scan_ctrl *sctrl,
 		u8 band_idx)
@@ -739,7 +739,7 @@ _cmd_scan_start(struct phl_info_t *phl_info,
 	rtw_hal_notification(phl_info->hal, MSG_EVT_SCAN_START, band_idx);
 }
 
-enum phl_mdl_ret_code _cmd_scan_hdl_internal_evt(
+static enum phl_mdl_ret_code _cmd_scan_hdl_internal_evt(
 	void* dispr, void* priv, struct phl_msg* msg)
 {
 	struct rtw_phl_scan_param *param = (struct rtw_phl_scan_param*)priv;
@@ -953,7 +953,7 @@ enum phl_mdl_ret_code _cmd_scan_hdl_internal_evt(
 }
 
 
-enum phl_mdl_ret_code _phl_cmd_scan_req_acquired(
+static enum phl_mdl_ret_code _phl_cmd_scan_req_acquired(
 	void* dispr, void* priv)
 {
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_SUCCESS;
@@ -1017,7 +1017,7 @@ error:
 	return MDL_RET_FAIL;
 }
 
-enum phl_mdl_ret_code _phl_cmd_scan_req_abort(
+static enum phl_mdl_ret_code _phl_cmd_scan_req_abort(
 	void* dispr, void* priv)
 {
 	struct rtw_phl_scan_param *param = (struct rtw_phl_scan_param*)priv;
@@ -1029,7 +1029,7 @@ enum phl_mdl_ret_code _phl_cmd_scan_req_abort(
 	return MDL_RET_SUCCESS;
 }
 
-enum phl_mdl_ret_code _phl_cmd_scan_req_ev_hdlr(
+static enum phl_mdl_ret_code _phl_cmd_scan_req_ev_hdlr(
 	void* dispr, void* priv,
 	struct phl_msg* msg)
 {
@@ -1067,7 +1067,7 @@ enum phl_mdl_ret_code _phl_cmd_scan_req_ev_hdlr(
 	return ret;
 }
 
-enum phl_mdl_ret_code _phl_cmd_scan_req_set_info(
+static enum phl_mdl_ret_code _phl_cmd_scan_req_set_info(
 	void* dispr, void* priv, struct phl_module_op_info* info)
 {
 	enum phl_mdl_ret_code ret = MDL_RET_IGNORE;
@@ -1116,7 +1116,7 @@ enum phl_mdl_ret_code _phl_cmd_scan_req_set_info(
 	return ret;
 }
 
-enum phl_mdl_ret_code _phl_cmd_scan_req_query_info(
+static enum phl_mdl_ret_code _phl_cmd_scan_req_query_info(
 	void* dispr, void* priv, struct phl_module_op_info* info)
 {
 	struct rtw_phl_scan_param *param = (struct rtw_phl_scan_param*)priv;
@@ -1375,7 +1375,7 @@ _cmd_scan_req_deinit(struct phl_info_t *phl_info,
 	}
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_cmd_scan_req_submit(struct phl_info_t *phl_info,
 		       struct rtw_phl_scan_param *param)
 {

--- a/phl/phl_cmd_ser.c
+++ b/phl/phl_cmd_ser.c
@@ -122,7 +122,7 @@ _ser_event_notify(void *phl, u8 *p_ntfy)
 	return phl_ser_send_msg(phl, notify);
 }
 
-void _ser_dump_stsl2(struct cmd_ser *cser)
+static void _ser_dump_stsl2(struct cmd_ser *cser)
 {
 	u8 idx =0;
 
@@ -134,7 +134,7 @@ void _ser_dump_stsl2(struct cmd_ser *cser)
 	}
 }
 
-void _ser_reset_status(struct cmd_ser *cser)
+static void _ser_reset_status(struct cmd_ser *cser)
 {
 	void *drv = phl_to_drvpriv(cser->phl_info);
 
@@ -152,7 +152,7 @@ void _ser_reset_status(struct cmd_ser *cser)
 	}
 }
 
-void _ser_set_status(struct cmd_ser *cser, u8 serstatus)
+static void _ser_set_status(struct cmd_ser *cser, u8 serstatus)
 {
 	void *drv = phl_to_drvpriv(cser->phl_info);
 
@@ -161,7 +161,7 @@ void _ser_set_status(struct cmd_ser *cser, u8 serstatus)
 	_os_spinunlock(drv, &cser->_lock, _bh, NULL);
 }
 
-void _ser_clear_status(struct cmd_ser *cser, u8 serstatus)
+static void _ser_clear_status(struct cmd_ser *cser, u8 serstatus)
 {
 	void *drv = phl_to_drvpriv(cser->phl_info);
 
@@ -428,7 +428,7 @@ err:
 	return;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _ser_fail_ev_hdlr(void *dispr, void *priv, struct phl_msg *msg)
 {
 	struct cmd_ser *cser = (struct cmd_ser *)priv;
@@ -446,7 +446,7 @@ _ser_fail_ev_hdlr(void *dispr, void *priv, struct phl_msg *msg)
 	return MDL_RET_SUCCESS;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _ser_hdl_external_evt(void *dispr, void *priv, struct phl_msg *msg)
 {
 	struct cmd_ser *cser = (struct cmd_ser *)priv;
@@ -619,7 +619,7 @@ static void _ser_msg_hdl_l2_reset_done(struct cmd_ser *cser)
 		PHL_WARN("Ser L2 state not set!\n");
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _ser_hdl_internal_evt(void *dispr, void *priv, struct phl_msg *msg)
 {
 	struct cmd_ser *cser = (struct cmd_ser *)priv;

--- a/phl/phl_cmd_ser.c
+++ b/phl/phl_cmd_ser.c
@@ -16,6 +16,8 @@
 #define _PHL_CMD_SER_C_
 #include "phl_headers.h"
 #include "phl_api.h"
+#include "phl_api_drv.h"
+#include "phl_ser_fsm.h"
 
 #define CMD_SER_L0 0x00000001
 #define CMD_SER_L1 0x00000002

--- a/phl/phl_ecsa.c
+++ b/phl/phl_ecsa.c
@@ -16,7 +16,7 @@
 #include "phl_headers.h"
 
 #ifdef CONFIG_PHL_ECSA
-void
+static void
 _phl_ecsa_dump_param(
 	struct rtw_phl_ecsa_param *param
 )
@@ -34,7 +34,7 @@ _phl_ecsa_dump_param(
 	PHL_DUMP_CHAN_DEF(&(param->new_chan_def));
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_ecsa_tx_pause(
 	struct phl_ecsa_ctrl_t *ecsa_ctrl
 )
@@ -65,7 +65,7 @@ _phl_ecsa_tx_pause(
 	return status;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_ecsa_tx_resume(
 	struct phl_ecsa_ctrl_t *ecsa_ctrl
 )
@@ -96,7 +96,7 @@ _phl_ecsa_tx_resume(
 	return status;
 }
 
-u32
+static u32
 _phl_ecsa_calculate_next_timer_ap(
 	struct phl_ecsa_ctrl_t *ecsa_ctrl
 )
@@ -158,7 +158,7 @@ _phl_ecsa_calculate_next_timer_ap(
 	return next_timeslot_us/1000;
 }
 
-u32
+static u32
 _phl_ecsa_calculate_next_timer_sta(
 	struct phl_ecsa_ctrl_t *ecsa_ctrl
 )
@@ -197,7 +197,7 @@ _phl_ecsa_calculate_next_timer_sta(
 	return next_timeslot;
 }
 
-void
+static void
 _phl_ecsa_calculate_next_timer(
 	struct phl_ecsa_ctrl_t *ecsa_ctrl
 )
@@ -216,7 +216,7 @@ _phl_ecsa_calculate_next_timer(
 
 }
 
-void _phl_ecsa_state_change_ap(
+static void _phl_ecsa_state_change_ap(
 	struct phl_ecsa_ctrl_t *ecsa_ctrl
 )
 {
@@ -285,7 +285,7 @@ void _phl_ecsa_state_change_ap(
 	_os_spinunlock(d, &(ecsa_ctrl->lock), _bh, NULL);
 }
 
-void _phl_ecsa_state_change_sta(
+static void _phl_ecsa_state_change_sta(
 	struct phl_ecsa_ctrl_t *ecsa_ctrl
 )
 {
@@ -341,7 +341,7 @@ void _phl_ecsa_state_change_sta(
 	_os_spinunlock(d, &(ecsa_ctrl->lock), _bh, NULL);
 }
 
-void
+static void
 _phl_ecsa_timer_callback(
 	void *context
 	)
@@ -355,7 +355,7 @@ _phl_ecsa_timer_callback(
 		_phl_ecsa_state_change_sta(ecsa_ctrl);
 }
 
-void
+static void
 _phl_ecsa_cmd_abort_hdlr(
 	void* dispr,
 	void* priv,
@@ -410,7 +410,7 @@ _phl_ecsa_cmd_abort_hdlr(
 	}
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _phl_ecsa_cmd_acquired(
 	void* dispr,
 	void* priv)
@@ -438,7 +438,7 @@ exit:
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _phl_ecsa_cmd_abort(
 	void* dispr,
 	void* priv)
@@ -447,7 +447,7 @@ _phl_ecsa_cmd_abort(
 	return MDL_RET_SUCCESS;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _phl_ecsa_cmd_msg_hdlr(
 	void* dispr,
 	void* priv,
@@ -708,7 +708,7 @@ _phl_ecsa_cmd_msg_hdlr(
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _phl_ecsa_cmd_set_info(
 	void* dispr,
 	void* priv,
@@ -720,7 +720,7 @@ _phl_ecsa_cmd_set_info(
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _phl_ecsa_cmd_query_info(
 	void* dispr,
 	void* priv,

--- a/phl/phl_ie.c
+++ b/phl/phl_ie.c
@@ -15,7 +15,7 @@
 #define _PHL_IE_C_
 #include "phl_headers.h"
 
-u8 _phl_build_ml_common_info(struct rtw_phl_com_t *phl_com,
+static u8 _phl_build_ml_common_info(struct rtw_phl_com_t *phl_com,
                              struct rtw_phl_ml_ie_info *info,
                              u8 *pbuf,
                              u8 *ml_ctrl)
@@ -79,7 +79,7 @@ _exit:
 	return len;
 }
 
-u8 _phl_build_basic_ml_ie(struct rtw_phl_com_t *phl_com,
+static u8 _phl_build_basic_ml_ie(struct rtw_phl_com_t *phl_com,
                           struct rtw_phl_ml_ie_info *info,
                           u8 *pbuf,
                           u8 *ml_ctrl)
@@ -110,7 +110,7 @@ u8 _phl_build_basic_ml_ie(struct rtw_phl_com_t *phl_com,
 	return len;
 }
 
-u8 _phl_build_probe_request_ml_ie(struct rtw_phl_com_t *phl_com,
+static u8 _phl_build_probe_request_ml_ie(struct rtw_phl_com_t *phl_com,
                                   struct rtw_phl_ml_ie_info *info,
                                   u8 *pbuf,
                                   u8 *ml_ctrl)
@@ -204,7 +204,7 @@ u8 rtw_phl_build_ml_ie(struct rtw_phl_com_t *phl_com,
 	return len;
 }
 
-u8 _phl_build_sta_info(struct rtw_phl_com_t *phl_com,
+static u8 _phl_build_sta_info(struct rtw_phl_com_t *phl_com,
                        struct rtw_phl_per_sta_profile_info *info,
                        u8 *pbuf,
                        u8 *sta_ctrl)
@@ -335,7 +335,7 @@ u8 rtw_phl_build_per_sta_profile(struct rtw_phl_com_t *phl_com,
 	return total_len;
 }
 
-void _set_link_mapping(u8 *ele_pos,
+static void _set_link_mapping(u8 *ele_pos,
                        u16 *tid2link,
                        u8 *indicator,
                        u8 *total_len)
@@ -411,7 +411,7 @@ u8 rtw_phl_build_tid2link(struct rtw_wifi_role_link_t *rlink,
 	return (total_len +3); /* From Element ID/ Len/ Ext ID */
 }
 
-void
+static void
 _dump_tid2link(struct rtw_phl_stainfo_t *sta)
 {
 	u8 idx =0;
@@ -497,7 +497,7 @@ void rtw_phl_tid2link_not_present(struct rtw_phl_stainfo_t *sta, u8 nego)
 	phl_mld_link2tid(sta);
 }
 
-void
+static void
 _dump_per_sta_profile(struct rtw_phl_per_sta_profile_element ele)
 {
 	PHL_INFO("###### _dump_per_sta_profile #######\n");
@@ -560,7 +560,7 @@ _dump_per_sta_profile(struct rtw_phl_per_sta_profile_element ele)
  *                   v
  *                   ele_pos
  */
-void
+static void
 phl_parse_per_sta_profile_ie(struct rtw_phl_com_t *phl_com,
                              u8 *ele_pos,
                              u16 ele_len,
@@ -657,7 +657,7 @@ phl_parse_per_sta_profile_ie(struct rtw_phl_com_t *phl_com,
 	_dump_per_sta_profile(*ele);
 }
 
-void
+static void
 _parse_ml_link_info(struct rtw_phl_com_t *phl_com,
                     u8 *ie_buf,
                     u16 ie_len,
@@ -742,7 +742,7 @@ _parse_ml_link_info(struct rtw_phl_com_t *phl_com,
 	} while(1);
 }
 
-void
+static void
 _dump_ml_basic(struct rtw_phl_ml_element ml_ele)
 {
 	PHL_INFO("###### _dump_ml_basic #######\n");
@@ -790,7 +790,7 @@ _dump_ml_basic(struct rtw_phl_ml_element ml_ele)
 	}
 }
 
-void
+static void
 _parse_ml_basic(struct rtw_phl_com_t *phl_com,
                 u8 *ie_buf,
                 u16 ie_len,
@@ -852,7 +852,7 @@ _parse_ml_basic(struct rtw_phl_com_t *phl_com,
 	                    ml_ele);
 }
 
-void
+static void
 _dump_ml_probe_req(struct rtw_phl_ml_element ml_ele)
 {
 	PHL_INFO("###### _dump_ml_probe_req #######\n");
@@ -862,7 +862,7 @@ _dump_ml_probe_req(struct rtw_phl_ml_element ml_ele)
 		PHL_INFO("%-25s: Not present\n", "MLD ID");
 }
 
-void
+static void
 _parse_ml_probe_req(struct rtw_phl_com_t *phl_com,
                     u8 *ie_buf,
                     u16 ie_len,
@@ -1050,7 +1050,7 @@ rtw_phl_is_ie_fragmentable(u32 eid,
  * affiliated with the same MLD as the reported AP. Therefore,
  * MLD ID would be 0.
  */
-u8 _build_mld_parameters(void *phl,
+static u8 _build_mld_parameters(void *phl,
                          struct rtw_wifi_role_link_t *rlink,
                          u8 *pbuf)
 {
@@ -1122,7 +1122,7 @@ u8 rtw_phl_build_reduced_nb_rpt(struct rtw_wifi_role_t *wrole,
 	return (u8)(p - pstart);
 }
 
-void _dump_reduced_nb_rpt(struct rtw_phl_rnb_rpt_element *reduced_nb_rpt)
+static void _dump_reduced_nb_rpt(struct rtw_phl_rnb_rpt_element *reduced_nb_rpt)
 {
 	struct tbtt_info_header *hdr;
 	struct rtw_phl_tbtt_info *tbtt_info;
@@ -1201,7 +1201,7 @@ void _dump_reduced_nb_rpt(struct rtw_phl_rnb_rpt_element *reduced_nb_rpt)
 	PHL_INFO("###### _dump_reduced_nb_rpt #######\n");
 }
 
-u8 _parse_tbtt_header(struct rtw_phl_com_t *phl_com,
+static u8 _parse_tbtt_header(struct rtw_phl_com_t *phl_com,
                       u8 *pos_start,
                       struct tbtt_info_header *hdr)
 {
@@ -1237,7 +1237,7 @@ exit:
 
 }
 
-u8 _parse_nb_info(struct rtw_phl_com_t *phl_com,
+static u8 _parse_nb_info(struct rtw_phl_com_t *phl_com,
                   u8 *pos_start,
                   struct rtw_phl_neighbor_ap *nb_ap)
 {

--- a/phl/phl_init.c
+++ b/phl/phl_init.c
@@ -20,7 +20,7 @@ static void phl_chsw_ofld_info_init(struct rtw_phl_com_t *phl_com)
 	rtw_phl_set_chsw_ofld_info(phl_com, false, false, false);
 }
 
-void _phl_com_init_rssi_stat(struct rtw_phl_com_t *phl_com)
+static void _phl_com_init_rssi_stat(struct rtw_phl_com_t *phl_com)
 {
 	u8 i = 0, j = 0;
 	for (i = 0; i < RTW_RSSI_TYPE_MAX; i++) {
@@ -34,7 +34,7 @@ void _phl_com_init_rssi_stat(struct rtw_phl_com_t *phl_com)
 	_os_spinlock_init(phl_com->drv_priv, &(phl_com->rssi_stat.lock));
 }
 
-void _phl_com_deinit_rssi_stat(struct rtw_phl_com_t *phl_com)
+static void _phl_com_deinit_rssi_stat(struct rtw_phl_com_t *phl_com)
 {
 	_os_spinlock_free(phl_com->drv_priv, &(phl_com->rssi_stat.lock));
 }
@@ -62,7 +62,7 @@ void rtw_phl_init_ppdu_sts_para(struct rtw_phl_com_t *phl_com,
 #endif
 }
 
-void _phl_com_deinit_ppdu_sts(struct rtw_phl_com_t *phl_com)
+static void _phl_com_deinit_ppdu_sts(struct rtw_phl_com_t *phl_com)
 {
 #ifdef CONFIG_PHL_RX_PSTS_PER_PKT
 	u8 i = 0;
@@ -81,7 +81,7 @@ void _phl_com_deinit_ppdu_sts(struct rtw_phl_com_t *phl_com)
 #endif
 }
 
-void _phl_com_init_ppdu_sts(struct rtw_phl_com_t *phl_com)
+static void _phl_com_init_ppdu_sts(struct rtw_phl_com_t *phl_com)
 {
 #ifdef CONFIG_PHL_RX_PSTS_PER_PKT
 	u8 i = 0;
@@ -1239,7 +1239,7 @@ void rtw_phl_cmd_debug_wd_release(void *phl, u32 value)
 #endif
 
 #ifdef RTW_PHL_BCN
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_add_beacon(struct phl_info_t *phl_info, struct rtw_bcn_info_cmn *bcn_cmn)
 {
 	struct rtw_phl_com_t *phl_com = phl_info->phl_com;
@@ -1251,7 +1251,7 @@ phl_add_beacon(struct phl_info_t *phl_info, struct rtw_bcn_info_cmn *bcn_cmn)
 		return RTW_PHL_STATUS_FAILURE;
 }
 
-enum rtw_phl_status phl_update_beacon(struct phl_info_t *phl_info, u8 bcn_id)
+static enum rtw_phl_status phl_update_beacon(struct phl_info_t *phl_info, u8 bcn_id)
 {
 	struct rtw_phl_com_t *phl_com = phl_info->phl_com;
 	void *hal = phl_info->hal;
@@ -1284,7 +1284,7 @@ rtw_phl_free_bcn_entry(void *phl,
 	return phl_status;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_beacon_stop(struct phl_info_t *phl_info,
                 struct rtw_wifi_role_link_t *rlink,
                 u8 stop)
@@ -1299,7 +1299,7 @@ phl_beacon_stop(struct phl_info_t *phl_info,
 	return pstatus;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_issue_beacon(struct phl_info_t *phl_info, struct rtw_bcn_info_cmn *bcn_cmn)
 {
 	struct rtw_phl_com_t *phl_com = phl_info->phl_com;
@@ -1729,7 +1729,7 @@ void rtw_phl_stop(void *phl)
 	phl_info->phl_com->dev_state = 0;
 }
 
-enum rtw_phl_status phl_wow_start(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta)
+static enum rtw_phl_status phl_wow_start(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta)
 {
 #ifdef CONFIG_WOWLAN
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_FAILURE;
@@ -1859,7 +1859,7 @@ static void _wow_stop_reinit(struct phl_info_t *phl_info)
 	phl_cmd_role_recover(phl_info);
 }
 
-void phl_wow_stop(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta, u8 *hw_reinit)
+static void phl_wow_stop(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta, u8 *hw_reinit)
 {
 #ifdef CONFIG_WOWLAN
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_FAILURE;
@@ -2281,7 +2281,7 @@ exit:
 	return phl_status;
 }
 
-enum rtw_phl_status rtw_phl_restart(void *phl)
+static enum rtw_phl_status rtw_phl_restart(void *phl)
 {
 	enum rtw_phl_status phl_status = RTW_PHL_STATUS_FAILURE;
 
@@ -2378,7 +2378,7 @@ void rtw_phl_restore_interrupt(void *phl)
 	rtw_hal_restore_interrupt(phl_info->phl_com, phl_info->hal);
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_gtimer_event(struct gtimer_ctx *gt_ctx, u8 *skip_tx)
 {
 	enum rtw_phl_status phl_status = RTW_PHL_STATUS_SUCCESS;

--- a/phl/phl_init.c
+++ b/phl/phl_init.c
@@ -20,7 +20,7 @@ static void phl_chsw_ofld_info_init(struct rtw_phl_com_t *phl_com)
 	rtw_phl_set_chsw_ofld_info(phl_com, false, false, false);
 }
 
-void _phl_com_init_rssi_stat(struct rtw_phl_com_t *phl_com)
+static void _phl_com_init_rssi_stat(struct rtw_phl_com_t *phl_com)
 {
 	u8 i = 0, j = 0;
 	for (i = 0; i < RTW_RSSI_TYPE_MAX; i++) {
@@ -34,7 +34,7 @@ void _phl_com_init_rssi_stat(struct rtw_phl_com_t *phl_com)
 	_os_spinlock_init(phl_com->drv_priv, &(phl_com->rssi_stat.lock));
 }
 
-void _phl_com_deinit_rssi_stat(struct rtw_phl_com_t *phl_com)
+static void _phl_com_deinit_rssi_stat(struct rtw_phl_com_t *phl_com)
 {
 	_os_spinlock_free(phl_com->drv_priv, &(phl_com->rssi_stat.lock));
 }
@@ -62,7 +62,7 @@ void rtw_phl_init_ppdu_sts_para(struct rtw_phl_com_t *phl_com,
 #endif
 }
 
-void _phl_com_deinit_ppdu_sts(struct rtw_phl_com_t *phl_com)
+static void _phl_com_deinit_ppdu_sts(struct rtw_phl_com_t *phl_com)
 {
 #ifdef CONFIG_PHL_RX_PSTS_PER_PKT
 	u8 i = 0;
@@ -81,7 +81,7 @@ void _phl_com_deinit_ppdu_sts(struct rtw_phl_com_t *phl_com)
 #endif
 }
 
-void _phl_com_init_ppdu_sts(struct rtw_phl_com_t *phl_com)
+static void _phl_com_init_ppdu_sts(struct rtw_phl_com_t *phl_com)
 {
 #ifdef CONFIG_PHL_RX_PSTS_PER_PKT
 	u8 i = 0;
@@ -1239,7 +1239,7 @@ void rtw_phl_cmd_debug_wd_release(void *phl, u32 value)
 #endif
 
 #ifdef RTW_PHL_BCN
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_add_beacon(struct phl_info_t *phl_info, struct rtw_bcn_info_cmn *bcn_cmn)
 {
 	struct rtw_phl_com_t *phl_com = phl_info->phl_com;
@@ -1251,7 +1251,7 @@ phl_add_beacon(struct phl_info_t *phl_info, struct rtw_bcn_info_cmn *bcn_cmn)
 		return RTW_PHL_STATUS_FAILURE;
 }
 
-enum rtw_phl_status phl_update_beacon(struct phl_info_t *phl_info, u8 bcn_id)
+static enum rtw_phl_status phl_update_beacon(struct phl_info_t *phl_info, u8 bcn_id)
 {
 	struct rtw_phl_com_t *phl_com = phl_info->phl_com;
 	void *hal = phl_info->hal;
@@ -1284,7 +1284,7 @@ rtw_phl_free_bcn_entry(void *phl,
 	return phl_status;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_beacon_stop(struct phl_info_t *phl_info,
                 struct rtw_wifi_role_link_t *rlink,
                 u8 stop)
@@ -1299,7 +1299,7 @@ phl_beacon_stop(struct phl_info_t *phl_info,
 	return pstatus;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_issue_beacon(struct phl_info_t *phl_info, struct rtw_bcn_info_cmn *bcn_cmn)
 {
 	struct rtw_phl_com_t *phl_com = phl_info->phl_com;
@@ -1729,9 +1729,9 @@ void rtw_phl_stop(void *phl)
 	phl_info->phl_com->dev_state = 0;
 }
 
-enum rtw_phl_status phl_wow_start(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta)
-{
 #ifdef CONFIG_WOWLAN
+static enum rtw_phl_status phl_wow_start(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta)
+{
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_FAILURE;
 	enum rtw_hal_status hstatus = RTW_HAL_STATUS_FAILURE;
 	struct phl_wow_info *wow_info = phl_to_wow_info(phl_info);
@@ -1828,10 +1828,8 @@ end:
 	}
 
 	return pstatus;
-#else
-	return RTW_PHL_STATUS_SUCCESS;
-#endif /* CONFIG_WOWLAN */
 }
+#endif /* CONFIG_WOWLAN */
 
 #ifdef CONFIG_WOWLAN
 static void _wow_stop_reinit(struct phl_info_t *phl_info)
@@ -1861,9 +1859,9 @@ static void _wow_stop_reinit(struct phl_info_t *phl_info)
 }
 #endif /* CONFIG_WOWLAN */
 
-void phl_wow_stop(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta, u8 *hw_reinit)
-{
 #ifdef CONFIG_WOWLAN
+static void phl_wow_stop(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta, u8 *hw_reinit)
+{
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_FAILURE;
 	enum rtw_hal_status hstatus = RTW_HAL_STATUS_FAILURE;
 	struct phl_wow_info *wow_info = phl_to_wow_info(phl_info);
@@ -1943,8 +1941,8 @@ reinit:
 	*hw_reinit = true;
 	return;
 
-#endif /* CONFIG_WOWLAN */
 }
+#endif /* CONFIG_WOWLAN */
 
 enum rtw_phl_status rtw_phl_rf_on(void *phl)
 {
@@ -2283,7 +2281,7 @@ exit:
 	return phl_status;
 }
 
-enum rtw_phl_status rtw_phl_restart(void *phl)
+static enum rtw_phl_status rtw_phl_restart(void *phl)
 {
 	enum rtw_phl_status phl_status = RTW_PHL_STATUS_FAILURE;
 
@@ -2380,7 +2378,7 @@ void rtw_phl_restore_interrupt(void *phl)
 	rtw_hal_restore_interrupt(phl_info->phl_com, phl_info->hal);
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_gtimer_event(struct gtimer_ctx *gt_ctx, u8 *skip_tx)
 {
 	enum rtw_phl_status phl_status = RTW_PHL_STATUS_SUCCESS;

--- a/phl/phl_mcc.c
+++ b/phl/phl_mcc.c
@@ -17,7 +17,7 @@
 
 #ifdef CONFIG_MCC_SUPPORT
 #include "phl_mcc.h"
-void _mcc_dump_state(enum rtw_phl_mcc_state *state)
+static void _mcc_dump_state(enum rtw_phl_mcc_state *state)
 {
 	if (MCC_NONE == *state) {
 		PHL_TRACE(COMP_PHL_MCC, _PHL_INFO_, "_mcc_dump_state(): MCC_NONE\n");
@@ -41,7 +41,7 @@ void _mcc_dump_state(enum rtw_phl_mcc_state *state)
 	}
 }
 
-void _mcc_dump_mode(enum rtw_phl_tdmra_wmode *mode)
+static void _mcc_dump_mode(enum rtw_phl_tdmra_wmode *mode)
 {
 	if (RTW_PHL_TDMRA_AP_CLIENT_WMODE == *mode) {
 		PHL_TRACE(COMP_PHL_MCC, _PHL_INFO_, "_mcc_dump_mode(): RTW_PHL_TDMRA_AP_CLIENT_WMODE\n");
@@ -55,13 +55,13 @@ void _mcc_dump_mode(enum rtw_phl_tdmra_wmode *mode)
 	}
 }
 
-void _mcc_dump_sync_tsf_info(struct rtw_phl_mcc_sync_tsf_info *info)
+static void _mcc_dump_sync_tsf_info(struct rtw_phl_mcc_sync_tsf_info *info)
 {
 	PHL_TRACE(COMP_PHL_MCC, _PHL_INFO_, "_mcc_dump_sync_tsf_info(): sync_en(%d), source macid(%d), target macid(%d), offset(%d)\n",
 		info->sync_en, info->source, info->target, info->offset);
 }
 
-void _mcc_dump_dur_info(struct rtw_phl_mcc_dur_info *dur_i)
+static void _mcc_dump_dur_info(struct rtw_phl_mcc_dur_info *dur_i)
 {
 	struct rtw_phl_mcc_dur_lim_info *dur_l = NULL;
 
@@ -72,7 +72,7 @@ void _mcc_dump_dur_info(struct rtw_phl_mcc_dur_info *dur_i)
 		dur_l->max_toa, dur_l->max_tob);
 }
 
-void _mcc_dump_role_info(struct rtw_phl_mcc_role *mrole)
+static void _mcc_dump_role_info(struct rtw_phl_mcc_role *mrole)
 {
 	struct rtw_phl_mcc_policy_info *policy = &mrole->policy;
 	u8 i = 0;
@@ -102,7 +102,7 @@ void _mcc_dump_role_info(struct rtw_phl_mcc_role *mrole)
 		policy->courtesy_target);
 }
 
-void _mcc_dump_pattern(struct rtw_phl_mcc_pattern *m_pattern)
+static void _mcc_dump_pattern(struct rtw_phl_mcc_pattern *m_pattern)
 {
 	struct rtw_phl_mcc_courtesy *courtesy_i = &m_pattern->courtesy_i;
 
@@ -120,7 +120,7 @@ void _mcc_dump_pattern(struct rtw_phl_mcc_pattern *m_pattern)
 	}
 }
 
-void _mcc_dump_ref_role_info(struct rtw_phl_mcc_en_info *info)
+static void _mcc_dump_ref_role_info(struct rtw_phl_mcc_en_info *info)
 {
 	struct rtw_phl_mcc_role *ref_role = NULL;
 
@@ -133,7 +133,7 @@ void _mcc_dump_ref_role_info(struct rtw_phl_mcc_en_info *info)
 		ref_role->chandef->offset);
 }
 
-void _mcc_dump_en_info(struct rtw_phl_mcc_en_info *info)
+static void _mcc_dump_en_info(struct rtw_phl_mcc_en_info *info)
 {
 	struct rtw_phl_mcc_role *m_role = NULL;
 	u8 midx = 0;
@@ -152,7 +152,7 @@ void _mcc_dump_en_info(struct rtw_phl_mcc_en_info *info)
 	}
 }
 
-void _mcc_dump_bt_ino(struct rtw_phl_mcc_bt_info *bt_info)
+static void _mcc_dump_bt_ino(struct rtw_phl_mcc_bt_info *bt_info)
 {
 	u8 seg_num = BT_SEG_NUM;
 
@@ -163,7 +163,7 @@ void _mcc_dump_bt_ino(struct rtw_phl_mcc_bt_info *bt_info)
 		bt_info->bt_seg[1], bt_info->add_bt_role);
 }
 
-void _mcc_dump_mcc_info(struct phl_mcc_info *minfo)
+static void _mcc_dump_mcc_info(struct phl_mcc_info *minfo)
 {
 	PHL_TRACE(COMP_PHL_MCC, _PHL_INFO_, ">>> _mcc_dump_mcc_info():\n");
 	_mcc_dump_mode(&minfo->mcc_mode);
@@ -173,7 +173,7 @@ void _mcc_dump_mcc_info(struct phl_mcc_info *minfo)
 	PHL_TRACE(COMP_PHL_MCC, _PHL_INFO_, "<<< _mcc_dump_mcc_info():\n");
 }
 
-void _mcc_set_state(struct phl_mcc_info *minfo, enum rtw_phl_mcc_state state)
+static void _mcc_set_state(struct phl_mcc_info *minfo, enum rtw_phl_mcc_state state)
 {
 	PHL_TRACE(COMP_PHL_MCC, _PHL_ALWAYS_, "_mcc_set_state(): Set from (%d) to (%d)\n",
 		minfo->state, state);
@@ -181,7 +181,7 @@ void _mcc_set_state(struct phl_mcc_info *minfo, enum rtw_phl_mcc_state state)
 	_mcc_dump_state(&minfo->state);
 }
 
-struct rtw_phl_mcc_role *
+static struct rtw_phl_mcc_role *
 _mcc_get_mrole_by_wrole(struct phl_mcc_info *minfo,
 				struct rtw_wifi_role_t *wrole)
 {
@@ -202,7 +202,7 @@ _mcc_get_mrole_by_wrole(struct phl_mcc_info *minfo,
 	return NULL;
 }
 
-u8
+static u8
 _mcc_get_mrole_idx_by_wrole(struct phl_mcc_info *minfo,
 				struct rtw_wifi_role_t *wrole, u8 *idx)
 {
@@ -226,7 +226,7 @@ _mcc_get_mrole_idx_by_wrole(struct phl_mcc_info *minfo,
 	return status;
 }
 
-struct rtw_phl_mcc_role *
+static struct rtw_phl_mcc_role *
 _mcc_get_mrole_by_category(struct rtw_phl_mcc_en_info *en_info,
 			enum _mcc_role_cat category)
 {
@@ -252,7 +252,7 @@ _mcc_get_mrole_by_category(struct rtw_phl_mcc_en_info *en_info,
 	return NULL;
 }
 
-enum rtw_phl_status _mcc_transfer_mode(struct phl_info_t *phl,
+static enum rtw_phl_status _mcc_transfer_mode(struct phl_info_t *phl,
 				struct phl_mcc_info *minfo, u8 role_map)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
@@ -300,7 +300,7 @@ exit:
 	return status;
 }
 
-enum rtw_phl_status _mcc_get_role_map(struct phl_info_t *phl,
+static enum rtw_phl_status _mcc_get_role_map(struct phl_info_t *phl,
 				struct hw_band_ctl_t *band_ctrl, u8 *role_map)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
@@ -320,7 +320,7 @@ enum rtw_phl_status _mcc_get_role_map(struct phl_info_t *phl,
 	return status;
 }
 
-void _mcc_set_fw_log_info(struct phl_info_t *phl, u8 hw_band,
+static void _mcc_set_fw_log_info(struct phl_info_t *phl, u8 hw_band,
 			bool en_fw_mcc_log, u8 fw_mcc_log_lv)
 {
 	struct phl_mcc_info *minfo = get_mcc_info(phl, hw_band);
@@ -335,7 +335,7 @@ void _mcc_set_fw_log_info(struct phl_info_t *phl, u8 hw_band,
 	}
 }
 
-void _mcc_up_fw_log_setting(struct phl_info_t *phl, struct phl_mcc_info *minfo)
+static void _mcc_up_fw_log_setting(struct phl_info_t *phl, struct phl_mcc_info *minfo)
 {
 	struct phl_mcc_fw_log_info *fw_log_i = &minfo->fw_log_i;
 
@@ -346,7 +346,7 @@ void _mcc_up_fw_log_setting(struct phl_info_t *phl, struct phl_mcc_info *minfo)
 	}
 }
 
-void _mcc_set_unspecific_dur(struct phl_mcc_info *minfo)
+static void _mcc_set_unspecific_dur(struct phl_mcc_info *minfo)
 {
 	struct rtw_phl_mcc_en_info *en_info = &minfo->en_info;
 	struct rtw_phl_mcc_role *m_role = NULL;
@@ -360,7 +360,7 @@ void _mcc_set_unspecific_dur(struct phl_mcc_info *minfo)
 	}
 }
 
-void _mcc_fill_dur_lim_info(struct phl_info_t *phl,
+static void _mcc_fill_dur_lim_info(struct phl_info_t *phl,
 				struct rtw_phl_mcc_role *mrole,
 				struct phl_mcc_dur_lim_req_info *dur_req)
 {
@@ -409,7 +409,7 @@ exit:
 	return;
 }
 
-void _mcc_fill_default_policy(struct phl_info_t *phl,
+static void _mcc_fill_default_policy(struct phl_info_t *phl,
 				struct rtw_phl_mcc_role *mrole)
 {
 	struct rtw_phl_mcc_policy_info *policy = &mrole->policy;
@@ -434,7 +434,7 @@ void _mcc_fill_default_policy(struct phl_info_t *phl,
 	}
 }
 
-void _mcc_fill_mcc_role_policy_info(struct phl_info_t *phl,
+static void _mcc_fill_mcc_role_policy_info(struct phl_info_t *phl,
                                     struct rtw_wifi_role_t *wrole,
                                     struct rtw_wifi_role_link_t *rlink,
                                     struct rtw_phl_mcc_role *mrole)
@@ -477,7 +477,7 @@ exit:
 	return;
 }
 
-void _mcc_fill_macid_bitmap_by_role(struct phl_info_t *phl,
+static void _mcc_fill_macid_bitmap_by_role(struct phl_info_t *phl,
 					struct rtw_phl_mcc_role *mrole)
 {
 	struct macid_ctl_t *mc = phl_to_mac_ctrl(phl);
@@ -499,7 +499,7 @@ void _mcc_fill_macid_bitmap_by_role(struct phl_info_t *phl,
 		used_macid->len, max_map_idx);
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _mcc_fill_mcc_role_basic_info(struct phl_info_t *phl,
                               struct rtw_wifi_role_t *wrole,
                               struct rtw_wifi_role_link_t *rlink,
@@ -531,7 +531,7 @@ exit:
 	return status;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _mcc_fill_ref_role_info(struct phl_info_t *phl,
                         struct rtw_phl_mcc_en_info *en_info,
                         struct rtw_wifi_role_t *wrole,
@@ -562,7 +562,7 @@ exit:
 	return status;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _mcc_fill_role_info(struct phl_info_t *phl,
                     struct rtw_phl_mcc_en_info *en_info,
                     u8 role_map,
@@ -625,7 +625,7 @@ exit:
 	return status;
 }
 
-void _mcc_fill_coex_mode(struct phl_info_t *phl, struct phl_mcc_info *minfo)
+static void _mcc_fill_coex_mode(struct phl_info_t *phl, struct phl_mcc_info *minfo)
 {
 	/* if get from core or ....
 	else*/
@@ -634,7 +634,7 @@ void _mcc_fill_coex_mode(struct phl_info_t *phl, struct phl_mcc_info *minfo)
 		minfo->coex_mode);
 }
 
-void _mcc_fill_bt_dur(struct phl_info_t *phl, enum phl_band_idx band_idx,
+static void _mcc_fill_bt_dur(struct phl_info_t *phl, enum phl_band_idx band_idx,
 			struct phl_mcc_info *minfo)
 {
 	minfo->bt_info.bt_dur = (u16)rtw_hal_get_btc_req_slot(phl->hal, band_idx);
@@ -652,7 +652,7 @@ void _mcc_fill_bt_dur(struct phl_info_t *phl, enum phl_band_idx band_idx,
  * @dur: time slot
  * @mrole: mcc role info
  */
-void _mcc_fill_slot_info(struct rtw_phl_mcc_pattern *m_pattern, bool bt_role,
+static void _mcc_fill_slot_info(struct rtw_phl_mcc_pattern *m_pattern, bool bt_role,
 				u16 dur, struct rtw_phl_mcc_role *mrole)
 {
 	if (m_pattern->slot_num >= SLOT_NUM) {
@@ -675,7 +675,7 @@ void _mcc_fill_slot_info(struct rtw_phl_mcc_pattern *m_pattern, bool bt_role,
 	m_pattern->slot_num++;
 }
 
-void _mcc_reset_minfo(struct phl_info_t *phl, struct phl_mcc_info *minfo,
+static void _mcc_reset_minfo(struct phl_info_t *phl, struct phl_mcc_info *minfo,
 				enum _mcc_minfo_reset_type reset_type)
 {
 	void *priv = phl_to_drvpriv(phl);
@@ -708,7 +708,7 @@ void _mcc_reset_minfo(struct phl_info_t *phl, struct phl_mcc_info *minfo,
 				sizeof(struct rtw_phl_mcc_pattern));
 }
 
-void _mcc_clean_noa(struct phl_info_t *phl, struct rtw_phl_mcc_en_info *en_info)
+static void _mcc_clean_noa(struct phl_info_t *phl, struct rtw_phl_mcc_en_info *en_info)
 {
 	struct phl_com_mcc_info *com_info = phl_to_com_mcc_info(phl);
 	struct rtw_phl_mcc_noa param = {0};
@@ -732,7 +732,7 @@ exit:
 	return;
 }
 
-bool _tdmra_calc_noa_2wrole(struct phl_info_t *phl, struct phl_mcc_info *minfo,
+static bool _tdmra_calc_noa_2wrole(struct phl_info_t *phl, struct phl_mcc_info *minfo,
 				struct rtw_phl_mcc_noa *param)
 {
 	struct rtw_phl_mcc_en_info *en_info = &minfo->en_info;
@@ -806,7 +806,7 @@ exit:
 	return ret;
 }
 
-bool _tdmra_calc_noa_1wrole(struct phl_info_t *phl, struct phl_mcc_info *minfo,
+static bool _tdmra_calc_noa_1wrole(struct phl_info_t *phl, struct phl_mcc_info *minfo,
 				struct rtw_phl_mcc_noa *param)
 {
 	struct rtw_phl_mcc_en_info *en_info = &minfo->en_info;
@@ -835,7 +835,7 @@ bool _tdmra_calc_noa_1wrole(struct phl_info_t *phl, struct phl_mcc_info *minfo,
 }
 
 
-void _mcc_up_noa(struct phl_info_t *phl, struct phl_mcc_info *minfo)
+static void _mcc_up_noa(struct phl_info_t *phl, struct phl_mcc_info *minfo)
 
 {
 	struct phl_com_mcc_info *com_info = phl_to_com_mcc_info(phl);
@@ -867,7 +867,7 @@ exit:
 	return;
 }
 
-bool _mcc_adjust_dur_for_2g_mcc_2role_bt(struct phl_mcc_info *minfo)
+static bool _mcc_adjust_dur_for_2g_mcc_2role_bt(struct phl_mcc_info *minfo)
 {
 	struct rtw_phl_mcc_bt_info *bt_info = &minfo->bt_info;
 	struct rtw_phl_mcc_en_info *en_info = &minfo->en_info;
@@ -929,7 +929,7 @@ bool _mcc_adjust_dur_for_2g_mcc_2role_bt(struct phl_mcc_info *minfo)
 	return adjust_ok;
 }
 
-void _mcc_adjust_dur_for_2_band_mcc_2role_bt(struct phl_mcc_info *minfo,
+static void _mcc_adjust_dur_for_2_band_mcc_2role_bt(struct phl_mcc_info *minfo,
 	struct rtw_phl_mcc_role *role_2g, struct rtw_phl_mcc_role *role_non_2g)
 {
 	struct rtw_phl_mcc_en_info *en_info = &minfo->en_info;
@@ -982,7 +982,7 @@ exit:
 	return;
 }
 
-bool _mcc_need_to_seg_bt_dur(struct phl_mcc_info *minfo)
+static bool _mcc_need_to_seg_bt_dur(struct phl_mcc_info *minfo)
 {
 /* Not ready for implementation*/
 	return false;
@@ -1014,7 +1014,7 @@ exit:
 /*
  * 2 wifi slot req + bt slot req
  */
-void _mcc_discision_dur_for_2g_mcc_2role_bt(struct phl_mcc_info *minfo)
+static void _mcc_discision_dur_for_2g_mcc_2role_bt(struct phl_mcc_info *minfo)
 {
 	struct rtw_phl_mcc_en_info *en_info = &minfo->en_info;
 	struct rtw_phl_mcc_role *m_role1 = &en_info->mcc_role[0];
@@ -1050,7 +1050,7 @@ void _mcc_discision_dur_for_2g_mcc_2role_bt(struct phl_mcc_info *minfo)
 	}
 }
 
-bool _mcc_discision_duration_for_2role_bt_v2(struct phl_mcc_info *minfo)
+static bool _mcc_discision_duration_for_2role_bt_v2(struct phl_mcc_info *minfo)
 {
 	struct rtw_phl_mcc_en_info *en_info = &minfo->en_info;
 	struct rtw_phl_mcc_bt_info *bt_info = &minfo->bt_info;
@@ -1085,7 +1085,7 @@ exit:
 	return add_extra_bt_role;
 }
 
-bool _mcc_discision_duration_for_2role_bt(struct phl_mcc_info *minfo)
+static bool _mcc_discision_duration_for_2role_bt(struct phl_mcc_info *minfo)
 {
 	struct rtw_phl_mcc_en_info *en_info = &minfo->en_info;
 	struct rtw_phl_mcc_role *m_role1 = &en_info->mcc_role[0];
@@ -1114,7 +1114,7 @@ exit:
 	return add_extra_bt_role;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _mcc_calculate_start_tsf(struct phl_info_t *phl,
                          struct rtw_phl_mcc_en_info *en_info)
 {
@@ -1172,7 +1172,7 @@ exit:
 	return status;
 }
 
-void _mcc_set_2_clients_worsecase_default_pattern(struct rtw_phl_mcc_pattern *m_pattern,
+static void _mcc_set_2_clients_worsecase_default_pattern(struct rtw_phl_mcc_pattern *m_pattern,
 					u16 dur_ref)
 {
 	m_pattern->toa_r = CLIENTS_WORSECASE_REF_TOA;
@@ -1194,7 +1194,7 @@ void _mcc_set_2_clients_worsecase_default_pattern(struct rtw_phl_mcc_pattern *m_
  *          bcn                bcn
  * | tob_r | toa_r|tob_a | toa_a| Bt slot |
  */
-s16 _mcc_get_offset_for_2_wslot_1_btslot_p1(s16 dur_r,
+static s16 _mcc_get_offset_for_2_wslot_1_btslot_p1(s16 dur_r,
 				s16 tob_r, s16 tob_a)
 {
 	return dur_r - tob_r + tob_a;
@@ -1207,13 +1207,13 @@ s16 _mcc_get_offset_for_2_wslot_1_btslot_p1(s16 dur_r,
  *          bcn                            bcn
  * | tob_r | toa_r| Bt slot |tob_a | toa_a|
  */
-s16 _mcc_get_offset_for_2_wslot_1_btslot_p2(s16 dur_r, s16 bt_dur,
+static s16 _mcc_get_offset_for_2_wslot_1_btslot_p2(s16 dur_r, s16 bt_dur,
 				s16 tob_r, s16 tob_a)
 {
 	return dur_r - tob_r + bt_dur + tob_a;
 }
 
-void _mcc_get_offset_range_for_2wslot_1btslot_p1(s16 ref_dur, s16 ano_dur,
+static void _mcc_get_offset_range_for_2wslot_1btslot_p1(s16 ref_dur, s16 ano_dur,
 				s16 *bcn_min, s16 *bcn_max)
 {
 	s16 min1 = 0, max1 = 0;
@@ -1234,7 +1234,7 @@ void _mcc_get_offset_range_for_2wslot_1btslot_p1(s16 ref_dur, s16 ano_dur,
 		*bcn_min, *bcn_max);
 }
 
-void _mcc_get_offset_range_for_2wslot_1btslot_p2(s16 ref_dur, s16 ano_dur,
+static void _mcc_get_offset_range_for_2wslot_1btslot_p2(s16 ref_dur, s16 ano_dur,
 				s16 bt_dur, s16 *bcn_min, s16 *bcn_max)
 {
 	s16 min1 = 0, max1 = 0;
@@ -1256,13 +1256,13 @@ void _mcc_get_offset_range_for_2wslot_1btslot_p2(s16 ref_dur, s16 ano_dur,
 		*bcn_min, *bcn_max);
 }
 
-s16 _mcc_get_offset_for_2_clients_worsecase(s16 ref_dur, s16 ano_dur,
+static s16 _mcc_get_offset_for_2_clients_worsecase(s16 ref_dur, s16 ano_dur,
 				u16 ref_bcn_intvl, s16 toa_ref, s16 tob_ano)
 {
 	return toa_ref + tob_ano + ref_dur + ano_dur - (2 * ref_bcn_intvl);
 }
 
-void _mcc_get_offset_range_for_2_clients_worsecase(s16 ref_dur, s16 ano_dur,
+static void _mcc_get_offset_range_for_2_clients_worsecase(s16 ref_dur, s16 ano_dur,
 				u16 ref_bcn_intvl, s16 *bcn_min, s16 *bcn_max)
 {
 	s16 min1 = 0, min2 = 0, max1 = 0, max2 = 0;
@@ -1291,7 +1291,7 @@ void _mcc_get_offset_range_for_2_clients_worsecase(s16 ref_dur, s16 ano_dur,
  * copy from _mcc_calc_2wslot_1btslot_nego_p1
  * | Wifi slot1 | Bt slot | Wifi slot2 |
  */
-bool _mcc_calc_2wslot_1btslot_nego_p2(struct rtw_phl_mcc_dur_info *ref_dur,
+static bool _mcc_calc_2wslot_1btslot_nego_p2(struct rtw_phl_mcc_dur_info *ref_dur,
 			struct rtw_phl_mcc_dur_info *ano_dur, s16 bt_dur,
 			s16 offset, struct rtw_phl_mcc_pattern *m_pattern)
 {
@@ -1407,7 +1407,7 @@ exit:
  *          bcn                bcn
  * | tob_r | toa_r|tob_a | toa_a| Bt slot |
  */
-bool _mcc_calc_2wslot_1btslot_nego_p1(struct rtw_phl_mcc_dur_info *ref_dur,
+static bool _mcc_calc_2wslot_1btslot_nego_p1(struct rtw_phl_mcc_dur_info *ref_dur,
 			struct rtw_phl_mcc_dur_info *ano_dur, s16 offset,
 			s16 bt_dur, struct rtw_phl_mcc_pattern *m_pattern)
 {
@@ -1527,7 +1527,7 @@ exit:
  * @offset: The offset of Bcns
  * @m_pattern: pattern info
  */
-enum rtw_phl_status _mcc_calculate_2wslot_1btslot_pattern2(
+static enum rtw_phl_status _mcc_calculate_2wslot_1btslot_pattern2(
 				struct rtw_phl_mcc_dur_info *ref_dur,
 				struct rtw_phl_mcc_dur_info *ano_dur,
 				u16 offset, s16 bt_dur,
@@ -1629,7 +1629,7 @@ exit:
  * @offset: The offset of Bcns
  * @m_pattern: pattern info
  */
-enum rtw_phl_status _mcc_calculate_2wslot_1btslot_pattern1(
+static enum rtw_phl_status _mcc_calculate_2wslot_1btslot_pattern1(
 			struct rtw_phl_mcc_dur_info *ref_dur,
 			struct rtw_phl_mcc_dur_info *ano_dur,
 			u16 offset, s16 bt_dur,
@@ -1722,7 +1722,7 @@ exit:
 /*
  * Calculate pattern for 2 wifi slot and 1 bt slot
  */
-enum rtw_phl_status _mcc_calculate_2wslot_1btslot_pattern(
+static enum rtw_phl_status _mcc_calculate_2wslot_1btslot_pattern(
 			struct rtw_phl_mcc_dur_info *ref_dur,
 			struct rtw_phl_mcc_dur_info *ano_dur,
 			s16 bt_dur, struct rtw_phl_mcc_pattern *m_pattern)
@@ -1783,7 +1783,7 @@ exit:
  *          bcn_r                                                     bcn_a
  * | tob_r | toa_r|                                        |tob_a | toa_a|
  */
-enum rtw_phl_status _mcc_calc_2_clients_worsecase_pattern(u16 ref_dur,
+static enum rtw_phl_status _mcc_calc_2_clients_worsecase_pattern(u16 ref_dur,
 				u16 ano_dur, u16 offset, u16 ref_bcn_intvl,
 				struct rtw_phl_mcc_pattern *m_pattern)
 {
@@ -1913,7 +1913,7 @@ exit:
 /*
  * |Wifi1 slot|Wifi2 slot|
  */
-bool _mcc_calc_2_wrole_nego_pattern(struct rtw_phl_mcc_dur_info *ref_dur,
+static bool _mcc_calc_2_wrole_nego_pattern(struct rtw_phl_mcc_dur_info *ref_dur,
 				struct rtw_phl_mcc_dur_info *ano_dur, s16 offset,
 				struct rtw_phl_mcc_pattern *m_pattern)
 {
@@ -2293,7 +2293,7 @@ exit:
  *                                  <tob_a> Bcn_a <toa_a>                                  <tob_a> Bcn_a <toa_a>
  *	         <       bcns_offset       >
  */
-enum rtw_phl_status _mcc_calculate_2_wrole_pattern(
+static enum rtw_phl_status _mcc_calculate_2_wrole_pattern(
 				struct rtw_phl_mcc_dur_info *ref_dur,
 				struct rtw_phl_mcc_dur_info *ano_dur,
 				u16 offset,
@@ -2394,7 +2394,7 @@ exit:
  *                                  <tob_a> Bcn_a <toa_a>                                  <tob_a> Bcn_a <toa_a>
  *	         <       bcns_offset       >
  */
-void _mcc_calculate_2_clients_pattern(u16 ref_dur, u16 ano_dur, u16 offset,
+static void _mcc_calculate_2_clients_pattern(u16 ref_dur, u16 ano_dur, u16 offset,
 					struct rtw_phl_mcc_pattern *m_pattern)
 {
 	u16 mcc_intvl = ref_dur + ano_dur;
@@ -2454,7 +2454,7 @@ void _mcc_calculate_2_clients_pattern(u16 ref_dur, u16 ano_dur, u16 offset,
  * @role_ref: reference wifi slot req
  * @role_ano: another wifi slot req
  */
-void _mcc_fill_2_wrole_bt_pattern(struct phl_mcc_info *minfo,
+static void _mcc_fill_2_wrole_bt_pattern(struct phl_mcc_info *minfo,
 	struct rtw_phl_mcc_role *role_ref, struct rtw_phl_mcc_role *role_ano)
 {
 	struct rtw_phl_mcc_en_info *en_info = &minfo->en_info;
@@ -2523,7 +2523,7 @@ exit:
 	return;
 }
 
-bool _mcc_fill_2wrole_pattern_with_limitation(struct phl_mcc_info *minfo,
+static bool _mcc_fill_2wrole_pattern_with_limitation(struct phl_mcc_info *minfo,
 	struct rtw_phl_mcc_role *role_ref, struct rtw_phl_mcc_role *role_ano)
 {
 	struct rtw_phl_mcc_en_info *en_info = &minfo->en_info;
@@ -2567,7 +2567,7 @@ exit:
 	return ret;
 }
 
-void _mcc_fill_2_clients_pattern(struct phl_mcc_info *minfo, u8 worsecase,
+static void _mcc_fill_2_clients_pattern(struct phl_mcc_info *minfo, u8 worsecase,
 	struct rtw_phl_mcc_role *role_ref, struct rtw_phl_mcc_role *role_ano)
 {
 	struct rtw_phl_mcc_en_info *en_info = &minfo->en_info;
@@ -2593,7 +2593,7 @@ exit:
 	return;
 }
 
-enum rtw_phl_status _mcc_get_2_clients_bcn_offset(struct phl_info_t *phl,
+static enum rtw_phl_status _mcc_get_2_clients_bcn_offset(struct phl_info_t *phl,
 			u16 *offset, struct rtw_phl_mcc_role *role_ref,
 			struct rtw_phl_mcc_role *role_ano)
 {
@@ -2639,7 +2639,7 @@ exit:
  *               <         bcns_offset         >
  **/
 
-void _mcc_set_ap_client_default_pattern(struct phl_mcc_info *minfo,
+static void _mcc_set_ap_client_default_pattern(struct phl_mcc_info *minfo,
 					u16 *bcns_offet)
 {
 	struct rtw_phl_mcc_en_info *en_info = &minfo->en_info;
@@ -2659,7 +2659,7 @@ void _mcc_set_ap_client_default_pattern(struct phl_mcc_info *minfo,
 		m_pattern->tob_r, m_pattern->toa_r, m_pattern->tob_a, m_pattern->toa_a);
 }
 
-void _mcc_set_worsecase_dur_for_2_clients_mode(
+static void _mcc_set_worsecase_dur_for_2_clients_mode(
 				struct rtw_phl_mcc_dur_info *dur_i_1,
 				struct rtw_phl_mcc_dur_info *dur_i_2,
 				u16 *mcc_intvl)
@@ -2676,7 +2676,7 @@ void _mcc_set_worsecase_dur_for_2_clients_mode(
 	}
 }
 
-void _mcc_set_dur_for_2_clients_mode(
+static void _mcc_set_dur_for_2_clients_mode(
 				struct rtw_phl_mcc_dur_info *dur_i_1,
 				struct rtw_phl_mcc_dur_info *dur_i_2,
 				u16 *mcc_intvl)
@@ -2717,7 +2717,7 @@ void _mcc_set_dur_for_2_clients_mode(
 	}
 }
 
-enum rtw_phl_status _mcc_fill_info_for_2_clients_mode(struct phl_info_t *phl,
+static enum rtw_phl_status _mcc_fill_info_for_2_clients_mode(struct phl_info_t *phl,
 						struct phl_mcc_info *minfo)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
@@ -2770,7 +2770,7 @@ exit:
 	return status;
 }
 
-void _mcc_set_dur_for_ap_client_mode(u16 *ap_dur, u16 *client_dur, u16 mcc_intvl)
+static void _mcc_set_dur_for_ap_client_mode(u16 *ap_dur, u16 *client_dur, u16 mcc_intvl)
 {
 	if (*ap_dur == MCC_DUR_NONSPECIFIC)
 		*ap_dur = mcc_intvl - *client_dur;
@@ -2786,7 +2786,7 @@ void _mcc_set_dur_for_ap_client_mode(u16 *ap_dur, u16 *client_dur, u16 mcc_intvl
 	*client_dur = mcc_intvl - *ap_dur;
 }
 
-enum rtw_phl_status _mcc_fill_info_for_ap_client_mode(
+static enum rtw_phl_status _mcc_fill_info_for_ap_client_mode(
 			struct phl_info_t *phl, struct phl_mcc_info *minfo)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
@@ -2848,7 +2848,7 @@ exit:
  * |         Wifi slot          |          BT slot         |
  * <tob_r> Bcn_r <toa_r>
 **/
-enum rtw_phl_status _mcc_fill_info_for_ap_bt_mode(
+static enum rtw_phl_status _mcc_fill_info_for_ap_bt_mode(
 			struct phl_info_t *phl, struct phl_mcc_info *minfo)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
@@ -2874,7 +2874,7 @@ exit:
 	return status;
 }
 
-enum rtw_phl_status _mcc_pkt_offload_for_client(struct phl_info_t *phl, u8 macid)
+static enum rtw_phl_status _mcc_pkt_offload_for_client(struct phl_info_t *phl, u8 macid)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
 	struct rtw_phl_stainfo_t *phl_sta = NULL;
@@ -2915,7 +2915,7 @@ exit:
 }
 
 
-enum rtw_phl_status _mcc_pkt_offload(struct phl_info_t *phl,
+static enum rtw_phl_status _mcc_pkt_offload(struct phl_info_t *phl,
 					struct rtw_phl_mcc_en_info *info)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
@@ -2941,7 +2941,7 @@ exit:
 	return status;
 }
 
-enum rtw_phl_status _mcc_update_2_clients_pattern(struct phl_info_t *phl,
+static enum rtw_phl_status _mcc_update_2_clients_pattern(struct phl_info_t *phl,
 				struct phl_mcc_info *ori_minfo,
 				struct phl_mcc_info *new_minfo)
 {
@@ -2966,7 +2966,7 @@ exit:
 	return status;
 }
 
-enum rtw_phl_status _mcc_update_ap_client_pattern(struct phl_info_t *phl,
+static enum rtw_phl_status _mcc_update_ap_client_pattern(struct phl_info_t *phl,
 		struct phl_mcc_info *ori_minfo, struct phl_mcc_info *new_minfo)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
@@ -3000,7 +3000,7 @@ exit:
 	return status;
 }
 
-enum rtw_phl_status _mcc_update_ap_bt_pattern(struct phl_info_t *phl,
+static enum rtw_phl_status _mcc_update_ap_bt_pattern(struct phl_info_t *phl,
 		struct phl_mcc_info *ori_minfo, struct phl_mcc_info *new_minfo)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
@@ -3025,7 +3025,7 @@ exit:
 	return status;
 }
 
-enum rtw_phl_status _mcc_duration_change(struct phl_info_t *phl,
+static enum rtw_phl_status _mcc_duration_change(struct phl_info_t *phl,
 		struct phl_mcc_info *minfo, struct phl_mcc_info *new_minfo)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
@@ -3061,7 +3061,7 @@ exit:
 	return status;
 }
 
-void _mcc_2_clients_tracking(struct phl_info_t *phl,
+static void _mcc_2_clients_tracking(struct phl_info_t *phl,
 				struct phl_mcc_info *minfo
 )
 {
@@ -3151,7 +3151,7 @@ exit:
 	return;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 rtw_phl_mcc_ap_bt_coex_enable(struct phl_info_t *phl,
                               struct rtw_wifi_role_t *cur_role,
                               struct rtw_wifi_role_link_t *cur_rlink)
@@ -3241,7 +3241,7 @@ exit:
 	return status;
 }
 
-enum rtw_phl_status rtw_phl_mcc_go_bt_coex_disable(struct phl_info_t *phl,
+static enum rtw_phl_status rtw_phl_mcc_go_bt_coex_disable(struct phl_info_t *phl,
 				struct rtw_wifi_role_t *spec_role)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
@@ -3313,7 +3313,7 @@ exit:
 	return;
 }
 
-enum rtw_phl_status rtw_phl_mcc_duration_change(struct phl_info_t *phl,
+static enum rtw_phl_status rtw_phl_mcc_duration_change(struct phl_info_t *phl,
 			struct phl_tdmra_dur_change_info *info)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
@@ -3345,7 +3345,7 @@ exit:
 	return status;
 }
 
-enum rtw_phl_status rtw_phl_mcc_bt_duration_change(struct phl_info_t *phl,
+static enum rtw_phl_status rtw_phl_mcc_bt_duration_change(struct phl_info_t *phl,
 				struct phl_tdmra_dur_change_info *info)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;

--- a/phl/phl_mr.c
+++ b/phl/phl_mr.c
@@ -1307,7 +1307,7 @@ _phl_mrc_module_stop(void *dispr, void *priv)
 }
 
 /* Same behaviour as rtw_phl_connect_prepare without cmd dispr */
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_mrc_module_connect_start_hdlr(struct phl_info_t *phl_info,
                                    struct rtw_wifi_role_t *wrole,
                                    struct rtw_wifi_role_link_t *rlink)
@@ -1341,7 +1341,7 @@ _exit:
 }
 
 /* Same behaviour as rtw_phl_connected without cmd dispr */
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_mrc_module_connect_end_hdlr(struct phl_info_t *phl_info,
 				 struct rtw_wifi_role_t *wrole)
 {
@@ -1418,7 +1418,7 @@ _exit:
 }
 
 /* Same behaviour as rtw_phl_disconnect without cmd dispr */
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_mrc_module_disconnect_hdlr(struct phl_info_t *phl_info,
 				struct rtw_wifi_role_t *wrole)
 {
@@ -1507,7 +1507,7 @@ _exit:
 }
 
 /* Same behaviour as rtw_phl_ap_started without cmd dispr */
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_mrc_module_ap_started_hdlr(struct phl_info_t *phl_info,
 				struct rtw_wifi_role_t *wrole)
 {
@@ -1553,7 +1553,7 @@ _exit:
 
 
 /* Same behaviour as rtw_phl_ap_stop without cmd dispr */
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_mrc_module_ap_stop_hdlr(struct phl_info_t *phl_info,
 				struct rtw_wifi_role_t *wrole)
 {
@@ -1601,7 +1601,7 @@ _exit:
 	return psts;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _phl_mrc_module_swch_start_hdlr(void *dispr,
 				void *priv,
 				struct phl_msg *msg)
@@ -1699,7 +1699,7 @@ _exit:
 	return ret;
 }
 
-enum phl_mdl_ret_code
+static enum phl_mdl_ret_code
 _phl_mrc_module_swch_done_hdlr(void *dispr,
 			       void *priv,
 			       struct phl_msg *msg)
@@ -2675,7 +2675,7 @@ phl_mr_ctrl_deinit(struct phl_info_t *phl_info)
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_mr_chandef_sync(struct phl_info_t *phl_info, struct hw_band_ctl_t *band_ctrl,
 			struct rtw_chan_ctx *chanctx, struct rtw_chan_def *chandef)
 {

--- a/phl/phl_mr_coex.c
+++ b/phl/phl_mr_coex.c
@@ -165,7 +165,7 @@ exit:
 
 
 /* find any existed role */
-struct rtw_wifi_role_t *_find_existed_role(struct phl_info_t *phl_info,
+static struct rtw_wifi_role_t *_find_existed_role(struct phl_info_t *phl_info,
 							enum phl_band_idx band_idx)
 {
 	struct rtw_phl_com_t *phl_com = phl_info->phl_com;
@@ -184,7 +184,7 @@ struct rtw_wifi_role_t *_find_existed_role(struct phl_info_t *phl_info,
 	return wr;
 }
 
-enum rtw_phl_status _tdmra_disable(struct phl_info_t *phl_info,
+static enum rtw_phl_status _tdmra_disable(struct phl_info_t *phl_info,
 			struct rtw_wifi_role_t *cur_wrole, enum phl_band_idx band_idx)
 {
 	enum rtw_phl_status psts = RTW_PHL_STATUS_SUCCESS;
@@ -229,7 +229,7 @@ exit:
  * Specific concurrent mode : 2g ap category x1 + BTC, MCC, MCC + BTC
  * @handle: True: handle specific concurrent mode for all interfaces; False: Not handleand maybe handle it by other coex mechanism.
  */
-enum rtw_phl_status
+static enum rtw_phl_status
 _tdmra_handle(struct phl_info_t *phl_info,
 				struct rtw_wifi_role_t *cur_wrole, u16 slot,
 				enum phl_band_idx band_idx,
@@ -519,7 +519,7 @@ exit:
 /*
  * Disable MR coex mechanism of 2g_scc_1ap_1sta_btc
  */
-enum rtw_phl_status
+static enum rtw_phl_status
 _mr_coex_2g_scc_1ap_1sta_btc_disable(struct phl_info_t *phl,
 			enum phl_band_idx band_idx)
 {

--- a/phl/phl_msg_hub.c
+++ b/phl/phl_msg_hub.c
@@ -114,7 +114,7 @@ static void push_back_wait_msg(struct phl_info_t* phl, struct phl_msg_ex* ex)
 	_os_sema_up(d, &(hub->msg_q_sema));
 }
 
-void msg_forward(struct phl_info_t* phl, struct phl_msg_ex* ex)
+static void msg_forward(struct phl_info_t* phl, struct phl_msg_ex* ex)
 {
 	void *d = phl_to_drvpriv(phl);
 	u8 i = 0;

--- a/phl/phl_p2pps.c
+++ b/phl/phl_p2pps.c
@@ -46,7 +46,7 @@ void phl_p2pps_deinit(struct phl_info_t *phl_info)
 	phl_com->p2pps_info = NULL;
 }
 
-void
+static void
 _phl_p2pps_dump_single_noa_desc(struct rtw_phl_noa_desc *desc)
 {
 	PHL_TRACE(COMP_PHL_P2PPS, _PHL_INFO_, "[NOA]_phl_p2pps_dump_single_noa_desc():enable = %d\n",
@@ -71,7 +71,7 @@ _phl_p2pps_dump_single_noa_desc(struct rtw_phl_noa_desc *desc)
 		desc->rlink);
 }
 
-void
+static void
 _phl_p2pps_dump_noa_table(struct rtw_phl_p2pps_info *psinfo,
 	struct rtw_phl_noa_info *info)
 {
@@ -113,7 +113,7 @@ _phl_p2pps_dump_noa_table(struct rtw_phl_p2pps_info *psinfo,
 	_os_spinunlock(drvpriv, &psinfo->p2pps_lock, _bh, NULL);
 }
 
-struct rtw_phl_noa_info *
+static struct rtw_phl_noa_info *
 _phl_p2pps_get_noa_info_by_role(struct rtw_phl_p2pps_info *psinfo,
 	struct rtw_wifi_role_t *wrole)
 {
@@ -121,7 +121,7 @@ _phl_p2pps_get_noa_info_by_role(struct rtw_phl_p2pps_info *psinfo,
 	return &psinfo->noa_info[idx];
 }
 
-struct rtw_phl_noa_desc *
+static struct rtw_phl_noa_desc *
 _phl_p2pps_get_first_noa_desc_with_cnt255(struct phl_info_t *phl,
 	struct rtw_phl_noa_info *info)
 {
@@ -141,7 +141,7 @@ _phl_p2pps_get_first_noa_desc_with_cnt255(struct phl_info_t *phl,
 
 #ifdef RTW_WKARD_P2PPS_SINGLE_NOA
 
-u8
+static u8
 _phl_p2pps_query_mcc_inprog_wkard(struct phl_info_t *phl_info,
 	struct rtw_wifi_role_t *w_role)
 {
@@ -154,7 +154,7 @@ _phl_p2pps_query_mcc_inprog_wkard(struct phl_info_t *phl_info,
 	return ret;
 }
 
-struct rtw_wifi_role_t *
+static struct rtw_wifi_role_t *
 _phl_get_role_by_band_port(struct phl_info_t* phl_info,
                            u8 hw_band,
                            u8 hw_port)
@@ -187,7 +187,7 @@ _phl_get_role_by_band_port(struct phl_info_t* phl_info,
 	return NULL;
 }
 
-void
+static void
 _phl_p2pps_calc_next_noa_s_time(struct phl_info_t *phl_info,
 	struct rtw_wifi_role_t *w_role,
 	struct rtw_phl_tsf32_tog_rpt *rpt,
@@ -218,7 +218,7 @@ _phl_p2pps_calc_next_noa_s_time(struct phl_info_t *phl_info,
 	new_desc->start_t_l = new_st & 0xFFFFFFFF;
 }
 
-void _phl_p2pps_ap_on_tsf32_tog(struct phl_info_t* phl_info,
+static void _phl_p2pps_ap_on_tsf32_tog(struct phl_info_t* phl_info,
 	struct rtw_wifi_role_t *wrole,
 	struct rtw_phl_tsf32_tog_rpt *rpt)
 {
@@ -278,7 +278,7 @@ void phl_p2pps_tsf32_tog_handler(struct phl_info_t* phl_info)
 	}
 }
 
-void
+static void
 _phl_p2pps_copy_noa_desc(struct rtw_phl_p2pps_info *psinfo,
 	struct rtw_phl_noa_desc *dest,
 	struct rtw_phl_noa_desc *src)
@@ -290,7 +290,7 @@ _phl_p2pps_copy_noa_desc(struct rtw_phl_p2pps_info *psinfo,
 	_os_spinunlock(drvpriv, &psinfo->p2pps_lock, _bh, NULL);
 }
 
-void
+static void
 _phl_p2pps_clear_noa_desc(struct rtw_phl_p2pps_info *psinfo,
 	struct rtw_phl_noa_desc *desc)
 {
@@ -301,7 +301,7 @@ _phl_p2pps_clear_noa_desc(struct rtw_phl_p2pps_info *psinfo,
 	_os_spinunlock(drvpriv, &psinfo->p2pps_lock, _bh, NULL);
 }
 
-void
+static void
 _phl_p2pps_noa_increase_desc(struct rtw_phl_p2pps_info *psinfo,
 	struct rtw_phl_noa_info *info)
 {
@@ -312,7 +312,7 @@ _phl_p2pps_noa_increase_desc(struct rtw_phl_p2pps_info *psinfo,
 	_os_spinunlock(drvpriv, &psinfo->p2pps_lock, _bh, NULL);
 }
 
-void
+static void
 _phl_p2pps_noa_decrease_desc(struct rtw_phl_p2pps_info *psinfo,
 	struct rtw_phl_noa_info *info)
 {
@@ -326,7 +326,7 @@ _phl_p2pps_noa_decrease_desc(struct rtw_phl_p2pps_info *psinfo,
 	_os_spinunlock(drvpriv, &psinfo->p2pps_lock, _bh, NULL);
 }
 
-u8
+static u8
 _phl_p2pps_noa_should_activate(struct rtw_phl_p2pps_info *psinfo,
 	struct rtw_phl_noa_desc *in_desc)
 {
@@ -372,7 +372,7 @@ exit:
 	return ret;
 }
 
-u8
+static u8
 _phl_p2pps_noa_is_all_disable(struct rtw_phl_p2pps_info *psinfo,
 	struct rtw_phl_noa_info *info)
 {
@@ -390,7 +390,7 @@ _phl_p2pps_noa_is_all_disable(struct rtw_phl_p2pps_info *psinfo,
 	return true;
 }
 
-u8
+static u8
 _phl_p2pps_noa_assign_noaid(struct rtw_phl_p2pps_info *psinfo,
 	struct rtw_phl_noa_info *info,
 	struct rtw_phl_noa_desc *desc)
@@ -420,7 +420,7 @@ _phl_p2pps_noa_assign_noaid(struct rtw_phl_p2pps_info *psinfo,
 	return id;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_p2pps_noa_disable(struct rtw_phl_p2pps_info *psinfo,
                        struct rtw_phl_noa_info *noa_info,
                        struct rtw_phl_noa_desc *noa_desc,
@@ -491,7 +491,7 @@ _phl_p2pps_noa_disable(struct rtw_phl_p2pps_info *psinfo,
 	return ret;
 }
 
-void _phl_p2pps_noa_disable_all(struct phl_info_t *phl,
+static void _phl_p2pps_noa_disable_all(struct phl_info_t *phl,
 	struct rtw_wifi_role_t *w_role)
 {
 	struct rtw_phl_p2pps_info *psinfo = phl_to_p2pps_info(phl);
@@ -514,7 +514,7 @@ void _phl_p2pps_noa_disable_all(struct phl_info_t *phl,
 	PHL_TRACE(COMP_PHL_P2PPS, _PHL_INFO_, "[NOA]%s:<====\n", __func__);
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_p2p_ps_up_clients_macid_for_ap_role(struct phl_info_t *phl,
 		struct rtw_phl_p2pps_info *psinfo, struct rtw_wifi_role_t *wrole)
 {
@@ -548,7 +548,7 @@ exit:
 	return psts;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_p2pps_noa_enable(struct rtw_phl_p2pps_info *psinfo,
                       struct rtw_phl_noa_info *noa_info,
                       struct rtw_phl_noa_desc *noa_desc,
@@ -622,7 +622,7 @@ _phl_p2pps_noa_enable(struct rtw_phl_p2pps_info *psinfo,
 	return ret;
 }
 
-bool
+static bool
 _phl_p2p_noa_runing(struct phl_info_t *phl,
 			struct rtw_wifi_role_t *w_role)
 {

--- a/phl/phl_pkt_ofld.c
+++ b/phl/phl_pkt_ofld.c
@@ -13,6 +13,7 @@
  *
  *****************************************************************************/
 #include "phl_headers.h"
+#include "phl_api_drv.h"
 
 #define HAL_PKT_OFLD_ADD(_pkt, _id, _pkt_buf, _len) \
 	rtw_hal_pkt_ofld((_pkt)->phl_info->hal, _id, PKT_OFLD_ADD, _pkt_buf, _len)

--- a/phl/phl_ps.c
+++ b/phl/phl_ps.c
@@ -173,7 +173,7 @@ static void _ps_ntfy_after_pwr_cfg(struct phl_info_t *phl_info, u8 ps_mode,
 }
 
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_ps_ctrl_datapath(struct phl_info_t *phl_info, bool pause)
 {
 	struct phl_data_ctl_t ctl = {0};
@@ -553,7 +553,7 @@ static enum rtw_phl_status _lps_leave_proto_cfg(struct phl_info_t *phl_info, str
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-enum rtw_phl_status phl_ps_lps_proto_cfg(struct phl_info_t *phl_info, struct ps_cfg *cfg, bool lps_en)
+static enum rtw_phl_status phl_ps_lps_proto_cfg(struct phl_info_t *phl_info, struct ps_cfg *cfg, bool lps_en)
 {
 	if (lps_en)
 		return _lps_enter_proto_cfg(phl_info, cfg);
@@ -561,7 +561,7 @@ enum rtw_phl_status phl_ps_lps_proto_cfg(struct phl_info_t *phl_info, struct ps_
 		return _lps_leave_proto_cfg(phl_info, cfg);
 }
 
-enum rtw_phl_status phl_ps_lps_enter(struct phl_info_t *phl_info, struct ps_cfg *cfg)
+static enum rtw_phl_status phl_ps_lps_enter(struct phl_info_t *phl_info, struct ps_cfg *cfg)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
 
@@ -584,7 +584,7 @@ enum rtw_phl_status phl_ps_lps_enter(struct phl_info_t *phl_info, struct ps_cfg 
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-enum rtw_phl_status phl_ps_lps_leave(struct phl_info_t *phl_info, struct ps_cfg *cfg)
+static enum rtw_phl_status phl_ps_lps_leave(struct phl_info_t *phl_info, struct ps_cfg *cfg)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
 
@@ -607,7 +607,7 @@ enum rtw_phl_status phl_ps_lps_leave(struct phl_info_t *phl_info, struct ps_cfg 
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-enum rtw_phl_status phl_ps_ips_proto_cfg(struct phl_info_t *phl_info, struct ps_cfg *cfg, bool ips_en)
+static enum rtw_phl_status phl_ps_ips_proto_cfg(struct phl_info_t *phl_info, struct ps_cfg *cfg, bool ips_en)
 {
 	/* ips protocol config */
 	PHL_TRACE(COMP_PHL_PS, _PHL_INFO_, "[PS], %s(): \n", __func__);
@@ -619,7 +619,7 @@ enum rtw_phl_status phl_ps_ips_proto_cfg(struct phl_info_t *phl_info, struct ps_
 	return phl_ps_ips_cfg(phl_info, cfg, ips_en);
 }
 
-enum rtw_phl_status phl_ps_ips_enter(struct phl_info_t *phl_info, struct ps_cfg *cfg)
+static enum rtw_phl_status phl_ps_ips_enter(struct phl_info_t *phl_info, struct ps_cfg *cfg)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
 
@@ -642,7 +642,7 @@ enum rtw_phl_status phl_ps_ips_enter(struct phl_info_t *phl_info, struct ps_cfg 
 	return status;
 }
 
-enum rtw_phl_status phl_ps_ips_leave(struct phl_info_t *phl_info, struct ps_cfg *cfg)
+static enum rtw_phl_status phl_ps_ips_leave(struct phl_info_t *phl_info, struct ps_cfg *cfg)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
 

--- a/phl/phl_regulation.c
+++ b/phl/phl_regulation.c
@@ -1785,7 +1785,7 @@ void phl_regu_policy_init(void *drv_priv, void *phl)
 	_os_spinunlock(drv_priv, &rg->lock, _bh, NULL);
 }
 
-bool rtw_phl_regulation_valid(void *phl)
+static bool rtw_phl_regulation_valid(void *phl)
 {
 	return _regulation_valid(phl);
 }

--- a/phl/phl_regulation_6g.c
+++ b/phl/phl_regulation_6g.c
@@ -16,6 +16,7 @@
 #include "phl_chnlplan.h"
 #include "phl_chnlplan_6g.h"
 #include "phl_country.h"
+#include "phl_regulation_6g.h"
 
 extern const struct chdef_6ghz chdef6g[MAX_CHDEF_6GHZ];
 extern const struct regulatory_domain_mapping_6g rdmap6[MAX_RD_MAP_NUM_6GHZ];

--- a/phl/phl_role.c
+++ b/phl/phl_role.c
@@ -634,7 +634,7 @@ phl_wifi_role_start_hdl(struct phl_info_t *phl_info, u8 *param)
 	return _phl_wifi_role_start(phl_info, cmd_wr->wrole, cmd_wr->mld);
 }
 
-void phl_wifi_role_start_done(void *drv_priv, u8 *cmd, u32 cmd_len,
+static void phl_wifi_role_start_done(void *drv_priv, u8 *cmd, u32 cmd_len,
 						enum rtw_phl_status status)
 {
 	if (cmd) {
@@ -984,7 +984,7 @@ rtw_phl_wifi_role_realloc_band(void *phl,
 }
 #endif /*CONFIG_DBCC_SUPPORT*/
 
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_wifi_role_realloc_port(struct phl_info_t *phl_info,
                            struct rtw_wifi_role_t *wrole,
                            struct rtw_wifi_role_link_t *rlink,
@@ -1077,7 +1077,7 @@ rtw_phl_wifi_role_realloc_port(void *phl,
 }
 
 
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_wifi_role_realloc_wmm(struct phl_info_t *phl_info,
                           struct rtw_wifi_role_link_t *rlink,
                           u8 new_wmm)
@@ -1566,7 +1566,7 @@ phl_wifi_role_chg_hdl(struct phl_info_t *phl_info, u8 *param)
 	                            wr_chg->info);
 }
 
-void phl_wifi_role_chg_done(void *drv_priv, u8 *cmd, u32 cmd_len,
+static void phl_wifi_role_chg_done(void *drv_priv, u8 *cmd, u32 cmd_len,
 						enum rtw_phl_status status)
 {
 	struct wr_chg_param *wr_chg = NULL;
@@ -1687,7 +1687,7 @@ rtw_phl_cmd_wrole_change(void *phl,
 }
 #endif /*CONFIG_CMD_DISP*/
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_wifi_role_stop(struct phl_info_t *phl_i, struct rtw_wifi_role_t *wrole)
 {
 	enum rtw_phl_status psts = RTW_PHL_STATUS_FAILURE;
@@ -1735,7 +1735,7 @@ phl_wifi_role_stop_hdl(struct phl_info_t *phl_info, u8 *param)
 
 	return _phl_wifi_role_stop(phl_info, wrole);
 }
-void phl_wifi_role_stop_done(void *drv_priv, u8 *cmd, u32 cmd_len,
+static void phl_wifi_role_stop_done(void *drv_priv, u8 *cmd, u32 cmd_len,
 						enum rtw_phl_status status)
 {
 	if (cmd) {
@@ -2091,7 +2091,7 @@ phl_wifi_role_macid_all_pause(struct phl_info_t *phl_info, struct rtw_wifi_role_
 	return pstatus;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_get_cur_tsf(void *phl,
 	struct rtw_phl_port_tsf *tsf)
 {

--- a/phl/phl_rx.c
+++ b/phl/phl_rx.c
@@ -61,7 +61,7 @@ u8 rtw_phl_is_phl_rx_idle(struct phl_info_t *phl_info)
 	return res;
 }
 
-void phl_dump_rx_stats(struct rtw_stats *stats)
+static void phl_dump_rx_stats(struct rtw_stats *stats)
 {
 	PHL_TRACE(COMP_PHL_XMIT, _PHL_DEBUG_,
 		  "Dump Rx statistics\n"
@@ -121,7 +121,7 @@ phl_rx_traffic_upd(struct rtw_stats *sts)
 	}
 }
 
-void phl_update_rx_stats(struct rtw_stats *stats, struct rtw_recv_pkt *rx_pkt)
+static void phl_update_rx_stats(struct rtw_stats *stats, struct rtw_recv_pkt *rx_pkt)
 {
 	u32 diff_t = 0, cur_time = _os_get_cur_time_ms();
 	u64 diff_bits = 0;
@@ -153,7 +153,7 @@ void phl_update_rx_stats(struct rtw_stats *stats, struct rtw_recv_pkt *rx_pkt)
 	}
 }
 
-void phl_rx_statistics(struct phl_info_t *phl_info, struct rtw_recv_pkt *rx_pkt)
+static void phl_rx_statistics(struct phl_info_t *phl_info, struct rtw_recv_pkt *rx_pkt)
 {
 	struct rtw_phl_com_t *phl_com = phl_info->phl_com;
 	struct rtw_stats *phl_stats = &phl_com->phl_stats;
@@ -338,7 +338,7 @@ void _phl_indic_new_rxpkt(struct phl_info_t *phl_info)
 #endif
 }
 
-void _phl_record_rx_stats(struct rtw_recv_pkt *recvpkt)
+static void _phl_record_rx_stats(struct rtw_recv_pkt *recvpkt)
 {
 	if(NULL == recvpkt)
 		return;
@@ -346,7 +346,7 @@ void _phl_record_rx_stats(struct rtw_recv_pkt *recvpkt)
 		recvpkt->tx_sta->stats.rx_rate = recvpkt->mdata.rx_rate;
 }
 
-enum rtw_phl_status _phl_add_rx_pkt(struct phl_info_t *phl_info,
+static enum rtw_phl_status _phl_add_rx_pkt(struct phl_info_t *phl_info,
 				    struct rtw_phl_rx_pkt *phl_rx)
 {
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_FAILURE;
@@ -408,7 +408,7 @@ out:
 	return pstatus;
 }
 
-void
+static void
 phl_sta_ps_enter(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta,
                  struct rtw_wifi_role_t *role)
 {
@@ -436,7 +436,7 @@ phl_sta_ps_enter(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta,
 	phl_send_client_ps_annc_ntfy_cmd(phl_info, sta, PHL_ClIENT_PS);
 }
 
-void
+static void
 phl_sta_ps_exit(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta,
                 struct rtw_wifi_role_t *role)
 {
@@ -464,7 +464,7 @@ phl_sta_ps_exit(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta,
 	phl_send_client_ps_annc_ntfy_cmd(phl_info, sta, PHL_ClIENT_ACTIVE);
 }
 
-void
+static void
 phl_rx_handle_sta_process(struct phl_info_t *phl_info,
                           struct rtw_phl_rx_pkt *rx)
 {
@@ -1073,7 +1073,7 @@ u8 phl_check_recv_ring_resource(struct phl_info_t *phl_info)
 		return true;
 }
 
-void dump_phl_rx_ring(void *phl)
+static void dump_phl_rx_ring(void *phl)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
 	void *drv_priv = phl_to_drvpriv(phl_info);
@@ -1137,7 +1137,7 @@ void phl_event_indicator(void *context)
 
 }
 
-void _phl_rx_statistics_reset(struct phl_info_t *phl_info)
+static void _phl_rx_statistics_reset(struct phl_info_t *phl_info)
 {
 	struct rtw_phl_com_t *phl_com = phl_info->phl_com;
 	struct rtw_phl_stainfo_t *sta = NULL;
@@ -1636,7 +1636,7 @@ _exit:
 }
 
 #ifdef CONFIG_PHL_RX_PSTS_PER_PKT
-void
+static void
 _phl_rx_proc_frame_list(struct phl_info_t *phl_info, struct phl_queue *pq)
 {
 	void *d = phl_to_drvpriv(phl_info);
@@ -1658,7 +1658,7 @@ _phl_rx_proc_frame_list(struct phl_info_t *phl_info, struct phl_queue *pq)
 	}
 }
 
-void
+static void
 _phl_rx_copy_phy_sts(struct rtw_phl_ppdu_phy_info *src, struct rtw_phl_ppdu_phy_info *dest)
 {
 	u8 i = 0;
@@ -2234,7 +2234,7 @@ void phl_rx_wp_report_record_sts(struct phl_info_t *phl_info,
 }
 
 
-void _phl_handle_ppdu_sts_q(struct phl_info_t *phl_info)
+static void _phl_handle_ppdu_sts_q(struct phl_info_t *phl_info)
 {
 #ifdef CONFIG_PHL_RX_PSTS_PER_PKT
 	struct rtw_phl_com_t *phl_com = phl_info->phl_com;

--- a/phl/phl_scanofld.c
+++ b/phl/phl_scanofld.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #include "phl_headers.h"
 #include "phl_scan.h"
+#include "phl_scanofld.h"
 
 #ifdef CONFIG_PHL_SCANOFLD
 

--- a/phl/phl_sec.c
+++ b/phl/phl_sec.c
@@ -74,7 +74,7 @@ _phl_cmd_set_key_done(void *drv_priv,
 	}
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_cmd_set_key(void *phl,
                  struct rtw_phl_stainfo_t *sta,
                  struct phl_sec_param_h *crypt,

--- a/phl/phl_sound.c
+++ b/phl/phl_sound.c
@@ -16,7 +16,7 @@
 
 #ifdef CONFIG_PHL_CMD_BF
 
-void __reset_snd_grp(struct phl_snd_grp *grp)
+static void __reset_snd_grp(struct phl_snd_grp *grp)
 {
 	u8 i = 0;
 
@@ -284,7 +284,7 @@ rtw_phl_sound_abort(void *phl)
 }
 
 /* set fixed mode parameters APIs*/
-void rtw_phl_snd_dump_fix_para(struct phl_info_t *phl_info)
+static void rtw_phl_snd_dump_fix_para(struct phl_info_t *phl_info)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
 	struct phl_snd_fix_param *para = NULL;
@@ -311,7 +311,7 @@ void rtw_phl_snd_dump_fix_para(struct phl_info_t *phl_info)
 	PHL_TRACE(COMP_PHL_SOUND, _PHL_INFO_, "<=== rtw_phl_snd_fix_dump_para \n");
 }
 /* fixed group idx */
-void rtw_phl_snd_fix_gidx(struct phl_info_t *phl_info, bool en, u8 gidx)
+static void rtw_phl_snd_fix_gidx(struct phl_info_t *phl_info, bool en, u8 gidx)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
 	PHL_TRACE(COMP_PHL_SOUND, _PHL_INFO_, "rtw_phl_snd_fix_gidx() set sounding gidx = 0x%x\n", gidx);
@@ -323,7 +323,7 @@ void rtw_phl_snd_fix_gidx(struct phl_info_t *phl_info, bool en, u8 gidx)
 	}
 }
 /* fixed snd feedback type */
-void rtw_phl_snd_fix_snd_fb_type(struct phl_info_t *phl_info,
+static void rtw_phl_snd_fix_snd_fb_type(struct phl_info_t *phl_info,
 				 bool en, enum snd_fb_type fb_type)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
@@ -338,7 +338,7 @@ void rtw_phl_snd_fix_snd_fb_type(struct phl_info_t *phl_info,
 }
 
 /* fixed sounding sta macids */
-void rtw_phl_snd_fix_set_sta(struct phl_info_t *phl_info,
+static void rtw_phl_snd_fix_set_sta(struct phl_info_t *phl_info,
 					bool en, u8 sidx, u16 macid)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
@@ -356,7 +356,7 @@ void rtw_phl_snd_fix_set_sta(struct phl_info_t *phl_info,
 }
 
 /* fixed sounding sta bw */
-void rtw_phl_snd_fix_set_bw(struct phl_info_t *phl_info,
+static void rtw_phl_snd_fix_set_bw(struct phl_info_t *phl_info,
 					bool en, u8 sidx, enum channel_width bw)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
@@ -492,7 +492,7 @@ phl_snd_get_grp_byidx(struct phl_info_t *phl_info, u8 gidx)
  * input:
  * @grp: (struct phl_snd_grp *) target sounding grp,
  */
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_snd_func_remove_grp(struct phl_info_t *phl_info, struct phl_snd_grp *grp)
 {
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_FAILURE;
@@ -552,7 +552,7 @@ phl_snd_func_remove_grp_all(struct phl_info_t *phl_info)
  * return:
  * @gidx: u8, the group idx in snd_param->grp[n]
  */
-u8 _phl_snd_get_available_gidx(struct phl_sound_obj *snd)
+static u8 _phl_snd_get_available_gidx(struct phl_sound_obj *snd)
 {
 	struct phl_sound_param *param = &snd->snd_param;
 	u8 gidx = MAX_SND_GRP_NUM;
@@ -575,7 +575,7 @@ u8 _phl_snd_get_available_gidx(struct phl_sound_obj *snd)
  * 	 the function will use  the macid / bw information in sta_info;
  * @gidx: the group idx to add
  */
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_func_grp_add_sta(
 	struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta, u8 gidx)
 {
@@ -638,7 +638,7 @@ _phl_snd_func_grp_add_sta(
  * @psta: (struct rtw_phl_stainfo_t *)Primary Sounding STA,
  *         if pSTA is unavailable , SND PROC for this group will be terminated.
  **/
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_snd_func_add_snd_grp(
 	struct phl_info_t *phl_info, bool he_snd,
 	u8 wrole_idx, struct rtw_phl_stainfo_t *psta, u8 *gidx)
@@ -693,7 +693,7 @@ phl_snd_func_add_snd_grp(
  * input:
  * @grp: (struct phl_snd_grp *) the target group.
  */
-void _phl_snd_func_set_grp_fb_mu(struct phl_snd_grp *grp)
+static void _phl_snd_func_set_grp_fb_mu(struct phl_snd_grp *grp)
 {
 	u8 i = 0;
 	if (grp == NULL)
@@ -841,7 +841,7 @@ phl_snd_func_grouping(struct phl_info_t *phl_info, u8 wroleidx)
 /* SND PROC */
 
 /* Free BF/CQI resource */
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_proc_release_res_cqi(
 	struct phl_info_t *phl_info, struct phl_snd_grp *grp)
 {
@@ -852,7 +852,7 @@ _phl_snd_proc_release_res_cqi(
 	return pstatus;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_proc_release_res_bf(
 	struct phl_info_t *phl_info, struct phl_snd_grp *grp)
 {
@@ -915,7 +915,7 @@ phl_snd_proc_release_res(struct phl_info_t *phl_info, struct phl_snd_grp *grp)
  * @grp: (struct phl_sound_grp *) sounding gorup
  * @nsta: return value : how many sta query resource success
  **/
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_proc_get_res_cqi_fb(
 	struct phl_info_t *phl_info, struct phl_snd_grp *grp, u8 *nsta)
 {
@@ -961,7 +961,7 @@ _phl_snd_proc_get_res_cqi_fb(
  * @grp: (struct phl_sound_grp *) sounding gorup
  * @nsta: return value : how many sta query bf resource success
  **/
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_proc_get_res_bf(
 	struct phl_info_t *phl_info, struct phl_snd_grp *grp, u8 *nsta)
 {
@@ -1090,7 +1090,7 @@ static u8 _get_mu_mimo_gid_2sta(u8 primary, u8 secondary)
 	return ret;
 }
 /* pre calculate mu-gid */
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_snd_cal_mu_grp_bitmap(struct phl_info_t *phl_info, struct phl_snd_grp *grp)
 {
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_SUCCESS;
@@ -1228,7 +1228,7 @@ phl_snd_proc_precfg(struct phl_info_t *phl_info, struct phl_snd_grp *grp)
 /* 3. Send Sounding Command to HAL/FW */
 /*TODO: RU Allocation is now hard code value */
 /* HE TB Sounding : 2 sta in a grp */
-void
+static void
 _phl_snd_proc_fw_cmd_he_tb_2sta(struct phl_info_t *phl_info,
 				struct phl_snd_grp *grp,
 				u8 *cmd, u8 bfrp_num)
@@ -1282,7 +1282,7 @@ _phl_snd_proc_fw_cmd_he_tb_2sta(struct phl_info_t *phl_info,
 }
 
 /* HE TB Sounding : 3 sta in a grp */
-void
+static void
 _phl_snd_proc_fw_cmd_he_tb_3sta(struct phl_info_t *phl_info,
 				struct phl_snd_grp *grp,
 				u8 *cmd, u8 bfrp_num)
@@ -1347,7 +1347,7 @@ _phl_snd_proc_fw_cmd_he_tb_3sta(struct phl_info_t *phl_info,
 }
 
 /* HE TB Sounding : 4 sta in a grp */
-void
+static void
 _phl_snd_proc_fw_cmd_he_tb_4sta(struct phl_info_t *phl_info,
 				struct phl_snd_grp *grp,
 				u8 *cmd, u8 bfrp_num)
@@ -1586,7 +1586,7 @@ phl_snd_proc_start_sounding_fw(struct phl_info_t *phl_info,
 /* 4. Post Configruation */
 
 /* BY MU_GID if MU Sounding */
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_proc_postcfg_mu_gid(struct phl_info_t *phl_info,
 					struct phl_snd_grp *grp)
 {
@@ -1637,7 +1637,7 @@ _phl_snd_proc_postcfg_mu_gid(struct phl_info_t *phl_info,
 	return pstatus;
 }
 /* Per STA setting */
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_proc_postcfg_sta(struct phl_info_t *phl_info,
 				struct phl_snd_grp *grp)
 {

--- a/phl/phl_sound_cmd.c
+++ b/phl/phl_sound_cmd.c
@@ -16,7 +16,7 @@
 
 #ifdef CONFIG_PHL_CMD_BF
 /* START of sounding / beamform cmd_disp module */
-void
+static void
 _phl_snd_cmd_set_eng_busy(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ctrl)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
@@ -26,7 +26,7 @@ _phl_snd_cmd_set_eng_busy(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ct
 	}
 }
 
-void
+static void
 _phl_snd_cmd_set_eng_idle(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ctrl)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
@@ -36,7 +36,7 @@ _phl_snd_cmd_set_eng_idle(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ct
 	}
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_cmd_get_eng_status(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ctrl)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
@@ -53,7 +53,7 @@ _phl_snd_cmd_get_eng_status(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl 
 	}
 	return pstatus;
 }
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_aquire_eng(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ctrl)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
@@ -76,7 +76,7 @@ _phl_snd_aquire_eng(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ctrl)
 	return pstatus;
 }
 
-void
+static void
 _phl_snd_free_eng(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ctrl)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
@@ -89,7 +89,7 @@ _phl_snd_free_eng(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ctrl)
 	}
 }
 
-void _snd_cmd_timer_callback(void *context)
+static void _snd_cmd_timer_callback(void *context)
 {
 	struct phl_sound_obj *snd_obj = (struct phl_sound_obj *)context;
 	struct snd_cmd_bfer *cur_snd_cmd = NULL;
@@ -623,7 +623,7 @@ enum rtw_phl_status phl_snd_cmd_register_module(struct phl_info_t *phl_info)
  * _phl_snd_cmd_post_set_vht_gid(...)
  * 	used by rtw_phl_snd_cmd_set_vht_gid(..)
  **/
-void _phl_snd_cmd_post_set_vht_gid(void* priv, struct phl_msg* msg)
+static void _phl_snd_cmd_post_set_vht_gid(void* priv, struct phl_msg* msg)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)priv;
 
@@ -688,7 +688,7 @@ exit:
 	return phl_status;
 }
 
-void _phl_snd_cmd_post_set_aid(void* priv, struct phl_msg* msg)
+static void _phl_snd_cmd_post_set_aid(void* priv, struct phl_msg* msg)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)priv;
 #ifdef RTW_WKARD_BFEE_SET_AID
@@ -767,7 +767,7 @@ exit:
 /**
  * For other module, such as LPS, direct set aid.
  **/
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_snd_cmd_set_aid_info(struct phl_info_t *phl,
 			 struct rtw_wifi_role_t *wrole,
 			 struct rtw_phl_stainfo_t *sta,
@@ -825,7 +825,7 @@ _phl_cmd_snd_restore_aid(struct phl_info_t *phl,
 #endif
 
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_cmd_ntfy_ps_enter(struct phl_info_t *phl,
 			   struct rtw_wifi_role_t *wrole)
 {
@@ -843,7 +843,7 @@ _phl_snd_cmd_ntfy_ps_enter(struct phl_info_t *phl,
 	return phl_status;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_cmd_ntfy_ps_leave(struct phl_info_t *phl,
 			   struct rtw_wifi_role_t *wrole)
 {
@@ -883,7 +883,7 @@ void phl_snd_cmd_sound_cancel_msg(struct phl_info_t *phl_info)
 	phl_disp_eng_cancel_msg(phl_info, 0, &snd_obj->msg_hdl);
 }
 
-void _phl_snd_cmd_post_sound_evt_success(
+static void _phl_snd_cmd_post_sound_evt_success(
 	struct phl_info_t *phl_info,
 	struct snd_cmd_bfer *cmd_buf)
 {
@@ -970,7 +970,7 @@ void _phl_snd_cmd_post_sound_evt_success(
 
 }
 
-void _phl_snd_cmd_post_sound_evt_fail(
+static void _phl_snd_cmd_post_sound_evt_fail(
 	struct phl_info_t *phl_info,
 	struct snd_cmd_bfer *cmd_buf)
 {
@@ -1008,7 +1008,7 @@ void _phl_snd_cmd_post_sound_evt_fail(
 	}
 }
 
-void _phl_snd_cmd_post_sound_evt(void* priv, struct phl_msg* msg)
+static void _phl_snd_cmd_post_sound_evt(void* priv, struct phl_msg* msg)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)priv;
 	struct snd_cmd_bfer *cmd_buf = NULL;

--- a/phl/phl_sound_cmd.c
+++ b/phl/phl_sound_cmd.c
@@ -16,7 +16,7 @@
 
 #ifdef CONFIG_PHL_CMD_BF
 /* START of sounding / beamform cmd_disp module */
-void
+static void
 _phl_snd_cmd_set_eng_busy(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ctrl)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
@@ -26,7 +26,7 @@ _phl_snd_cmd_set_eng_busy(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ct
 	}
 }
 
-void
+static void
 _phl_snd_cmd_set_eng_idle(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ctrl)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
@@ -36,7 +36,7 @@ _phl_snd_cmd_set_eng_idle(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ct
 	}
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_cmd_get_eng_status(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ctrl)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
@@ -53,7 +53,7 @@ _phl_snd_cmd_get_eng_status(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl 
 	}
 	return pstatus;
 }
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_aquire_eng(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ctrl)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
@@ -76,7 +76,7 @@ _phl_snd_aquire_eng(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ctrl)
 	return pstatus;
 }
 
-void
+static void
 _phl_snd_free_eng(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ctrl)
 {
 	struct phl_sound_obj *snd = (struct phl_sound_obj *)phl_info->snd_obj;
@@ -89,7 +89,7 @@ _phl_snd_free_eng(struct phl_info_t *phl_info, enum snd_cmd_disp_ctrl ctrl)
 	}
 }
 
-void _snd_cmd_timer_callback(void *context)
+static void _snd_cmd_timer_callback(void *context)
 {
 	struct phl_sound_obj *snd_obj = (struct phl_sound_obj *)context;
 	struct snd_cmd_bfer *cur_snd_cmd = NULL;
@@ -623,7 +623,7 @@ enum rtw_phl_status phl_snd_cmd_register_module(struct phl_info_t *phl_info)
  * _phl_snd_cmd_post_set_vht_gid(...)
  * 	used by rtw_phl_snd_cmd_set_vht_gid(..)
  **/
-void _phl_snd_cmd_post_set_vht_gid(void* priv, struct phl_msg* msg)
+static void _phl_snd_cmd_post_set_vht_gid(void* priv, struct phl_msg* msg)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)priv;
 
@@ -688,7 +688,7 @@ exit:
 	return phl_status;
 }
 
-void _phl_snd_cmd_post_set_aid(void* priv, struct phl_msg* msg)
+static void _phl_snd_cmd_post_set_aid(void* priv, struct phl_msg* msg)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)priv;
 #ifdef RTW_WKARD_BFEE_SET_AID
@@ -767,7 +767,8 @@ exit:
 /**
  * For other module, such as LPS, direct set aid.
  **/
-enum rtw_phl_status
+#ifdef RTW_WKARD_BFEE_SET_AID
+static enum rtw_phl_status
 phl_snd_cmd_set_aid_info(struct phl_info_t *phl,
 			 struct rtw_wifi_role_t *wrole,
 			 struct rtw_phl_stainfo_t *sta,
@@ -791,6 +792,7 @@ phl_snd_cmd_set_aid_info(struct phl_info_t *phl,
 	PHL_TRACE(COMP_PHL_DBG, _PHL_INFO_, "<-- %s\n", __func__);
 	return phl_status;
 }
+#endif /* RTW_WKARD_BFEE_SET_AID */
 
 #ifdef RTW_WKARD_BFEE_SET_AID
 enum rtw_phl_status
@@ -825,7 +827,7 @@ _phl_cmd_snd_restore_aid(struct phl_info_t *phl,
 #endif
 
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_cmd_ntfy_ps_enter(struct phl_info_t *phl,
 			   struct rtw_wifi_role_t *wrole)
 {
@@ -843,7 +845,7 @@ _phl_snd_cmd_ntfy_ps_enter(struct phl_info_t *phl,
 	return phl_status;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_snd_cmd_ntfy_ps_leave(struct phl_info_t *phl,
 			   struct rtw_wifi_role_t *wrole)
 {
@@ -883,7 +885,7 @@ void phl_snd_cmd_sound_cancel_msg(struct phl_info_t *phl_info)
 	phl_disp_eng_cancel_msg(phl_info, 0, &snd_obj->msg_hdl);
 }
 
-void _phl_snd_cmd_post_sound_evt_success(
+static void _phl_snd_cmd_post_sound_evt_success(
 	struct phl_info_t *phl_info,
 	struct snd_cmd_bfer *cmd_buf)
 {
@@ -970,7 +972,7 @@ void _phl_snd_cmd_post_sound_evt_success(
 
 }
 
-void _phl_snd_cmd_post_sound_evt_fail(
+static void _phl_snd_cmd_post_sound_evt_fail(
 	struct phl_info_t *phl_info,
 	struct snd_cmd_bfer *cmd_buf)
 {
@@ -1008,7 +1010,7 @@ void _phl_snd_cmd_post_sound_evt_fail(
 	}
 }
 
-void _phl_snd_cmd_post_sound_evt(void* priv, struct phl_msg* msg)
+static void _phl_snd_cmd_post_sound_evt(void* priv, struct phl_msg* msg)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)priv;
 	struct snd_cmd_bfer *cmd_buf = NULL;

--- a/phl/phl_sta.c
+++ b/phl/phl_sta.c
@@ -298,7 +298,7 @@ exit:
 	return phl_status;
 }
 
-u16 _phl_get_macid(struct phl_info_t *phl_info,
+static u16 _phl_get_macid(struct phl_info_t *phl_info,
 		struct rtw_phl_stainfo_t *phl_sta)
 {
 	/* TODO: macid management */
@@ -694,7 +694,7 @@ _exit:
  * @phl: see phl_info_t
  * @macid: macid
  */
-u8
+static u8
 rtw_phl_macid_is_wrole_shared(void *phl, u16 macid)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
@@ -725,7 +725,7 @@ rtw_phl_macid_is_wrole_shared(void *phl, u16 macid)
  * @macid: macid
  * @wrole: check id belong to this wifi role
  */
-u8
+static u8
 rtw_phl_macid_is_wrole_specific(void *phl,
 					u16 macid, struct rtw_wifi_role_t *wrole)
 {
@@ -777,7 +777,7 @@ _phl_stainfo_init(struct phl_info_t *phl_info,
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_stainfo_deinit(struct phl_info_t *phl_info,
 				struct rtw_phl_stainfo_t *phl_sta)
 {
@@ -796,7 +796,7 @@ _phl_stainfo_deinit(struct phl_info_t *phl_info,
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_stainfo_enqueue(struct phl_info_t *phl_info,
 			 struct phl_queue *sta_queue,
 			 struct rtw_phl_stainfo_t *psta)
@@ -813,7 +813,7 @@ phl_stainfo_enqueue(struct phl_info_t *phl_info,
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-struct rtw_phl_stainfo_t *
+static struct rtw_phl_stainfo_t *
 phl_stainfo_dequeue(struct phl_info_t *phl_info,
 			struct phl_queue *sta_queue)
 {
@@ -835,7 +835,7 @@ phl_stainfo_dequeue(struct phl_info_t *phl_info,
 	return psta;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_stainfo_queue_del(struct phl_info_t *phl_info,
 			 struct phl_queue *sta_queue,
 			 struct rtw_phl_stainfo_t *psta)
@@ -854,7 +854,7 @@ phl_stainfo_queue_del(struct phl_info_t *phl_info,
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-struct rtw_phl_stainfo_t *
+static struct rtw_phl_stainfo_t *
 phl_stainfo_queue_search(struct phl_info_t *phl_info,
                          struct phl_queue *sta_queue,
                          u8 *addr)
@@ -893,7 +893,7 @@ _exit:
 	return sta;
 }
 
-struct rtw_phl_stainfo_t *
+static struct rtw_phl_stainfo_t *
 phl_stainfo_queue_get_first(struct phl_info_t *phl_info,
 			 struct phl_queue *sta_queue)
 {
@@ -1301,7 +1301,7 @@ phl_free_stainfo_sw(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta)
 	return pstatus;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 __phl_free_stainfo_sw(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta)
 {
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_FAILURE;
@@ -1374,7 +1374,7 @@ _exit:
 	return pstatus;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 __phl_free_stainfo_hw(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta)
 {
 	struct rtw_wifi_role_t *wrole = sta->wrole;
@@ -1410,7 +1410,7 @@ __phl_free_stainfo(struct phl_info_t *phl, struct rtw_phl_stainfo_t *sta)
 	return pstatus;
 }
 
-u8 _phl_tx_ring_register_decision(struct phl_info_t *phl_info,
+static u8 _phl_tx_ring_register_decision(struct phl_info_t *phl_info,
 				  struct rtw_phl_stainfo_t *sta)
 {
 	/* In one TXQ case, only register 1 shared tring to save memory usage */
@@ -1623,7 +1623,7 @@ _exit:
 	return pstatus;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 __phl_alloc_stainfo_hw(struct phl_info_t *phl_info,
 				    struct rtw_wifi_role_t *wrole,
 				    struct rtw_wifi_role_link_t *rlink,
@@ -2197,7 +2197,7 @@ phl_update_media_status_hdl(struct phl_info_t *phl_info, u8 *param)
 			media_sts->sta, media_sts->sta_addr, media_sts->is_connect);
 }
 
-void phl_update_media_status_done(void *drv_priv, u8 *cmd, u32 cmd_len,
+static void phl_update_media_status_done(void *drv_priv, u8 *cmd, u32 cmd_len,
 						enum rtw_phl_status status)
 {
 	if (cmd) {
@@ -3154,7 +3154,7 @@ _associated_tsf_error_handle_done(void *drv_priv, u8 *cmd, u32 cmd_len, enum rtw
 	}
 }
 
-void
+static void
 _associated_tsf_error_handle(struct phl_info_t *phl,
 			struct rtw_phl_stainfo_t *sta)
 {
@@ -3176,7 +3176,7 @@ _associated_tsf_error_handle(struct phl_info_t *phl,
 	}
 }
 
-bool
+static bool
 _error_tsf_detect(struct phl_info_t *phl, struct rtw_rx_bcn_info *bcn_i,
 			struct rtw_bcn_pkt_info *info)
 {
@@ -3243,7 +3243,7 @@ static void _data_sorting(u16 *array, u16 num)
 /*
  * Get next idx
  */
-u8 _get_fidx(u8 num, u8 cur_idx, u8 boundary)
+static u8 _get_fidx(u8 num, u8 cur_idx, u8 boundary)
 {
 	u8 idx = 0;
 
@@ -3260,7 +3260,7 @@ u8 _get_fidx(u8 num, u8 cur_idx, u8 boundary)
 /*
  * Get previous idx
  */
-u8 _get_bidx(u8 num, u8 cur_idx)
+static u8 _get_bidx(u8 num, u8 cur_idx)
 {
 	u8 idx = 0;
 
@@ -3351,7 +3351,7 @@ _min_tbtt(u32 tbtt1, u32 tbtt2, u32 bcn_intvl)
 	return min;
 }
 
-void _phl_sta_up_bcn_offset_info(struct phl_info_t *phl,
+static void _phl_sta_up_bcn_offset_info(struct phl_info_t *phl,
 			struct rtw_rx_bcn_info *bcn_i)
 {
 	struct rtw_bcn_long_i *bcn_l = &bcn_i->bcn_l_i;
@@ -4466,7 +4466,7 @@ static bool _phl_self_mld_chk(struct phl_info_t *phl_info,
 	return is_self;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_link_mld_stainfo(struct rtw_phl_mld_t *mld,
                       struct rtw_phl_stainfo_t *phl_sta,
                       u8 lidx)
@@ -4874,7 +4874,7 @@ phl_cmd_set_seciv_hdl(struct phl_info_t *phl_info, u8 *param)
 }
 #endif
 
-enum rtw_phl_status
+static enum rtw_phl_status
 rtw_phl_cmd_set_sta_seciv(void *phl,
                        struct rtw_wifi_role_t *wifi_role,
                        struct rtw_phl_stainfo_t *sta,

--- a/phl/phl_sta.c
+++ b/phl/phl_sta.c
@@ -14,6 +14,7 @@
  *****************************************************************************/
 #define _PHL_STA_C_
 #include "phl_headers.h"
+#include "phl_api.h"
 
 /*********** macid ctrl section ***********/
 enum rtw_phl_status

--- a/phl/phl_sta.c
+++ b/phl/phl_sta.c
@@ -298,7 +298,7 @@ exit:
 	return phl_status;
 }
 
-u16 _phl_get_macid(struct phl_info_t *phl_info,
+static u16 _phl_get_macid(struct phl_info_t *phl_info,
 		struct rtw_phl_stainfo_t *phl_sta)
 {
 	/* TODO: macid management */
@@ -694,7 +694,7 @@ _exit:
  * @phl: see phl_info_t
  * @macid: macid
  */
-u8
+static u8
 rtw_phl_macid_is_wrole_shared(void *phl, u16 macid)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
@@ -725,7 +725,7 @@ rtw_phl_macid_is_wrole_shared(void *phl, u16 macid)
  * @macid: macid
  * @wrole: check id belong to this wifi role
  */
-u8
+static u8
 rtw_phl_macid_is_wrole_specific(void *phl,
 					u16 macid, struct rtw_wifi_role_t *wrole)
 {
@@ -777,7 +777,7 @@ _phl_stainfo_init(struct phl_info_t *phl_info,
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_stainfo_deinit(struct phl_info_t *phl_info,
 				struct rtw_phl_stainfo_t *phl_sta)
 {
@@ -796,7 +796,7 @@ _phl_stainfo_deinit(struct phl_info_t *phl_info,
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_stainfo_enqueue(struct phl_info_t *phl_info,
 			 struct phl_queue *sta_queue,
 			 struct rtw_phl_stainfo_t *psta)
@@ -813,7 +813,7 @@ phl_stainfo_enqueue(struct phl_info_t *phl_info,
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-struct rtw_phl_stainfo_t *
+static struct rtw_phl_stainfo_t *
 phl_stainfo_dequeue(struct phl_info_t *phl_info,
 			struct phl_queue *sta_queue)
 {
@@ -835,7 +835,7 @@ phl_stainfo_dequeue(struct phl_info_t *phl_info,
 	return psta;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 phl_stainfo_queue_del(struct phl_info_t *phl_info,
 			 struct phl_queue *sta_queue,
 			 struct rtw_phl_stainfo_t *psta)
@@ -854,7 +854,7 @@ phl_stainfo_queue_del(struct phl_info_t *phl_info,
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-struct rtw_phl_stainfo_t *
+static struct rtw_phl_stainfo_t *
 phl_stainfo_queue_search(struct phl_info_t *phl_info,
                          struct phl_queue *sta_queue,
                          u8 *addr)
@@ -893,7 +893,7 @@ _exit:
 	return sta;
 }
 
-struct rtw_phl_stainfo_t *
+static struct rtw_phl_stainfo_t *
 phl_stainfo_queue_get_first(struct phl_info_t *phl_info,
 			 struct phl_queue *sta_queue)
 {
@@ -1301,7 +1301,7 @@ phl_free_stainfo_sw(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta)
 	return pstatus;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 __phl_free_stainfo_sw(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta)
 {
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_FAILURE;
@@ -1374,7 +1374,7 @@ _exit:
 	return pstatus;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 __phl_free_stainfo_hw(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta)
 {
 	struct rtw_wifi_role_t *wrole = sta->wrole;
@@ -1410,7 +1410,7 @@ __phl_free_stainfo(struct phl_info_t *phl, struct rtw_phl_stainfo_t *sta)
 	return pstatus;
 }
 
-u8 _phl_tx_ring_register_decision(struct phl_info_t *phl_info,
+static u8 _phl_tx_ring_register_decision(struct phl_info_t *phl_info,
 				  struct rtw_phl_stainfo_t *sta)
 {
 	/* In one TXQ case, only register 1 shared tring to save memory usage */
@@ -1623,7 +1623,7 @@ _exit:
 	return pstatus;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 __phl_alloc_stainfo_hw(struct phl_info_t *phl_info,
 				    struct rtw_wifi_role_t *wrole,
 				    struct rtw_wifi_role_link_t *rlink,
@@ -2197,7 +2197,7 @@ phl_update_media_status_hdl(struct phl_info_t *phl_info, u8 *param)
 			media_sts->sta, media_sts->sta_addr, media_sts->is_connect);
 }
 
-void phl_update_media_status_done(void *drv_priv, u8 *cmd, u32 cmd_len,
+static void phl_update_media_status_done(void *drv_priv, u8 *cmd, u32 cmd_len,
 						enum rtw_phl_status status)
 {
 	if (cmd) {
@@ -3156,7 +3156,7 @@ _associated_tsf_error_handle_done(void *drv_priv, u8 *cmd, u32 cmd_len, enum rtw
 	}
 }
 
-void
+static void
 _associated_tsf_error_handle(struct phl_info_t *phl,
 			struct rtw_phl_stainfo_t *sta)
 {
@@ -3178,7 +3178,7 @@ _associated_tsf_error_handle(struct phl_info_t *phl,
 	}
 }
 
-bool
+static bool
 _error_tsf_detect(struct phl_info_t *phl, struct rtw_rx_bcn_info *bcn_i,
 			struct rtw_bcn_pkt_info *info)
 {
@@ -3245,7 +3245,7 @@ static void _data_sorting(u16 *array, u16 num)
 /*
  * Get next idx
  */
-u8 _get_fidx(u8 num, u8 cur_idx, u8 boundary)
+static u8 _get_fidx(u8 num, u8 cur_idx, u8 boundary)
 {
 	u8 idx = 0;
 
@@ -3262,7 +3262,7 @@ u8 _get_fidx(u8 num, u8 cur_idx, u8 boundary)
 /*
  * Get previous idx
  */
-u8 _get_bidx(u8 num, u8 cur_idx)
+static u8 _get_bidx(u8 num, u8 cur_idx)
 {
 	u8 idx = 0;
 
@@ -3353,7 +3353,7 @@ _min_tbtt(u32 tbtt1, u32 tbtt2, u32 bcn_intvl)
 	return min;
 }
 
-void _phl_sta_up_bcn_offset_info(struct phl_info_t *phl,
+static void _phl_sta_up_bcn_offset_info(struct phl_info_t *phl,
 			struct rtw_rx_bcn_info *bcn_i)
 {
 	struct rtw_bcn_long_i *bcn_l = &bcn_i->bcn_l_i;
@@ -4468,7 +4468,7 @@ static bool _phl_self_mld_chk(struct phl_info_t *phl_info,
 	return is_self;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_link_mld_stainfo(struct rtw_phl_mld_t *mld,
                       struct rtw_phl_stainfo_t *phl_sta,
                       u8 lidx)
@@ -4876,7 +4876,7 @@ phl_cmd_set_seciv_hdl(struct phl_info_t *phl_info, u8 *param)
 }
 #endif
 
-enum rtw_phl_status
+static enum rtw_phl_status
 rtw_phl_cmd_set_sta_seciv(void *phl,
                        struct rtw_wifi_role_t *wifi_role,
                        struct rtw_phl_stainfo_t *sta,

--- a/phl/phl_sw_cap.c
+++ b/phl/phl_sw_cap.c
@@ -67,7 +67,7 @@ _phl_pwrlmt_para_free(
 	para_info->ext_reg_map_num = 0;
 }
 
-enum channel_width _phl_sw_cap_get_hi_bw(struct phy_cap_t *phy_cap)
+static enum channel_width _phl_sw_cap_get_hi_bw(struct phy_cap_t *phy_cap)
 {
 	enum channel_width bw = CHANNEL_WIDTH_20;
 	do {
@@ -200,7 +200,7 @@ void rtw_phl_init_free_para_buf(struct rtw_phl_com_t *phl_com)
 }
 
 
-u16 _phl_sw_role_cap_bf(enum role_type rtype)
+static u16 _phl_sw_role_cap_bf(enum role_type rtype)
 {
 	u16 def_bf_cap = 0;
 

--- a/phl/phl_tx.c
+++ b/phl/phl_tx.c
@@ -111,7 +111,7 @@ void phl_dump_t_fctrl_result(_os_list *t_fctrl_result)
 	}
 }
 
-void phl_dump_tx_stats(struct rtw_stats *stats)
+static void phl_dump_tx_stats(struct rtw_stats *stats)
 {
 	PHL_TRACE(COMP_PHL_XMIT, _PHL_DEBUG_,
 		  "Dump Tx statistics\n"
@@ -196,7 +196,7 @@ phl_tx_traffic_upd(struct rtw_stats *sts)
 	}
 }
 
-void phl_update_tx_stats(struct rtw_stats *stats, struct rtw_xmit_req *tx_req)
+static void phl_update_tx_stats(struct rtw_stats *stats, struct rtw_xmit_req *tx_req)
 {
 	u32 diff_t = 0, cur_time = _os_get_cur_time_ms();
 	u64 diff_bits = 0;
@@ -230,7 +230,7 @@ void phl_update_tx_stats(struct rtw_stats *stats, struct rtw_xmit_req *tx_req)
 	}
 }
 
-void phl_tx_statistics(struct phl_info_t *phl_info, struct rtw_xmit_req *tx_req)
+static void phl_tx_statistics(struct phl_info_t *phl_info, struct rtw_xmit_req *tx_req)
 {
 	struct rtw_phl_com_t *phl_com = phl_info->phl_com;
 	struct rtw_stats *phl_stats = &phl_com->phl_stats;
@@ -293,7 +293,7 @@ static void _phl_free_phl_tring_list(void *phl,
 }
 
 
-void _phl_init_tx_plan(struct phl_tx_plan * tx_plan)
+static void _phl_init_tx_plan(struct phl_tx_plan * tx_plan)
 {
 	INIT_LIST_HEAD(&tx_plan->list);
 	tx_plan->sleep = false;
@@ -500,7 +500,7 @@ void phl_release_ring_sts(struct phl_info_t *phl_info,
 }
 
 
-void _phl_ring_status_deinit(struct phl_info_t *phl_info)
+static void _phl_ring_status_deinit(struct phl_info_t *phl_info)
 {
 	struct phl_ring_sts_pool *ring_sts_pool = NULL;
 	u16 buf_len = 0;
@@ -518,7 +518,7 @@ void _phl_ring_status_deinit(struct phl_info_t *phl_info)
 }
 
 
-enum rtw_phl_status _phl_ring_status_init(struct phl_info_t *phl_info)
+static enum rtw_phl_status _phl_ring_status_init(struct phl_info_t *phl_info)
 {
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_FAILURE;
 	struct phl_ring_sts_pool *ring_sts_pool = NULL;
@@ -562,7 +562,7 @@ enum rtw_phl_status _phl_ring_status_init(struct phl_info_t *phl_info)
 	return pstatus;
 }
 
-struct phl_ring_status *
+static struct phl_ring_status *
 _phl_check_ring_status(struct phl_info_t *phl_info,
 					struct rtw_phl_tx_ring *ring,
 					struct rtw_phl_tring_list *tring_list)
@@ -610,7 +610,7 @@ _phl_check_ring_status(struct phl_info_t *phl_info,
 	return ring_sts;
 }
 
-void _phl_reset_tx_plan(struct phl_info_t *phl_info,
+static void _phl_reset_tx_plan(struct phl_info_t *phl_info,
 			 struct phl_tx_plan *tx_plan)
 {
 	struct phl_ring_status *ring_sts, *t;
@@ -628,7 +628,7 @@ void _phl_reset_tx_plan(struct phl_info_t *phl_info,
 }
 
 
-void _phl_sort_ring_by_tid(struct phl_ring_status *ring_sts,
+static void _phl_sort_ring_by_tid(struct phl_ring_status *ring_sts,
 			   struct phl_tx_plan *tx_plan,
 			   enum rtw_phl_ring_cat cat)
 {
@@ -1179,7 +1179,7 @@ static void _phl_free_h2c_pkt(struct phl_info_t *phl_info,
 	}
 }
 
-struct rtw_h2c_pkt *_phl_alloc_h2c_pkt(struct phl_info_t *phl_info,
+static struct rtw_h2c_pkt *_phl_alloc_h2c_pkt(struct phl_info_t *phl_info,
 	struct phl_h2c_pkt_pool *h2c_pool)
 {
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_FAILURE;
@@ -1268,7 +1268,7 @@ static void _phl_free_h2c_pool(struct phl_info_t *phl_info)
 	FUNCOUT();
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_alloc_h2c_pool(struct phl_info_t *phl_info)
 {
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_FAILURE;
@@ -1675,7 +1675,7 @@ enum rtw_phl_status rtw_phl_tx_req_notify(void *phl)
 	return pstatus;
 }
 
-struct rtw_phl_tx_ring *
+static struct rtw_phl_tx_ring *
 _phl_select_tx_ring(struct phl_info_t *phl_info, struct rtw_xmit_req *tx_req)
 {
 	struct rtw_phl_tring_list *tring_list, *t;
@@ -2201,7 +2201,7 @@ rtw_phl_cvt_tid_to_cat(u8 tid)
 	return cat;
 }
 
-enum data_ctrl_mdl _phl_get_ctrl_mdl(enum phl_module_id id)
+static enum data_ctrl_mdl _phl_get_ctrl_mdl(enum phl_module_id id)
 {
 	enum data_ctrl_mdl ctrl_mdl = DATA_CTRL_MDL_NONE;
 
@@ -2232,7 +2232,7 @@ enum data_ctrl_mdl _phl_get_ctrl_mdl(enum phl_module_id id)
 }
 
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_poll_hw_tx_done(void)
 {
 	PHL_TRACE(COMP_PHL_DBG, _PHL_ERR_, "[DATA_CTRL] Polling hw tx done is not supported now\n");
@@ -2240,7 +2240,7 @@ _phl_poll_hw_tx_done(void)
 	return RTW_PHL_STATUS_FAILURE;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_hw_tx_resume(void)
 {
 	PHL_TRACE(COMP_PHL_DBG, _PHL_ERR_, "[DATA_CTRL] Resume hw tx not is supported now\n");
@@ -2248,7 +2248,7 @@ _phl_hw_tx_resume(void)
 	return RTW_PHL_STATUS_FAILURE;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_sw_tx_resume(struct phl_info_t *phl_info, struct phl_data_ctl_t *ctl)
 {
 	enum rtw_phl_status sts = RTW_PHL_STATUS_FAILURE;
@@ -2283,7 +2283,7 @@ _phl_sw_tx_resume(struct phl_info_t *phl_info, struct phl_data_ctl_t *ctl)
 	return sts;
 }
 
-void
+static void
 _phl_sw_tx_rst(struct phl_info_t *phl_info)
 {
 	struct phl_hci_trx_ops *ops = phl_info->hci_trx_ops;
@@ -2291,7 +2291,7 @@ _phl_sw_tx_rst(struct phl_info_t *phl_info)
 	ops->trx_reset(phl_info, PHL_CTRL_TX);
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_sw_tx_pause(struct phl_info_t *phl_info,
                  struct phl_data_ctl_t *ctl,
                  bool rst_sw)
@@ -2383,7 +2383,7 @@ exit:
 	return sts;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_poll_hw_rx_done(void)
 {
 	PHL_TRACE(COMP_PHL_DBG, _PHL_ERR_, "[DATA_CTRL] Polling hw rx done is not supported now\n");
@@ -2391,7 +2391,7 @@ _phl_poll_hw_rx_done(void)
 	return RTW_PHL_STATUS_FAILURE;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_hw_rx_resume(void)
 {
 	PHL_TRACE(COMP_PHL_DBG, _PHL_ERR_, "[DATA_CTRL] Resume hw rx not is supported now\n");
@@ -2399,7 +2399,7 @@ _phl_hw_rx_resume(void)
 	return RTW_PHL_STATUS_FAILURE;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_sw_rx_resume(struct phl_info_t *phl_info, struct phl_data_ctl_t *ctl)
 {
 	enum rtw_phl_status sts = RTW_PHL_STATUS_FAILURE;
@@ -2434,7 +2434,7 @@ _phl_sw_rx_resume(struct phl_info_t *phl_info, struct phl_data_ctl_t *ctl)
 	return sts;
 }
 
-void
+static void
 _phl_sw_rx_rst(struct phl_info_t *phl_info)
 {
 	struct phl_hci_trx_ops *ops = phl_info->hci_trx_ops;
@@ -2442,7 +2442,7 @@ _phl_sw_rx_rst(struct phl_info_t *phl_info)
 	ops->trx_reset(phl_info, PHL_CTRL_RX);
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_sw_rx_pause(struct phl_info_t *phl_info,
                  struct phl_data_ctl_t *ctl,
                  bool rst_sw)
@@ -2543,7 +2543,7 @@ exit:
 	return sts;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_hw_trx_rst_resume(struct phl_info_t *phl_info)
 {
 	void *drv = phl_to_drvpriv(phl_info);
@@ -2562,7 +2562,7 @@ _phl_hw_trx_rst_resume(struct phl_info_t *phl_info)
 	}
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_hw_trx_pause(struct phl_info_t *phl_info)
 {
 	void *drv = phl_to_drvpriv(phl_info);
@@ -2581,7 +2581,7 @@ _phl_hw_trx_pause(struct phl_info_t *phl_info)
 	}
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_trx_sw_pause(struct phl_info_t *phl_info, struct phl_data_ctl_t *ctl)
 {
 	enum rtw_phl_status sts = RTW_PHL_STATUS_FAILURE;
@@ -2603,7 +2603,7 @@ _phl_trx_sw_pause(struct phl_info_t *phl_info, struct phl_data_ctl_t *ctl)
 	return sts;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_trx_sw_resume(struct phl_info_t *phl_info, struct phl_data_ctl_t *ctl)
 {
 	enum rtw_phl_status sts = RTW_PHL_STATUS_FAILURE;
@@ -2625,7 +2625,7 @@ _phl_trx_sw_resume(struct phl_info_t *phl_info, struct phl_data_ctl_t *ctl)
 	return sts;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_trx_pause_w_rst(struct phl_info_t *phl_info,
                      struct phl_data_ctl_t *ctl,
                      struct phl_msg *msg)
@@ -2676,7 +2676,7 @@ _phl_trx_pause_w_rst(struct phl_info_t *phl_info,
 	return sts;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_trx_resume_w_rst(struct phl_info_t *phl_info,
                       struct phl_data_ctl_t *ctl,
                       struct phl_msg *msg)

--- a/phl/test/fpga/phl_test_fpga.c
+++ b/phl/test/fpga/phl_test_fpga.c
@@ -18,7 +18,7 @@
 #include "phl_test_fpga_api.h"
 
 #ifdef CONFIG_PHL_TEST_FPGA
-void fpga_notification_complete(void* priv, struct phl_msg* msg)
+static void fpga_notification_complete(void* priv, struct phl_msg* msg)
 {
 	struct fpga_context *fpga_ctx = (struct fpga_context *)priv;
 
@@ -29,7 +29,7 @@ void fpga_notification_complete(void* priv, struct phl_msg* msg)
 }
 
 
-void fpga_cmd_done_notification(struct fpga_context *fpga_ctx, enum fpga_class fpga_class,
+static void fpga_cmd_done_notification(struct fpga_context *fpga_ctx, enum fpga_class fpga_class,
 							u8 fpga_cmd_id)
 {
 	struct phl_msg msg = {0};
@@ -66,7 +66,7 @@ void fpga_cmd_done_notification(struct fpga_context *fpga_ctx, enum fpga_class f
  * @enum phl_msg_evt_id id: Assign different types of FPGA related msg event
  *	to pass buffer to another layer for further process
  */
-void fpga_buf_notification(struct fpga_context *fpga_ctx, void *buf, u32 buf_len,
+static void fpga_buf_notification(struct fpga_context *fpga_ctx, void *buf, u32 buf_len,
 			 enum phl_msg_evt_id id)
 {
 	struct phl_msg msg = {0};
@@ -98,7 +98,7 @@ void fpga_buf_notification(struct fpga_context *fpga_ctx, void *buf, u32 buf_len
 }
 
 
-bool fpga_get_rpt_check(struct fpga_context *fpga_ctx, void *rpt_buf)
+static bool fpga_get_rpt_check(struct fpga_context *fpga_ctx, void *rpt_buf)
 {
 	bool ret = true;
 #if 0
@@ -118,7 +118,7 @@ bool fpga_get_rpt_check(struct fpga_context *fpga_ctx, void *rpt_buf)
 	return ret;
 }
 
-u8 fpga_get_class_from_buf(struct fpga_context *fpga_ctx)
+static u8 fpga_get_class_from_buf(struct fpga_context *fpga_ctx)
 {
 	u8 *buf_tmp = NULL;
 	u8 fpga_class = FPGA_CLASS_MAX;
@@ -129,7 +129,7 @@ u8 fpga_get_class_from_buf(struct fpga_context *fpga_ctx)
 	return fpga_class;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _fpga_mlo_replace_tx(struct fpga_context *fpga_ctx,
                      struct rtw_xmit_req *tx_req)
 {
@@ -199,7 +199,7 @@ exit:
 }
 
 
-u8 fpga_bp_handler(void *priv, struct test_bp_info* bp_info)
+static u8 fpga_bp_handler(void *priv, struct test_bp_info* bp_info)
 {
 	struct fpga_context *fpga_ctx = (struct fpga_context *)priv;
 	enum rtw_phl_status phl_status = RTW_PHL_STATUS_FAILURE;
@@ -247,26 +247,26 @@ u8 fpga_bp_handler(void *priv, struct test_bp_info* bp_info)
 	return phl_status;
 }
 
-u8 fpga_get_fail_rsn(void *priv,char* rsn, u32 max_len)
+static u8 fpga_get_fail_rsn(void *priv,char* rsn, u32 max_len)
 {
 	//struct fpga_context *fpga_ctx = (struct fpga_context *)priv;
 	return true;
 }
 
-u8 fpga_is_test_end(void *priv)
+static u8 fpga_is_test_end(void *priv)
 {
 	struct fpga_context *fpga_ctx = (struct fpga_context *)priv;
 
 	return fpga_ctx->is_fpga_test_end;
 }
 
-u8 fpga_is_test_pass(void *priv)
+static u8 fpga_is_test_pass(void *priv)
 {
 	//struct fpga_context *fpga_ctx = (struct fpga_context *)priv;
 	return true;
 }
 
-u8 fpga_start(void *priv)
+static u8 fpga_start(void *priv)
 {
 	struct fpga_context *fpga_ctx = (struct fpga_context *)priv;
 	struct rtw_phl_com_t* phl_com = fpga_ctx->phl_com;

--- a/phl/test/fpga/phl_test_fpga_config.c
+++ b/phl/test/fpga/phl_test_fpga_config.c
@@ -19,7 +19,7 @@
 
 #ifdef CONFIG_PHL_TEST_FPGA
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _fpga_config_pkt_tx(struct fpga_context *fpga,
                     struct fpga_config_arg *arg)
 {
@@ -33,7 +33,7 @@ _fpga_config_pkt_tx(struct fpga_context *fpga,
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _fpga_config_loopback(struct fpga_context *fpga,
                      struct fpga_config_arg *arg)
 {
@@ -47,7 +47,7 @@ _fpga_config_loopback(struct fpga_context *fpga,
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-enum rtw_phl_status
+static enum rtw_phl_status
 _fpga_config_normal(struct fpga_context *fpga,
                      struct fpga_config_arg *arg)
 {

--- a/phl/test/fpga/phl_test_fpga_config.c
+++ b/phl/test/fpga/phl_test_fpga_config.c
@@ -16,6 +16,7 @@
 #include "../../phl_headers.h"
 #include "phl_test_fpga_def.h"
 #include "../../hal_g6/test/fpga/hal_test_fpga_api.h"
+#include "phl_test_fpga_api.h"
 
 #ifdef CONFIG_PHL_TEST_FPGA
 

--- a/phl/test/mp/phl_test_mp.c
+++ b/phl/test/mp/phl_test_mp.c
@@ -20,7 +20,7 @@
 #include "../../hal_g6/test/mp/hal_test_mp_api.h"
 
 #ifdef CONFIG_PHL_TEST_MP
-void mp_notification_complete(void* priv, struct phl_msg* msg)
+static void mp_notification_complete(void* priv, struct phl_msg* msg)
 {
 	struct mp_context *mp_ctx = (struct mp_context *)priv;
 
@@ -30,7 +30,7 @@ void mp_notification_complete(void* priv, struct phl_msg* msg)
 	}
 }
 
-void mp_cmd_done_notification(struct mp_context *mp_ctx, enum mp_class mp_class,
+static void mp_cmd_done_notification(struct mp_context *mp_ctx, enum mp_class mp_class,
 							u8 mp_cmd_id)
 {
 	struct phl_msg msg = {0};
@@ -67,7 +67,7 @@ void mp_cmd_done_notification(struct mp_context *mp_ctx, enum mp_class mp_class,
  * @enum phl_msg_evt_id id: Assign different types of MP related msg event
  *	to pass buffer to another layer for further process
  */
-void mp_buf_notification(struct mp_context *mp_ctx, void *buf, u32 buf_len,
+static void mp_buf_notification(struct mp_context *mp_ctx, void *buf, u32 buf_len,
 			 enum phl_msg_evt_id id)
 {
 	struct phl_msg msg = {0};
@@ -99,7 +99,7 @@ void mp_buf_notification(struct mp_context *mp_ctx, void *buf, u32 buf_len,
 }
 
 
-bool mp_get_rpt_check(struct mp_context *mp_ctx, void *rpt_buf)
+static bool mp_get_rpt_check(struct mp_context *mp_ctx, void *rpt_buf)
 {
 	bool ret = true;
 	struct mp_arg_hdr *rpt_hdr = (struct mp_arg_hdr *)mp_ctx->rpt;
@@ -116,7 +116,7 @@ bool mp_get_rpt_check(struct mp_context *mp_ctx, void *rpt_buf)
 	return ret;
 }
 
-u8 mp_get_class_from_buf(struct mp_context *mp_ctx)
+static u8 mp_get_class_from_buf(struct mp_context *mp_ctx)
 {
 	u8 *buf_tmp = NULL;
 	u8 mp_class = MP_CLASS_MAX;
@@ -127,7 +127,7 @@ u8 mp_get_class_from_buf(struct mp_context *mp_ctx)
 	return mp_class;
 }
 
-u8 mp_bp_handler(void *priv, struct test_bp_info* bp_info)
+static u8 mp_bp_handler(void *priv, struct test_bp_info* bp_info)
 {
 	struct mp_context *mp_ctx = (struct mp_context *)priv;
 	enum rtw_phl_status phl_status = RTW_PHL_STATUS_FAILURE;
@@ -176,20 +176,20 @@ u8 mp_bp_handler(void *priv, struct test_bp_info* bp_info)
 	return phl_status;
 }
 
-u8 mp_get_fail_rsn(void *priv,char* rsn, u32 max_len)
+static u8 mp_get_fail_rsn(void *priv,char* rsn, u32 max_len)
 {
 	//struct mp_context *mp_ctx = (struct mp_context *)priv;
 	return true;
 }
 
-u8 mp_is_test_end(void *priv)
+static u8 mp_is_test_end(void *priv)
 {
 	struct mp_context *mp_ctx = (struct mp_context *)priv;
 
 	return mp_ctx->is_mp_test_end;
 }
 
-u8 mp_is_test_pass(void *priv)
+static u8 mp_is_test_pass(void *priv)
 {
 	//struct mp_context *mp_ctx = (struct mp_context *)priv;
 	return true;
@@ -274,7 +274,7 @@ u8 mp_start(void *priv)
 	return (u8)phl_status;
 }
 
-void mp_change_mode(struct mp_context *mp_ctx, enum rtw_drv_mode driver_mode)
+static void mp_change_mode(struct mp_context *mp_ctx, enum rtw_drv_mode driver_mode)
 {
 	struct phl_info_t *phl_info = mp_ctx->phl;
 	#ifdef RTW_WKARD_AP_MP

--- a/phl/test/mp/phl_test_mp_cal.c
+++ b/phl/test/mp/phl_test_mp_cal.c
@@ -16,6 +16,7 @@
 #include "../../phl_headers.h"
 #include "phl_test_mp_def.h"
 #include "../../hal_g6/test/mp/hal_test_mp_api.h"
+#include "phl_test_mp_api.h"
 
 #ifdef CONFIG_PHL_TEST_MP
 static enum rtw_phl_status phl_mp_cal_trigger(

--- a/phl/test/mp/phl_test_mp_config.c
+++ b/phl/test/mp/phl_test_mp_config.c
@@ -16,6 +16,7 @@
 #include "../../phl_headers.h"
 #include "phl_test_mp_def.h"
 #include "../../hal_g6/test/mp/hal_test_mp_api.h"
+#include "phl_test_mp_api.h"
 
 #ifdef CONFIG_PHL_TEST_MP
 static enum rtw_phl_status phl_mp_config_start_dut(

--- a/phl/test/mp/phl_test_mp_efuse.c
+++ b/phl/test/mp/phl_test_mp_efuse.c
@@ -16,6 +16,7 @@
 #include "../../phl_headers.h"
 #include "phl_test_mp_def.h"
 #include "../../hal_g6/test/mp/hal_test_mp_api.h"
+#include "phl_test_mp_api.h"
 
 #ifdef CONFIG_PHL_TEST_MP
 static enum rtw_phl_status phl_mp_efuse_wifi_shadow_read(

--- a/phl/test/mp/phl_test_mp_reg.c
+++ b/phl/test/mp/phl_test_mp_reg.c
@@ -16,6 +16,7 @@
 #include "../../phl_headers.h"
 #include "phl_test_mp_def.h"
 #include "../../hal_g6/test/mp/hal_test_mp_api.h"
+#include "phl_test_mp_api.h"
 
 #ifdef CONFIG_PHL_TEST_MP
 static enum rtw_phl_status phl_mp_reg_read_macreg(

--- a/phl/test/mp/phl_test_mp_rx.c
+++ b/phl/test/mp/phl_test_mp_rx.c
@@ -202,7 +202,7 @@ static enum rtw_phl_status phl_mp_rx_get_physts(
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-enum rtw_phl_status phl_mp_rx_get_rssi_ex(
+static enum rtw_phl_status phl_mp_rx_get_rssi_ex(
 	struct mp_context *mp, struct mp_rx_arg *arg)
 {
 	enum rtw_hal_status hal_status = RTW_HAL_STATUS_FAILURE;

--- a/phl/test/mp/phl_test_mp_rx.c
+++ b/phl/test/mp/phl_test_mp_rx.c
@@ -16,6 +16,7 @@
 #include "../../phl_headers.h"
 #include "phl_test_mp_def.h"
 #include "../../hal_g6/test/mp/hal_test_mp_api.h"
+#include "phl_test_mp_api.h"
 
 #ifdef CONFIG_PHL_TEST_MP
 static enum rtw_phl_status phl_mp_rx_phy_crc_ok(

--- a/phl/test/mp/phl_test_mp_tx.c
+++ b/phl/test/mp/phl_test_mp_tx.c
@@ -17,6 +17,7 @@
 #include "phl_test_mp_def.h"
 #include "../../hal_g6/test/mp/hal_test_mp_api.h"
 #include "../../phl_api.h"
+#include "phl_test_mp_api.h"
 
 #ifdef CONFIG_PHL_TEST_MP
 static enum rtw_phl_status

--- a/phl/test/mp/phl_test_mp_txpwr.c
+++ b/phl/test/mp/phl_test_mp_txpwr.c
@@ -16,6 +16,7 @@
 #include "../../phl_headers.h"
 #include "phl_test_mp_def.h"
 #include "../../hal_g6/test/mp/hal_test_mp_api.h"
+#include "phl_test_mp_api.h"
 
 #ifdef CONFIG_PHL_TEST_MP
 static enum rtw_phl_status phl_mp_txpwr_read_table(

--- a/phl/test/mp/phl_test_mp_txpwr.c
+++ b/phl/test/mp/phl_test_mp_txpwr.c
@@ -378,7 +378,7 @@ static enum rtw_phl_status phl_mp_txpwr_get_pwr_ref_cw(
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
-enum rtw_phl_status phl_mp_set_tx_pow_patten_sharp(
+static enum rtw_phl_status phl_mp_set_tx_pow_patten_sharp(
 	struct mp_context *mp, struct mp_txpwr_arg *arg)
 {
 	enum rtw_hal_status hal_status = RTW_HAL_STATUS_SUCCESS;

--- a/phl/test/mp/phl_test_mp_watchdog.c
+++ b/phl/test/mp/phl_test_mp_watchdog.c
@@ -21,7 +21,7 @@
 
 #ifdef CONFIG_PHL_TEST_MP
 
-void _phl_mp_timer_cb(void *context)
+static void _phl_mp_timer_cb(void *context)
 {
 	struct mp_context *mp_ctx = (struct mp_context *)context;
 	struct phl_info_t *phl_info = (struct phl_info_t *)mp_ctx->phl;

--- a/phl/test/phl_dbg_cmd.c
+++ b/phl/test/phl_dbg_cmd.c
@@ -30,7 +30,7 @@ static const struct phl_dbg_cmd_info phl_dbg_core_cmd_i[] = {
 	{"git_info", PHL_DBG_CORE_GIT_INFO}
 };
 
-void phl_dbg_git_info(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_git_info(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		      u32 input_num, char *output, u32 out_len)
 {
 /* #REMOVE BEGIN */
@@ -68,7 +68,7 @@ void phl_dbg_git_info(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 /* #REMOVE END */
 }
 
-void phl_dbg_core_cmd_parser(void *phl, char input[][MAX_ARGV],
+static void phl_dbg_core_cmd_parser(void *phl, char input[][MAX_ARGV],
 		        u32 input_num, char *output, u32 out_len)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
@@ -122,7 +122,7 @@ void phl_dbg_core_cmd_parser(void *phl, char input[][MAX_ARGV],
 	}
 }
 
-s32
+static s32
 phl_dbg_core_proc_cmd(struct phl_info_t *phl_info,
 		 char *input, char *output, u32 out_len)
 {
@@ -163,7 +163,7 @@ rtw_phl_dbg_core_cmd(struct phl_info_t *phl_info,
 }
 
 #ifdef CONFIG_PHL_TEST_SUITE
-bool
+static bool
 _is_hex_digit(char ch_tmp)
 {
 	if( (ch_tmp >= '0' && ch_tmp <= '9') ||
@@ -176,7 +176,7 @@ _is_hex_digit(char ch_tmp)
 }
 
 
-u32
+static u32
 _map_char_to_hex_digit(char ch_tmp)
 {
 	if(ch_tmp >= '0' && ch_tmp <= '9')
@@ -230,7 +230,7 @@ _get_hex_from_string(char *szstr, u32 *val)
 	return true;
 }
 
-void
+static void
 _phl_dbg_cmd_switch_chbw(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 			 u32 input_num, char *output, u32 out_len)
 {
@@ -301,7 +301,7 @@ _phl_dbg_cmd_switch_chbw(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	} while (0);
 }
 
-void _dump_wifi_role(struct phl_info_t *phl_info,
+static void _dump_wifi_role(struct phl_info_t *phl_info,
 		char input[][MAX_ARGV], u32 input_num,
 		char *output, u32 out_len)
 {
@@ -431,7 +431,7 @@ void _dump_wifi_role(struct phl_info_t *phl_info,
 	}
 }
 
-void _dump_mr_info(struct phl_info_t *phl_info, char *output, u32 out_len)
+static void _dump_mr_info(struct phl_info_t *phl_info, char *output, u32 out_len)
 {
 	struct rtw_phl_com_t *phl_com = phl_info->phl_com;
 	struct mr_ctl_t *mr_ctl = phlcom_to_mr_ctrl(phl_com);
@@ -535,7 +535,7 @@ void _dump_mr_info(struct phl_info_t *phl_info, char *output, u32 out_len)
 	}
 }
 
-void _dump_rx_rate(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void _dump_rx_rate(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		      u32 input_num, char *output, u32 out_len)
 {
 	u32 ctrl = 0;
@@ -794,7 +794,7 @@ static const char *_get_wow_opmode_str(enum rtw_wow_op_mode mode)
 	}
 }
 
-void _dump_wow_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void _dump_wow_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	u32 input_num, char *output, u32 out_len)
 {
 #ifdef CONFIG_WOWLAN
@@ -820,7 +820,7 @@ void _dump_wow_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 }
 
 #ifdef CONFIG_MCC_SUPPORT
-void _dump_mcc_info(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void _dump_mcc_info(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	u32 input_num, char *output, u32 out_len)
 {
 	bool get_ok = false;
@@ -938,7 +938,7 @@ exit:
 #endif /*CONFIG_MCC_SUPPORT*/
 
 
-void _rxbcn_dbg_info(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void _rxbcn_dbg_info(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	u32 input_num, char *output, u32 out_len)
 {
 	u32 used = 0;
@@ -1022,7 +1022,7 @@ _exit:
 }
 
 
-void _bcn_cmd_parser(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void _bcn_cmd_parser(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 			u32 input_num, char *output, u32 out_len)
 {
 	u32 used = 0;
@@ -1041,7 +1041,7 @@ void _bcn_cmd_parser(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	}
 }
 
-void phl_dbg_cmd_snd(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_cmd_snd(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		      u32 input_num, char *output, u32 out_len)
 {
 #ifdef CONFIG_PHL_CMD_BF
@@ -1107,7 +1107,7 @@ void phl_dbg_cmd_snd(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 #endif
 }
 
-void _convert_tx_rate(enum hal_rate_mode mode, u8 mcs_ss_idx, char *str, u32 str_len)
+static void _convert_tx_rate(enum hal_rate_mode mode, u8 mcs_ss_idx, char *str, u32 str_len)
 {
 	switch (mode) {
 	case HAL_LEGACY_MODE:
@@ -1144,7 +1144,7 @@ void _convert_tx_rate(enum hal_rate_mode mode, u8 mcs_ss_idx, char *str, u32 str
 	}
 }
 
-void _convert_rx_rate(u32 rx_rate, char *str, u32 str_len)
+static void _convert_rx_rate(u32 rx_rate, char *str, u32 str_len)
 {
 	switch(rx_rate) {
 	case RTW_DATA_RATE_CCK1:	_os_snprintf(str, str_len,"CCK 1"); break;
@@ -1294,7 +1294,7 @@ void _convert_rx_rate(u32 rx_rate, char *str, u32 str_len)
 	}
 }
 
-void phl_dbg_cmd_asoc_sta(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_cmd_asoc_sta(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		      u32 input_num, char *output, u32 out_len)
 {
 	u32 ctrl = 0, wrole_idx = 0;
@@ -1448,7 +1448,7 @@ void phl_dbg_cmd_asoc_sta(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	}
 }
 
-void phl_dbg_cmd_phy_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_cmd_phy_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		      u32 input_num, char *output, u32 out_len)
 {
 	struct rtw_hal_com_t *hal_com = rtw_hal_get_halcom(phl_info->hal);
@@ -1549,7 +1549,7 @@ void _dbg_tx_stats_pcie(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 }
 #endif
 
-void phl_dbg_ltr_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_ltr_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		       u32 input_num, char *output, u32 out_len)
 {
 	#ifdef CONFIG_PCI_HCI
@@ -1595,7 +1595,7 @@ void phl_dbg_ltr_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	#endif
 }
 
-void phl_dbg_trx_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_trx_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		       u32 input_num, char *output, u32 out_len)
 {
  	struct rtw_phl_com_t *phl_com = phl_info->phl_com;
@@ -1647,7 +1647,7 @@ void phl_dbg_trx_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 			 (int)phl_stats->last_rx_time_ms);
 }
 
-void phl_dbg_cmd_show_rssi(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_cmd_show_rssi(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		 	   u32 input_num, char *output, u32 out_len)
 {
 	u32 used = 0;
@@ -2014,7 +2014,7 @@ static void _phl_dump_cccr(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 }
 #endif /*CONFIG_RTW_DEBUG_CCCR*/
 
-void phl_dbg_cmd_parser(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_cmd_parser(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		        u32 input_num, char *output, u32 out_len)
 {
 	u8 id = 0;
@@ -2293,7 +2293,7 @@ void phl_dbg_cmd_parser(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	}
 }
 
-s32
+static s32
 phl_dbg_proc_cmd(struct phl_info_t *phl_info,
 		 char *input, char *output, u32 out_len)
 {

--- a/phl/test/phl_dbg_cmd.c
+++ b/phl/test/phl_dbg_cmd.c
@@ -30,7 +30,7 @@ static const struct phl_dbg_cmd_info phl_dbg_core_cmd_i[] = {
 	{"git_info", PHL_DBG_CORE_GIT_INFO}
 };
 
-void phl_dbg_git_info(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_git_info(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		      u32 input_num, char *output, u32 out_len)
 {
 /* #REMOVE BEGIN */
@@ -68,7 +68,7 @@ void phl_dbg_git_info(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 /* #REMOVE END */
 }
 
-void phl_dbg_core_cmd_parser(void *phl, char input[][MAX_ARGV],
+static void phl_dbg_core_cmd_parser(void *phl, char input[][MAX_ARGV],
 		        u32 input_num, char *output, u32 out_len)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
@@ -122,7 +122,7 @@ void phl_dbg_core_cmd_parser(void *phl, char input[][MAX_ARGV],
 	}
 }
 
-s32
+static s32
 phl_dbg_core_proc_cmd(struct phl_info_t *phl_info,
 		 char *input, char *output, u32 out_len)
 {
@@ -163,7 +163,7 @@ rtw_phl_dbg_core_cmd(struct phl_info_t *phl_info,
 }
 
 #ifdef CONFIG_PHL_TEST_SUITE
-bool
+static bool
 _is_hex_digit(char ch_tmp)
 {
 	if( (ch_tmp >= '0' && ch_tmp <= '9') ||
@@ -176,7 +176,7 @@ _is_hex_digit(char ch_tmp)
 }
 
 
-u32
+static u32
 _map_char_to_hex_digit(char ch_tmp)
 {
 	if(ch_tmp >= '0' && ch_tmp <= '9')
@@ -230,7 +230,7 @@ _get_hex_from_string(char *szstr, u32 *val)
 	return true;
 }
 
-void
+static void
 _phl_dbg_cmd_switch_chbw(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 			 u32 input_num, char *output, u32 out_len)
 {
@@ -301,7 +301,7 @@ _phl_dbg_cmd_switch_chbw(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	} while (0);
 }
 
-void _dump_wifi_role(struct phl_info_t *phl_info,
+static void _dump_wifi_role(struct phl_info_t *phl_info,
 		char input[][MAX_ARGV], u32 input_num,
 		char *output, u32 out_len)
 {
@@ -431,7 +431,7 @@ void _dump_wifi_role(struct phl_info_t *phl_info,
 	}
 }
 
-void _dump_mr_info(struct phl_info_t *phl_info, char *output, u32 out_len)
+static void _dump_mr_info(struct phl_info_t *phl_info, char *output, u32 out_len)
 {
 	struct rtw_phl_com_t *phl_com = phl_info->phl_com;
 	struct mr_ctl_t *mr_ctl = phlcom_to_mr_ctrl(phl_com);
@@ -535,7 +535,7 @@ void _dump_mr_info(struct phl_info_t *phl_info, char *output, u32 out_len)
 	}
 }
 
-void _dump_rx_rate(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void _dump_rx_rate(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		      u32 input_num, char *output, u32 out_len)
 {
 	u32 ctrl = 0;
@@ -796,7 +796,7 @@ static const char *_get_wow_opmode_str(enum rtw_wow_op_mode mode)
 }
 #endif /* CONFIG_WOWLAN */
 
-void _dump_wow_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void _dump_wow_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	u32 input_num, char *output, u32 out_len)
 {
 #ifdef CONFIG_WOWLAN
@@ -822,7 +822,7 @@ void _dump_wow_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 }
 
 #ifdef CONFIG_MCC_SUPPORT
-void _dump_mcc_info(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void _dump_mcc_info(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	u32 input_num, char *output, u32 out_len)
 {
 	bool get_ok = false;
@@ -940,7 +940,7 @@ exit:
 #endif /*CONFIG_MCC_SUPPORT*/
 
 
-void _rxbcn_dbg_info(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void _rxbcn_dbg_info(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	u32 input_num, char *output, u32 out_len)
 {
 	u32 used = 0;
@@ -1024,7 +1024,7 @@ _exit:
 }
 
 
-void _bcn_cmd_parser(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void _bcn_cmd_parser(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 			u32 input_num, char *output, u32 out_len)
 {
 	u32 used = 0;
@@ -1043,7 +1043,7 @@ void _bcn_cmd_parser(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	}
 }
 
-void phl_dbg_cmd_snd(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_cmd_snd(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		      u32 input_num, char *output, u32 out_len)
 {
 #ifdef CONFIG_PHL_CMD_BF
@@ -1109,7 +1109,7 @@ void phl_dbg_cmd_snd(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 #endif
 }
 
-void _convert_tx_rate(enum hal_rate_mode mode, u8 mcs_ss_idx, char *str, u32 str_len)
+static void _convert_tx_rate(enum hal_rate_mode mode, u8 mcs_ss_idx, char *str, u32 str_len)
 {
 	switch (mode) {
 	case HAL_LEGACY_MODE:
@@ -1146,7 +1146,7 @@ void _convert_tx_rate(enum hal_rate_mode mode, u8 mcs_ss_idx, char *str, u32 str
 	}
 }
 
-void _convert_rx_rate(u32 rx_rate, char *str, u32 str_len)
+static void _convert_rx_rate(u32 rx_rate, char *str, u32 str_len)
 {
 	switch(rx_rate) {
 	case RTW_DATA_RATE_CCK1:	_os_snprintf(str, str_len,"CCK 1"); break;
@@ -1296,7 +1296,7 @@ void _convert_rx_rate(u32 rx_rate, char *str, u32 str_len)
 	}
 }
 
-void phl_dbg_cmd_asoc_sta(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_cmd_asoc_sta(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		      u32 input_num, char *output, u32 out_len)
 {
 	u32 ctrl = 0, wrole_idx = 0;
@@ -1450,7 +1450,7 @@ void phl_dbg_cmd_asoc_sta(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	}
 }
 
-void phl_dbg_cmd_phy_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_cmd_phy_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		      u32 input_num, char *output, u32 out_len)
 {
 	struct rtw_hal_com_t *hal_com = rtw_hal_get_halcom(phl_info->hal);
@@ -1551,7 +1551,7 @@ void _dbg_tx_stats_pcie(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 }
 #endif
 
-void phl_dbg_ltr_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_ltr_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		       u32 input_num, char *output, u32 out_len)
 {
 	#ifdef CONFIG_PCI_HCI
@@ -1597,7 +1597,7 @@ void phl_dbg_ltr_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	#endif
 }
 
-void phl_dbg_trx_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_trx_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		       u32 input_num, char *output, u32 out_len)
 {
  	struct rtw_phl_com_t *phl_com = phl_info->phl_com;
@@ -1649,7 +1649,7 @@ void phl_dbg_trx_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 			 (int)phl_stats->last_rx_time_ms);
 }
 
-void phl_dbg_cmd_show_rssi(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_cmd_show_rssi(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		 	   u32 input_num, char *output, u32 out_len)
 {
 	u32 used = 0;
@@ -2016,7 +2016,7 @@ static void _phl_dump_cccr(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 }
 #endif /*CONFIG_RTW_DEBUG_CCCR*/
 
-void phl_dbg_cmd_parser(struct phl_info_t *phl_info, char input[][MAX_ARGV],
+static void phl_dbg_cmd_parser(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		        u32 input_num, char *output, u32 out_len)
 {
 	u8 id = 0;
@@ -2295,7 +2295,7 @@ void phl_dbg_cmd_parser(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	}
 }
 
-s32
+static s32
 phl_dbg_proc_cmd(struct phl_info_t *phl_info,
 		 char *input, char *output, u32 out_len)
 {

--- a/phl/test/phl_ser_dbg_cmd.c
+++ b/phl/test/phl_ser_dbg_cmd.c
@@ -33,7 +33,7 @@ struct phl_ser_cmd_info phl_ser_cmd_i[] = {
 };
 
 /* echo phl ser state */
-void _phl_ser_cmd_state(struct phl_info_t *phl_info, u32 *used, char input[][MAX_ARGV],
+static void _phl_ser_cmd_state(struct phl_info_t *phl_info, u32 *used, char input[][MAX_ARGV],
 			u32 input_num, char *output, u32 out_len)
 {
 	struct rtw_stats *ser_stat = &phl_info->phl_com->phl_stats;
@@ -60,7 +60,7 @@ void _phl_ser_cmd_state(struct phl_info_t *phl_info, u32 *used, char input[][MAX
 }
 
 /* echo phl ser cmac */
-void _phl_ser_cmd_cmac(struct phl_info_t *phl_info, u32 *used, char input[][MAX_ARGV],
+static void _phl_ser_cmd_cmac(struct phl_info_t *phl_info, u32 *used, char input[][MAX_ARGV],
 			u32 input_num, char *output, u32 out_len )
 {
 	enum rtw_hal_status status = RTW_HAL_STATUS_FAILURE;
@@ -72,7 +72,7 @@ void _phl_ser_cmd_cmac(struct phl_info_t *phl_info, u32 *used, char input[][MAX_
 }
 
 /* echo phl ser dmac */
-void _phl_ser_cmd_dmac(struct phl_info_t *phl_info, u32 *used, char input[][MAX_ARGV],
+static void _phl_ser_cmd_dmac(struct phl_info_t *phl_info, u32 *used, char input[][MAX_ARGV],
 			u32 input_num, char *output, u32 out_len )
 {
 	enum rtw_hal_status status = RTW_HAL_STATUS_FAILURE;

--- a/phl/test/test_module.c
+++ b/phl/test/test_module.c
@@ -127,7 +127,7 @@ static u8 _dequeue_head_obj(void *d,
 		(false) : (true);
 }
 
-int run_test(void *testobj)
+static int run_test(void *testobj)
 {
 	struct test_object_ex *obj = (struct test_object_ex *)testobj;
 	struct test_mgnt_info *test_mgnt = obj->test_mgnt;
@@ -186,7 +186,7 @@ int run_test(void *testobj)
 	return 0;
 }
 
-int test_thread(void *param)
+static int test_thread(void *param)
 {
 	struct test_mgnt_info *test_mgnt
 		= (struct test_mgnt_info *)phl_container_of(param,
@@ -430,7 +430,7 @@ rtw_phl_test_set_max_run_time(struct rtw_phl_com_t* phl_com,
 	return true;
 }
 
-void setup_test_rpt(void *d, struct test_rpt* rpt,struct test_object_ex *obj)
+static void setup_test_rpt(void *d, struct test_rpt* rpt,struct test_object_ex *obj)
 {
 	char str[] = "Exceed Time Limit";
 	char str2[] = "Test not run";
@@ -536,7 +536,7 @@ static void _test_obj_thread_callback(void *context)
 	obj->test_obj.ctrl.start_test(obj->test_obj.priv);
 }
 
-u8 init_obj_thread(struct test_mgnt_info *test_mgnt,
+static u8 init_obj_thread(struct test_mgnt_info *test_mgnt,
                    struct test_object_ex *obj,
                    enum TEST_RUN_LVL lvl)
 {

--- a/phl/test/trx_test.c
+++ b/phl/test/trx_test.c
@@ -24,7 +24,7 @@ enum rtw_phl_status phl_recycle_test_tx(void *phl, struct rtw_xmit_req *treq);
 
 
 
-void _phl_free_rx_req_pool(void *phl)
+static void _phl_free_rx_req_pool(void *phl)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
@@ -49,7 +49,7 @@ void _phl_free_rx_req_pool(void *phl)
 
 }
 
-enum rtw_phl_status _phl_alloc_rx_req_pool(void *phl, u32 rx_req_num)
+static enum rtw_phl_status _phl_alloc_rx_req_pool(void *phl, u32 rx_req_num)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
@@ -91,7 +91,7 @@ enum rtw_phl_status _phl_alloc_rx_req_pool(void *phl, u32 rx_req_num)
 	return status;
 }
 
-struct rtw_test_rx *_phl_query_idle_rx_req(struct phl_info_t *phl_info)
+static struct rtw_test_rx *_phl_query_idle_rx_req(struct phl_info_t *phl_info)
 {
 	struct rtw_test_rx *rreq = NULL;
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
@@ -112,7 +112,7 @@ struct rtw_test_rx *_phl_query_idle_rx_req(struct phl_info_t *phl_info)
 	return rreq;
 }
 
-struct rtw_test_rx *_phl_query_busy_rx_req(struct phl_info_t *phl_info)
+static struct rtw_test_rx *_phl_query_busy_rx_req(struct phl_info_t *phl_info)
 {
 	struct rtw_test_rx *rreq = NULL;
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
@@ -133,7 +133,7 @@ struct rtw_test_rx *_phl_query_busy_rx_req(struct phl_info_t *phl_info)
 	return rreq;
 }
 
-void _phl_release_rx_req(struct phl_info_t *phl_info, struct rtw_test_rx *rreq)
+static void _phl_release_rx_req(struct phl_info_t *phl_info, struct rtw_test_rx *rreq)
 {
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
 	struct rtw_pool *rx_req_pool = &trx_test->rx_req_pool;
@@ -156,7 +156,7 @@ void _phl_release_rx_req(struct phl_info_t *phl_info, struct rtw_test_rx *rreq)
 	_os_spinunlock(drv_priv, &rx_req_pool->idle_lock, _bh, NULL);
 }
 
-void _phl_insert_busy_rx_req(struct phl_info_t *phl_info, struct rtw_test_rx *rreq)
+static void _phl_insert_busy_rx_req(struct phl_info_t *phl_info, struct rtw_test_rx *rreq)
 {
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
 	struct rtw_pool *rx_req_pool = &trx_test->rx_req_pool;
@@ -171,7 +171,7 @@ void _phl_insert_busy_rx_req(struct phl_info_t *phl_info, struct rtw_test_rx *rr
 }
 
 
-void _phl_free_tx_req_pool(void *phl)
+static void _phl_free_tx_req_pool(void *phl)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
@@ -196,7 +196,7 @@ void _phl_free_tx_req_pool(void *phl)
 
 }
 
-enum rtw_phl_status _phl_alloc_tx_req_pool(void *phl, u32 tx_req_num)
+static enum rtw_phl_status _phl_alloc_tx_req_pool(void *phl, u32 tx_req_num)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
@@ -240,7 +240,7 @@ enum rtw_phl_status _phl_alloc_tx_req_pool(void *phl, u32 tx_req_num)
 	return status;
 }
 
-struct rtw_xmit_req *_phl_query_idle_tx_req(struct phl_info_t *phl_info)
+static struct rtw_xmit_req *_phl_query_idle_tx_req(struct phl_info_t *phl_info)
 {
 	struct rtw_xmit_req *treq = NULL;
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
@@ -261,7 +261,7 @@ struct rtw_xmit_req *_phl_query_idle_tx_req(struct phl_info_t *phl_info)
 	return treq;
 }
 
-struct rtw_xmit_req *_phl_query_busy_tx_req(struct phl_info_t *phl_info)
+static struct rtw_xmit_req *_phl_query_busy_tx_req(struct phl_info_t *phl_info)
 {
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
 	struct rtw_pool *tx_req_pool = &trx_test->tx_req_pool;
@@ -282,7 +282,7 @@ struct rtw_xmit_req *_phl_query_busy_tx_req(struct phl_info_t *phl_info)
 	return treq;
 }
 
-void _phl_remove_busy_tx_req(struct phl_info_t *phl_info, struct rtw_xmit_req *treq)
+static void _phl_remove_busy_tx_req(struct phl_info_t *phl_info, struct rtw_xmit_req *treq)
 {
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
 	struct rtw_pool *tx_req_pool = &trx_test->tx_req_pool;
@@ -299,7 +299,7 @@ void _phl_remove_busy_tx_req(struct phl_info_t *phl_info, struct rtw_xmit_req *t
 }
 
 
-void _phl_release_tx_req(struct phl_info_t *phl_info, struct rtw_xmit_req *treq)
+static void _phl_release_tx_req(struct phl_info_t *phl_info, struct rtw_xmit_req *treq)
 {
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
 	struct rtw_pool *tx_req_pool = &trx_test->tx_req_pool;
@@ -322,7 +322,7 @@ void _phl_release_tx_req(struct phl_info_t *phl_info, struct rtw_xmit_req *treq)
 	_os_spinunlock(drv_priv, &tx_req_pool->idle_lock, _bh, NULL);
 }
 
-void _phl_insert_busy_tx_req(struct phl_info_t *phl_info, struct rtw_xmit_req *treq)
+static void _phl_insert_busy_tx_req(struct phl_info_t *phl_info, struct rtw_xmit_req *treq)
 {
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
 	struct rtw_pool *tx_req_pool = &trx_test->tx_req_pool;
@@ -336,7 +336,7 @@ void _phl_insert_busy_tx_req(struct phl_info_t *phl_info, struct rtw_xmit_req *t
 }
 
 
-void _phl_free_tx_pkt_pool(void *phl)
+static void _phl_free_tx_pkt_pool(void *phl)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
@@ -386,7 +386,7 @@ void _phl_free_tx_pkt_pool(void *phl)
 }
 
 
-enum rtw_phl_status _phl_alloc_tx_pkt_pool(void *phl, u32 tx_pkt_num,
+static enum rtw_phl_status _phl_alloc_tx_pkt_pool(void *phl, u32 tx_pkt_num,
 					   u32 tx_pkt_size)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
@@ -452,7 +452,7 @@ enum rtw_phl_status _phl_alloc_tx_pkt_pool(void *phl, u32 tx_pkt_num,
 	return status;
 }
 
-struct rtw_payload *_phl_query_idle_tx_pkt(struct phl_info_t *phl_info)
+static struct rtw_payload *_phl_query_idle_tx_pkt(struct phl_info_t *phl_info)
 {
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
 	struct rtw_pool *tx_pkt_pool = &trx_test->tx_pkt_pool;
@@ -473,7 +473,7 @@ struct rtw_payload *_phl_query_idle_tx_pkt(struct phl_info_t *phl_info)
 	return tpkt;
 }
 
-struct rtw_payload *_phl_query_busy_tx_pkt(struct phl_info_t *phl_info)
+static struct rtw_payload *_phl_query_busy_tx_pkt(struct phl_info_t *phl_info)
 {
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
 	struct rtw_pool *tx_pkt_pool = &trx_test->tx_pkt_pool;
@@ -494,7 +494,7 @@ struct rtw_payload *_phl_query_busy_tx_pkt(struct phl_info_t *phl_info)
 	return tpkt;
 }
 
-void _phl_remove_busy_tx_pkt(struct phl_info_t *phl_info, struct rtw_payload *tpkt)
+static void _phl_remove_busy_tx_pkt(struct phl_info_t *phl_info, struct rtw_payload *tpkt)
 {
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
 	struct rtw_pool *tx_pkt_pool = &trx_test->tx_pkt_pool;
@@ -511,7 +511,7 @@ void _phl_remove_busy_tx_pkt(struct phl_info_t *phl_info, struct rtw_payload *tp
 }
 
 
-void _phl_release_tx_pkt(struct phl_info_t *phl_info, struct rtw_payload *tpkt)
+static void _phl_release_tx_pkt(struct phl_info_t *phl_info, struct rtw_payload *tpkt)
 {
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
 	struct rtw_pool *tx_pkt_pool = &trx_test->tx_pkt_pool;
@@ -529,7 +529,7 @@ void _phl_release_tx_pkt(struct phl_info_t *phl_info, struct rtw_payload *tpkt)
 	_os_spinunlock(drv_priv, &tx_pkt_pool->idle_lock, _bh, NULL);
 }
 
-void _phl_insert_busy_tx_pkt(struct phl_info_t *phl_info, struct rtw_payload *tpkt)
+static void _phl_insert_busy_tx_pkt(struct phl_info_t *phl_info, struct rtw_payload *tpkt)
 {
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
 	struct rtw_pool *tx_pkt_pool = &trx_test->tx_pkt_pool;
@@ -543,7 +543,7 @@ void _phl_insert_busy_tx_pkt(struct phl_info_t *phl_info, struct rtw_payload *tp
 	_os_spinunlock(drv_priv, &tx_pkt_pool->busy_lock, _bh, NULL);
 }
 
-u8 _phl_is_tx_test_done(void *phl)
+static u8 _phl_is_tx_test_done(void *phl)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
@@ -558,7 +558,7 @@ u8 _phl_is_tx_test_done(void *phl)
 
 
 
-void phl_update_test_param(void *phl, struct rtw_trx_test_param *test_param)
+static void phl_update_test_param(void *phl, struct rtw_trx_test_param *test_param)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
@@ -571,7 +571,7 @@ extern enum rtw_phl_status
 phl_wifi_role_start(struct phl_info_t *phl_info,
 				struct rtw_wifi_role_t *wrole,
 				struct rtw_phl_stainfo_t *sta);
-enum rtw_phl_status
+static enum rtw_phl_status
 _phl_test_add_role(void *phl, struct rtw_trx_test_param *test_param)
 {
 	enum rtw_phl_status phl_status = RTW_PHL_STATUS_FAILURE;
@@ -607,7 +607,7 @@ _phl_test_add_role(void *phl, struct rtw_trx_test_param *test_param)
 
 extern enum rtw_phl_status
 phl_wifi_role_stop(struct phl_info_t *phl_info, struct rtw_wifi_role_t *wrole);
-enum rtw_phl_status _phl_test_remove_role(
+static enum rtw_phl_status _phl_test_remove_role(
 					   void *phl,
 				       struct rtw_trx_test_param *test_param)
 {
@@ -622,7 +622,7 @@ enum rtw_phl_status _phl_test_remove_role(
 	return phl_status;
 }
 
-void phl_test_sw_free(void *phl)
+static void phl_test_sw_free(void *phl)
 {
 	FUNCIN();
 
@@ -634,7 +634,7 @@ void phl_test_sw_free(void *phl)
 }
 
 
-enum rtw_phl_status phl_test_sw_alloc(void *phl)
+static enum rtw_phl_status phl_test_sw_alloc(void *phl)
 {
 	enum rtw_phl_status sts = RTW_PHL_STATUS_FAILURE;
 	FUNCIN_WSTS(sts);
@@ -725,7 +725,7 @@ void phl_trx_test_deinit(void *phl)
 }
 
 
-void phl_test_hw_config_init(void *phl, u8 mode)
+static void phl_test_hw_config_init(void *phl, u8 mode)
 {
 	switch (mode) {
 	case TEST_MODE_PHL_TX_RING_TEST:
@@ -742,7 +742,7 @@ void phl_test_hw_config_init(void *phl, u8 mode)
 }
 
 
-void phl_test_hw_config_runtime(void *phl, u8 mode)
+static void phl_test_hw_config_runtime(void *phl, u8 mode)
 {
 	switch (mode) {
 	case TEST_MODE_PHL_TX_RING_TEST:
@@ -759,7 +759,7 @@ void phl_test_hw_config_runtime(void *phl, u8 mode)
 }
 
 
-void phl_test_fill_packet_content(struct phl_info_t *phl_info, u8 *pkt,
+static void phl_test_fill_packet_content(struct phl_info_t *phl_info, u8 *pkt,
 				  u16 size,
 				  struct rtw_trx_test_param *test_param)
 {
@@ -846,7 +846,7 @@ void rtw_phl_test_rx_callback(void *context)
 }
 
 
-enum rtw_phl_status rtw_phl_rx_reap(void *phl, u8 *xmit_req,
+static enum rtw_phl_status rtw_phl_rx_reap(void *phl, u8 *xmit_req,
 				    struct rtw_trx_test_param *param)
 {
 	enum rtw_phl_status sts = RTW_PHL_STATUS_FAILURE;
@@ -913,7 +913,7 @@ enum rtw_phl_status rtw_phl_rx_reap(void *phl, u8 *xmit_req,
 	return sts;
 }
 
-enum rtw_phl_status rtw_phl_test_rxq_notify(void *phl)
+static enum rtw_phl_status rtw_phl_test_rxq_notify(void *phl)
 {
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_FAILURE;
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
@@ -925,7 +925,7 @@ enum rtw_phl_status rtw_phl_test_rxq_notify(void *phl)
 }
 
 
-enum rtw_phl_status phl_tx_ring_test(void *phl,
+static enum rtw_phl_status phl_tx_ring_test(void *phl,
 				     struct rtw_trx_test_param *test_param)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
@@ -998,7 +998,7 @@ enum rtw_phl_status phl_tx_ring_test(void *phl,
 	return sts;
 }
 
-enum rtw_phl_status phl_rx_ring_test(void *phl,
+static enum rtw_phl_status phl_rx_ring_test(void *phl,
 				     struct rtw_trx_test_param *test_param)
 {
 	enum rtw_phl_status sts = RTW_PHL_STATUS_FAILURE;
@@ -1016,7 +1016,7 @@ enum rtw_phl_status phl_rx_ring_test(void *phl,
 }
 
 
-enum rtw_phl_status phl_hal_tx_test(void *phl,
+static enum rtw_phl_status phl_hal_tx_test(void *phl,
 				     struct rtw_trx_test_param *test_param)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
@@ -1083,7 +1083,7 @@ enum rtw_phl_status phl_hal_tx_test(void *phl,
 	return sts;
 }
 
-enum rtw_phl_status phl_hal_rx_test(void *phl,
+static enum rtw_phl_status phl_hal_rx_test(void *phl,
 				     struct rtw_trx_test_param *test_param)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;
@@ -1105,7 +1105,7 @@ enum rtw_phl_status phl_hal_rx_test(void *phl,
 }
 
 
-enum rtw_phl_status phl_trx_test_start(void *phl,
+static enum rtw_phl_status phl_trx_test_start(void *phl,
 				       struct rtw_trx_test_param *test_param)
 {
 	enum rtw_phl_status status = RTW_PHL_STATUS_FAILURE;
@@ -1131,7 +1131,7 @@ enum rtw_phl_status phl_trx_test_start(void *phl,
 	return status;
 }
 
-void phl_trx_test_dump_result(void *phl, struct rtw_trx_test_param *test_param)
+static void phl_trx_test_dump_result(void *phl, struct rtw_trx_test_param *test_param)
 {
 	PHL_INFO("Test Done");
 }
@@ -1179,7 +1179,7 @@ end:
 	return sts;
 }
 
-void _phl_rx_test_pattern(struct phl_info_t *phl_info, void *ptr)
+static void _phl_rx_test_pattern(struct phl_info_t *phl_info, void *ptr)
 {
 	struct rtw_recv_pkt *rpkt = NULL;
 
@@ -1293,7 +1293,7 @@ enum rtw_phl_status rtw_phl_trx_testsuite(void *phl,
 }
 
 
-u8 trx_test_bp_handler(void *priv, struct test_bp_info* bp_info)
+static u8 trx_test_bp_handler(void *priv, struct test_bp_info* bp_info)
 {
 	u8 ret = BP_RET_SKIP_SECTION;
 
@@ -1301,7 +1301,7 @@ u8 trx_test_bp_handler(void *priv, struct test_bp_info* bp_info)
 }
 
 
-u8 trx_test_is_test_end(void *priv)
+static u8 trx_test_is_test_end(void *priv)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)priv;
 	struct phl_trx_test *trx_test = (struct phl_trx_test *)phl_info->trx_test;
@@ -1310,32 +1310,32 @@ u8 trx_test_is_test_end(void *priv)
 	FUNCOUT();
 	return (test_param->is_trx_test_end == true) ? (true) : (false);
 }
-u8 trx_test_is_test_pass(void *priv)
+static u8 trx_test_is_test_pass(void *priv)
 {
 	FUNCIN();
 	FUNCOUT();
 	return true;
 }
 
-u8 trx_test_get_fail_rsn(void *priv, char* rsn, u32 max_len)
-{
-	//struct phl_info_t *phl_info = (struct phl_info_t *)priv;
-	FUNCIN();
-	FUNCOUT();
-	return true;
-
-}
-
-u8 trx_test_start_test(void *priv)
+static u8 trx_test_get_fail_rsn(void *priv, char* rsn, u32 max_len)
 {
 	//struct phl_info_t *phl_info = (struct phl_info_t *)priv;
 	FUNCIN();
 	FUNCOUT();
 	return true;
+
+}
+
+static u8 trx_test_start_test(void *priv)
+{
+	//struct phl_info_t *phl_info = (struct phl_info_t *)priv;
+	FUNCIN();
+	FUNCOUT();
+	return true;
 }
 
 
-void
+static void
 phl_add_trx_test_obj(void *phl)
 {
 	struct phl_info_t *phl_info = (struct phl_info_t *)phl;

--- a/phl/test/verify/dbcc/phl_test_dbcc.c
+++ b/phl/test/verify/dbcc/phl_test_dbcc.c
@@ -17,6 +17,7 @@
 #include "../phl_test_verify_def.h"
 #include "../phl_test_verify_api.h"
 #include "phl_test_dbcc_def.h"
+#include "phl_test_dbcc_api.h"
 
 #ifdef CONFIG_PHL_TEST_VERIFY
 static u8 dbcc_get_class_from_buf(struct verify_context *ctx)

--- a/phl/test/verify/phl_test_verify.c
+++ b/phl/test/verify/phl_test_verify.c
@@ -25,7 +25,7 @@ static struct s_handler test_handlers[VERIFY_FEATURES_MAX] = {
 	{ rtw_test_dbcc_cmd_process }, /* VERIFY_FEATURES_DBCC */
 };
 
-void verify_cmd_done_notification_complete(void *ctx, struct phl_msg *msg)
+static void verify_cmd_done_notification_complete(void *ctx, struct phl_msg *msg)
 {
 	struct verify_context *ver_ctx = (struct verify_context *)ctx;
 
@@ -35,7 +35,7 @@ void verify_cmd_done_notification_complete(void *ctx, struct phl_msg *msg)
 	}
 }
 
-void verify_cmd_done_notification(struct verify_context *ver_ctx, u8 feature,
+static void verify_cmd_done_notification(struct verify_context *ver_ctx, u8 feature,
 	u8 cmd_id)
 {
 	struct phl_msg msg = { 0 };
@@ -66,7 +66,7 @@ void verify_cmd_done_notification(struct verify_context *ver_ctx, u8 feature,
 	}
 }
 
-bool verify_get_rpt_check(struct verify_context *ver_ctx, void *rpt_buf)
+static bool verify_get_rpt_check(struct verify_context *ver_ctx, void *rpt_buf)
 {
 	bool ret = true;
 	struct verify_cmd_hdr *rpt_hdr = (struct verify_cmd_hdr *)ver_ctx->rpt;
@@ -83,7 +83,7 @@ bool verify_get_rpt_check(struct verify_context *ver_ctx, void *rpt_buf)
 	return ret;
 }
 
-u8 verify_get_feature_from_buf(struct verify_context *ver_ctx)
+static u8 verify_get_feature_from_buf(struct verify_context *ver_ctx)
 {
 	u8 *buf_tmp = NULL;
 	u8 feature = VERIFY_FEATURES_MAX;
@@ -95,7 +95,7 @@ u8 verify_get_feature_from_buf(struct verify_context *ver_ctx)
 	return feature;
 }
 
-u8 verify_bp_handler(void *ctx, struct test_bp_info *bp_info)
+static u8 verify_bp_handler(void *ctx, struct test_bp_info *bp_info)
 {
 	struct verify_context *ver_ctx = (struct verify_context *)ctx;
 	enum rtw_phl_status phl_status = RTW_PHL_STATUS_FAILURE;
@@ -115,26 +115,26 @@ u8 verify_bp_handler(void *ctx, struct test_bp_info *bp_info)
 	return phl_status;
 }
 
-u8 verify_get_fail_rsn(void *ctx, char *rsn, u32 max_len)
+static u8 verify_get_fail_rsn(void *ctx, char *rsn, u32 max_len)
 {
 	//struct verify_context *ver_ctx = (struct verify_context *)ctx;
 	return true;
 }
 
-u8 verify_is_test_end(void *ctx)
+static u8 verify_is_test_end(void *ctx)
 {
 	struct verify_context *ver_ctx = (struct verify_context *)ctx;
 
 	return ver_ctx->is_test_end;
 }
 
-u8 verifyg_is_test_pass(void *ctx)
+static u8 verifyg_is_test_pass(void *ctx)
 {
 	//struct verify_context *ver_ctx = (struct verify_context *)ctx;
 	return true;
 }
 
-u8 verify_start(void *ctx)
+static u8 verify_start(void *ctx)
 {
 	struct verify_context *ver_ctx = (struct verify_context *)ctx;
 	struct rtw_phl_com_t *phl_com = ver_ctx->phl_com;
@@ -188,7 +188,7 @@ u8 verify_start(void *ctx)
 	return (u8)phl_status;
 }
 
-void verify_change_mode(struct verify_context *ver_ctx, enum rtw_drv_mode driver_mode)
+static void verify_change_mode(struct verify_context *ver_ctx, enum rtw_drv_mode driver_mode)
 {
 	struct phl_info_t *phl_info = ver_ctx->phl;
 


### PR DESCRIPTION
Builds the driver cleanly under -Wmissing-prototypes (enabled by default in
recent kernels), cutting the warning count from 2179 to 42 (-98%).

Approach:
- File-private functions are made `static` (1707 functions across 173 files).
- Many functions whose prototype already lived in a paired header simply
  weren't #include'd at the definition site — added the missing self-include
  to 66 source files (e.g. hal_api.c -> hal_api.h, core/rtw_sdio.c ->
  rtw_sdio.h).
- A few cross-file functions had no declaration anywhere; added real
  prototypes to the appropriate headers.

Including the headers also surfaced two pre-existing prototype/definition
type mismatches — real latent ABI bugs — fixed here:
- rtw_hal_com_set_gt3: the definition truncated `timeout` to u8 while the
  prototype and the rest of the call chain use u32; widened the definition.
- rtw_hal_ps_pwr_lvl_cfg: the prototype declared `req_pwr_lvl` as u32 while
  the definition and every caller use u8; narrowed the prototype.

The remaining 42 warnings are left untouched on purpose — they are the hard
cases: functions assigned into ops tables across files (where `static` would
break linkage), prototypes guarded behind CONFIG_USB_HCI / CONFIG_PCI_HCI on
an SDIO build, and platform-specific paths. Each needs a semantic decision
rather than a mechanical fix.

Verified against Armbian rockchip64 kernel builds on both edge (7.0) and
current (6.18): the driver compiles cleanly with no conflicting-types errors.

**Also fixes two mismatched include guards.** `custom_gpio.h` and
`halrf_ops_rtl8852b.h` each `#define` a guard macro whose name differs from the
one tested by `#ifndef` (a stray extra underscore, and a dropped `_H_`), so the
guard never engages and the header is re-parsed on every inclusion. Making
`#define` match `#ifndef` is harmless here (no prototype was hidden by it) but
removes the latent re-parse.

**Guarding config-disabled statics (`-Wunused-function`).** Making a function `static` exposes `-Wunused-function` when its sole caller is gated out by a build option. 25 such functions (plus 6 private helpers they alone call) are wrapped in the same `#if` that gates their caller, so definition and caller track each other across all configs. Verified on a from-scratch rk35xx/SDIO 8852bs kernel build: all 31 of these warnings gone, none newly introduced; the remaining `-Wunused-function` reports are pre-existing vendor dead code with no caller in any config (left untouched).


---
*Commits are split by subsystem (core / os_dep / phl / hal_g6 / mac / phy-bb / phy-rf / test), each a homogeneous independently-reviewable unit; the two ABI type fixes and the include-guard fix are isolated commits.*
