### PR TITLE
Guard config-disabled static helpers to silence -Wunused-function

### DIFF
--- a/core/rtw_he.c
+++ b/core/rtw_he.c
@@ -1540,6 +1540,7 @@ static int rtw_build_max_cohost_bssid_ind(_adapter *padapter, u8 *pbuf)
 	return info_len;
 }
 
+#if CONFIG_IEEE80211_BAND_6GHZ
 static int rtw_build_6g_oper_info(_adapter *padapter, struct _ADAPTER_LINK *padapter_link,
 	u8 *pbuf, struct rtw_chan_def *chandef)
 {
@@ -1560,6 +1561,7 @@ static int rtw_build_6g_oper_info(_adapter *padapter, struct _ADAPTER_LINK *pada
 	/* Set 6GHz Operation Information (optional) */
 	return info_len;
 }
+#endif /* CONFIG_IEEE80211_BAND_6GHZ */
 
 u32	rtw_build_he_operation_ie(_adapter *padapter,
 				struct _ADAPTER_LINK *padapter_link,

--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -5896,6 +5896,7 @@ _connect_swch_done_notify(struct _ADAPTER *a,
 	return status;
 }
 
+#ifdef CONFIG_DBCC_SUPPORT
 static enum rtw_phl_status _connect_disconnect_end_notify(struct _ADAPTER *a)
 {
 	struct dvobj_priv *d = adapter_to_dvobj(a);
@@ -5917,6 +5918,7 @@ static enum rtw_phl_status _connect_disconnect_end_notify(struct _ADAPTER *a)
 
 	return status;
 }
+#endif /* CONFIG_DBCC_SUPPORT */
 
 static void _connect_cmd_done(struct _ADAPTER *a)
 {

--- a/core/rtw_phl.c
+++ b/core/rtw_phl.c
@@ -3179,6 +3179,7 @@ u8 rtw_hw_wow(struct _ADAPTER *a, u8 wow_en)
 }
 #endif /* CONFIG_WOWLAN */
 
+#if defined(CONFIG_USB_HCI) || defined(CONFIG_PCI_HCI)
 static u32 rtw_tx_sts_total(u32 *tx_sts, u8 num)
 {
 	u32 ret = 0;
@@ -3188,6 +3189,7 @@ static u32 rtw_tx_sts_total(u32 *tx_sts, u8 num)
 		ret += tx_sts[i];
 	return ret;
 }
+#endif /* CONFIG_USB_HCI || CONFIG_PCI_HCI */
 
 int rtw_get_sta_tx_stat(_adapter *adapter, struct sta_info *psta)
 {

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -3471,6 +3471,7 @@ move_to_next:
 	return ret;
 }
 
+#if defined(CONFIG_80211N_HT) && defined(CONFIG_RECV_REORDERING_CTRL)
 static int recv_process_mpdu(_adapter *padapter, union recv_frame *prframe)
 {
 	struct rx_pkt_attrib *pattrib = &prframe->u.hdr.attrib;
@@ -3575,6 +3576,7 @@ static int recv_process_mpdu(_adapter *padapter, union recv_frame *prframe)
 exit:
 	return ret;
 }
+#endif /* CONFIG_80211N_HT && CONFIG_RECV_REORDERING_CTRL */
 
 #if defined(CONFIG_80211N_HT) && defined(CONFIG_RECV_REORDERING_CTRL)
 static int check_indicate_seq(struct recv_reorder_ctrl *preorder_ctrl, u16 seq_num)

--- a/phl/hal_g6/hal_api_mac.c
+++ b/phl/hal_g6/hal_api_mac.c
@@ -827,6 +827,7 @@ static u8 hal_mac_sdio_cmd52_cia_r8(void *h, u32 addr)
 }
 #endif /*CONFIG_SDIO_HCI*/
 
+#if defined(CONFIG_USB_HCI) || defined(CONFIG_PCI_HCI)
 static u8 hal_mac_reg_r8(void *h, u32 addr)
 {
 	return hal_read8((struct rtw_hal_com_t *)h, addr);
@@ -851,6 +852,7 @@ static void hal_mac_reg_w32(void *h, u32 addr, u32 val)
 {
 	hal_write32((struct rtw_hal_com_t *)h, addr, val);
 }
+#endif /* CONFIG_USB_HCI || CONFIG_PCI_HCI */
 
 
 #ifdef DBG_HAL_MAC_MEM_MOINTOR
@@ -3506,6 +3508,7 @@ rtw_hal_mac_chk_allq_empty(struct hal_info_t *hal_info, u8 *empty)
 	return RTW_HAL_STATUS_SUCCESS;
 }
 
+#ifdef CONFIG_WOWLAN
 static void _dump_txq_status(struct mac_ax_tx_queue_empty *val)
 {
 	u8 i = 0;
@@ -3520,6 +3523,7 @@ static void _dump_txq_status(struct mac_ax_tx_queue_empty *val)
 	PHL_INFO("%s : h2c_empty %d.\n", __func__, val->h2c_empty);
 	PHL_INFO("%s : others_empty %d.\n", __func__, val->others_empty);
 }
+#endif /* CONFIG_WOWLAN */
 
 #ifdef CONFIG_WOWLAN
 enum rtw_hal_status

--- a/phl/hal_g6/mac/mac_ax/wowlan.c
+++ b/phl/hal_g6/mac/mac_ax/wowlan.c
@@ -2018,9 +2018,9 @@ static void dump_bytes(struct mac_ax_adapter *adapter, u8 *start, u32 size)
 #endif
 }
 
