### PR TITLE
wireless: fix h2cb_alloc PHL prototype enum type (-Wenum-conversion 143 -> 27)

### DIFF
--- a/phl/hal_g6/mac/mac_ax/fwcmd.c
+++ b/phl/hal_g6/mac/mac_ax/fwcmd.c
@@ -399,7 +399,7 @@ fail:
 
 #if MAC_AX_PHL_H2C
 struct rtw_h2c_pkt *h2cb_alloc(struct mac_ax_adapter *adapter,
-			       enum rtw_h2c_pkt_type buf_class)
+			       enum h2c_buf_class buf_class)
 {
 	struct rtw_h2c_pkt *h2cb;
 #if MAC_AX_H2C_LMT_EN
@@ -408,7 +408,7 @@ struct rtw_h2c_pkt *h2cb_alloc(struct mac_ax_adapter *adapter,
 	u8 cnt = 100;
 #endif
 
-	if (buf_class >= H2CB_TYPE_MAX) {
+	if (buf_class >= H2CB_CLASS_MAX) {
 		PLTFM_MSG_ERR("[ERR]unknown class\n");
 		return NULL;
 	}

--- a/phl/hal_g6/mac/mac_ax/fwcmd.h
+++ b/phl/hal_g6/mac/mac_ax/fwcmd.h
@@ -285,7 +285,7 @@ u32 h2cb_exit(struct mac_ax_adapter *adapter);
  */
 #if MAC_AX_PHL_H2C
 struct rtw_h2c_pkt *h2cb_alloc(struct mac_ax_adapter *adapter,
-			       enum rtw_h2c_pkt_type buf_class);
+			       enum h2c_buf_class buf_class);
 /**
  * @}
  * @}


### PR DESCRIPTION
One prototype fix. The MAC_AX_PHL_H2C variant of h2cb_alloc() is declared with
enum rtw_h2c_pkt_type, but all 122 callers pass enum h2c_buf_class values
(H2CB_CLASS_*), and the argument goes on into the pltfm_cb rtl_query_h2c
callback — declared with enum h2c_buf_class, whose implementation
(hal_query_h2c_pkt) already converts the class to rtw_h2c_pkt_type via an
explicit switch. The prototype was the only odd link in an otherwise
h2c_buf_class chain; gcc flagged every call.

Take enum h2c_buf_class like the non-PHL variant does, and bound-check against
H2CB_CLASS_MAX instead of H2CB_TYPE_MAX (both are 3, behaviour unchanged).

Built before/after against Armbian rockchip64 headers (CONFIG_RTW_DEBUG=n,
CONFIG_PLATFORM_ARM_ROCKCHIP=y): -Wenum-conversion 143 -> 27; every other
warning class unchanged count-for-count. Runtime untested — no RTL8852BS
hardware here.
