### PR TITLE
Import long-carried armbian/build regd-init fix, with authorship

### DIFF
--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -1276,7 +1276,7 @@ int rtw_regd_init(struct wiphy *wiphy)
 	wiphy->regulatory_flags &= ~REGULATORY_DISABLE_BEACON_HINTS;
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0))
 	wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
 #endif
 


### PR DESCRIPTION
## What

Brings a patch that armbian/build has carried out-of-tree since 2024 into the repo itself, with original authorship preserved (`git am`):

- **update rtw_regd_init for kernel v6.1** (@pyavitz) — `REGULATORY_IGNORE_STALE_KICKOFF` was removed from cfg80211 in 6.1, but `os_dep/linux/wifi_regd.c` references it unconditionally for any kernel ≥ 3.19. The patch caps that branch at `< 6.1`.

## Why

General, non-armbian-specific: without it the module fails to build (`error: 'REGULATORY_IGNORE_STALE_KICKOFF' undeclared`) on every kernel ≥ 6.1 — which is all currently supported branches.

It currently lives only as a downstream patch in armbian/build:
https://github.com/armbian/build/blob/main/patch/misc/wireless-rtl8852bs-Update-rtw_regd_init-for-6.1.patch

**Once this merges, that downstream patch should be deleted from armbian/build** — otherwise it will fail to apply (or become a redundant no-op) on top of the now-fixed source.

Verified: clean build (arm64, rockchip64, kernels 6.18 and 7.1).