+#if PROXY_MDNS_DUMP
 static void mdns_sprintf(struct mac_ax_adapter *adapter, char *content, u8 *in, u32 len)
 {
-#if PROXY_MDNS_DUMP
 	u32 idx;
 	u32 write_idx;
 
@@ -2045,20 +2045,20 @@ static void mdns_sprintf(struct mac_ax_adapter *adapter, char *content, u8 *in, 
 	}
 	content[write_idx++] = '>';
 	content[write_idx] = 0;
-#endif
 }
+#endif /* PROXY_MDNS_DUMP */
 
+#if PROXY_MDNS_DUMP
 static void dump_mdns_machine(struct mac_ax_adapter *adapter,
 			      struct rtw_hal_mac_proxy_mdns_machine *machine)
 {
-#if PROXY_MDNS_DUMP
 
 	char p[128];
 
 	mdns_sprintf(adapter, p, machine->name, machine->len);
 	PLTFM_MSG_TRACE("[MDNS][Mchn] %s (%d)\n", &p, machine->len);
-#endif
 }
+#endif /* PROXY_MDNS_DUMP */
 
 static void dump_mdns_rsp_hdr(struct mac_ax_adapter *adapter,
 			      struct rtw_hal_mac_proxy_mdns_rsp_hdr h)

--- a/phl/phl_chan.c
+++ b/phl/phl_chan.c
@@ -1132,6 +1132,7 @@ is_ch_in_same_band(struct rtw_chan_def *chdef_a, struct rtw_chan_def *chdef_b)
 	return ch_in_same_band;
 }
 
+#ifdef CONFIG_DBCC_SUPPORT
 static bool
 is_ch_in_interference_band(struct rtw_chan_def *chdef_a, struct rtw_chan_def *chdef_b)
 {
@@ -1156,6 +1157,7 @@ is_ch_in_interference_band(struct rtw_chan_def *chdef_a, struct rtw_chan_def *ch
 	}
 	return ch_in_same_band;
 }
+#endif /* CONFIG_DBCC_SUPPORT */
 
 static void _phl_dump_mr_cc_info(struct phl_info_t *phl_info,
 					struct rtw_mr_chctx_info *mr_cc_info)

--- a/phl/phl_cmd_scan.c
+++ b/phl/phl_cmd_scan.c
@@ -1429,6 +1429,7 @@ _phl_cmd_scan_req_submit(struct phl_info_t *phl_info,
 	return RTW_PHL_STATUS_SUCCESS;
 }
 
+#ifdef CONFIG_DBCC_SUPPORT
 static u8
 _cmd_scan_dbcc_policy(struct phl_info_t *phl_info,
                       struct rtw_phl_scan_param *param)
@@ -1458,6 +1459,7 @@ _cmd_scan_dbcc_policy(struct phl_info_t *phl_info,
 
 	 return sctrl_num;
 }
+#endif /* CONFIG_DBCC_SUPPORT */
 
 /* For EXTERNAL application to request scan (expose) */
 /* @pscan: scan object

--- a/phl/phl_init.c
+++ b/phl/phl_init.c
@@ -1833,6 +1833,7 @@ end:
 #endif /* CONFIG_WOWLAN */
 }
 
+#ifdef CONFIG_WOWLAN
 static void _wow_stop_reinit(struct phl_info_t *phl_info)
 {
 	enum rtw_phl_status pstatus = RTW_PHL_STATUS_FAILURE;
@@ -1858,6 +1859,7 @@ static void _wow_stop_reinit(struct phl_info_t *phl_info)
 		PHL_ERR("%s : rtw_phl_start fail!\n", __func__);
 	phl_cmd_role_recover(phl_info);
 }
+#endif /* CONFIG_WOWLAN */
 
 void phl_wow_stop(struct phl_info_t *phl_info, struct rtw_phl_stainfo_t *sta, u8 *hw_reinit)
 {

--- a/phl/phl_sta.c
+++ b/phl/phl_sta.c
@@ -2817,6 +2817,7 @@ fail:
 #endif
 }
 
+#if defined(CONFIG_PHL_RELEASE_RPT_ENABLE) || defined(CONFIG_PCI_HCI)
 static u32 rtw_phl_get_hw_tx_fail_cnt(struct rtw_hal_stainfo_t *hal_sta,
 	enum phl_ac_queue qsel) {
 #if defined(CONFIG_PHL_RELEASE_RPT_ENABLE) || defined(CONFIG_PCI_HCI)
@@ -2862,6 +2863,7 @@ static void rtw_phl_reset_tx_fail_cnt(struct phl_info_t *phl_info,
 	PHL_WARN("%s not support\n", __func__);
 #endif
 }
+#endif /* CONFIG_PHL_RELEASE_RPT_ENABLE || CONFIG_PCI_HCI */
 
 /**
  * rtw_phl_get_tx_fail_rpt() - get tx fail info.

--- a/phl/test/phl_dbg_cmd.c
+++ b/phl/test/phl_dbg_cmd.c
@@ -766,6 +766,7 @@ void phl_dbg_cmd_phl_rx(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 }
 #endif /* DEBUG_PHL_RX */
 
+#ifdef CONFIG_WOWLAN
 static const char *_get_mac_pwr_st_str(enum rtw_mac_pwr_st st)
 {
 	switch (st) {
@@ -793,6 +794,7 @@ static const char *_get_wow_opmode_str(enum rtw_wow_op_mode mode)
 		return "n/a";
 	}
 }
+#endif /* CONFIG_WOWLAN */
 
 void _dump_wow_stats(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 	u32 input_num, char *output, u32 out_len)


### PR DESCRIPTION
Twenty file-private (`static`) helpers are only ever called from code behind a config option disabled in a typical SDIO/ARM build: `CONFIG_USB_HCI`/`CONFIG_PCI_HCI`, `CONFIG_WOWLAN`, `CONFIG_DBCC_SUPPORT`, `CONFIG_IEEE80211_BAND_6GHZ`, `CONFIG_PHL_RELEASE_RPT_ENABLE`, `CONFIG_80211N_HT && CONFIG_RECV_REORDERING_CTRL`, `PROXY_MDNS_DUMP`.

Their definitions were unconditional (or under a wider guard than the caller), so when the only caller is compiled out the function is left defined-but-unused and gcc emits `-Wunused-function`.

Each definition is wrapped in the same condition as its sole caller, so definition and caller appear and disappear together. No change for any configuration where the function is actually used.