### PR TITLE
Fix misc warning tail: unused labels, no-effect statements, set-but-unused parameters (22 -> 0)

### DIFF
--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -1964,7 +1964,6 @@ chbw_decision:
 			rtw_warn_on(1);
 	}
 
-_exit:
 	parm->ifbmp_ch_changed = ifbmp_ch_changed;
 	parm->req_band = new_chdef.band;
 	parm->ch_to_set = new_chdef.chan;
@@ -2872,7 +2871,7 @@ u8 rtw_ap_set_sta_key(_adapter *adapter, const u8 *addr, u8 alg, const u8 *key, 
 	param.gk = gk;
 
 	set_stakey_hdl(adapter, &param, PHL_CMD_NO_WAIT, 0);
-exit:
+
 	return res;
 }
 
@@ -2931,7 +2930,6 @@ static int rtw_ap_set_key(_adapter *padapter, struct _ADAPTER_LINK *padapter_lin
 	_rtw_memcpy(&(setkeyparm.key[0]), key, keylen);
 	setkey_hdl(padapter, padapter_link, &setkeyparm, PHL_CMD_NO_WAIT, 0);
 
-exit:
 	return res;
 }
 #else /* CONFIG_FSM */

--- a/core/rtw_cmd.c
+++ b/core/rtw_cmd.c
@@ -1100,7 +1100,7 @@ u8 rtw_setstakey_cmd(_adapter *padapter, struct sta_info *sta, u8 key_type, bool
 	} else {
 		set_stakey_hdl(padapter, &setstakey_para, PHL_CMD_DIRECTLY, 0);
 	}
-exit:
+
 	return res;
 }
 

--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -7067,7 +7067,6 @@ static bool _disconnect_wait(struct _ADAPTER *a, u32 timeout)
 	RTW_DBG(FUNC_ADPT_FMT ": Stop waiting disconnect FG, cost %u ms\n",
 		FUNC_ADPT_ARG(a), pass_t);
 
-exit:
 	RTW_DBG(FUNC_ADPT_FMT ": - %s\n", FUNC_ADPT_ARG(a), terminated?"OK":"Fail!");
 	return terminated;
 }

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -1166,7 +1166,9 @@ unsigned int OnProbeReq(_adapter *padapter, union recv_frame *precv_frame)
 #endif
 #endif /* CONFIG_IOCTL_CFG80211 */
 
+#ifdef CONFIG_80211BE_EHT
 _skip_cfg80211_rx:
+#endif
 
 #ifdef CONFIG_P2P
 	if (rtw_p2p_chk_role(pwdinfo, P2P_ROLE_DEVICE) ||
@@ -8777,7 +8779,9 @@ u8 collect_bss_info(_adapter *padapter, union recv_frame *precv_frame, WLAN_BSSI
 			bssid->Configuration.DSConfig = rtw_get_oper_ch(padapter, padapter_link);
 		}
 	}
+#if CONFIG_IEEE80211_BAND_6GHZ
 dsconfig_done:
+#endif
 
 	_rtw_memcpy(&bssid->Configuration.BeaconPeriod, rtw_get_beacon_interval_from_ie(bssid->IEs), 2);
 	bssid->Configuration.BeaconPeriod = le32_to_cpu(bssid->Configuration.BeaconPeriod);

--- a/core/rtw_mp.c
+++ b/core/rtw_mp.c
@@ -2178,6 +2178,7 @@ u32 mp_query_psd(_adapter *adapter, u8 *data)
 	u32 i, psd_pts = 0, psd_start = 0, psd_stop = 0;
 	u32 fft = 0, avg = 0, iq_path = 0;
 	u32 psd_data = 0;
+	int len;
 
 	my_psd_arg = _rtw_malloc(sizeof(struct rtw_mp_cal_arg));
 
@@ -2229,9 +2230,10 @@ u32 mp_query_psd(_adapter *adapter, u8 *data)
 			RTW_INFO("PSD_QUERY CMD FAIL!\n");
 
 		data[0] = '\0';
+		len = 0;
 		i = 0;
 		while (i < 320) {
-			sprintf(data, "%s%x ", data, (my_psd_arg->outbuf[i]));
+			len += sprintf(data + len, "%x ", (my_psd_arg->outbuf[i]));
 			i++;
 		}
 	}
@@ -3513,7 +3515,7 @@ void rtw_mp_set_crystal_cap(_adapter *padapter, u32 xcapvalue)
 	cfg_arg.mp_class = RTW_MP_CLASS_REG;
 	cfg_arg.cmd = RTW_MP_REG_CMD_SET_XCAP;
 
-	for (i <=0 ; i <= sc_xo_idx; i++) {
+	for (i = 0; i <= sc_xo_idx; i++) {
 		cfg_arg.cmd_ok = 0;
 		cfg_arg.sc_xo = i;
 		cfg_arg.io_value = xcapvalue;

--- a/core/rtw_p2p.c
+++ b/core/rtw_p2p.c
@@ -3255,7 +3255,6 @@ int rtw_p2p_enable(_adapter *padapter, enum P2P_ROLE role)
 		update_tx_basic_rate(padapter, padapter_link, padapter->registrypriv.wireless_mode);
 	}
 
-exit:
 	return ret;
 }
 

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -2686,7 +2686,6 @@ static sint mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
 			pmppriv->rx_pktcount_filter_out++;
 	}
 
-exit:
 	ret = _SUCCESS;
 	return ret;
 

--- a/core/rtw_sta_mgt.c
+++ b/core/rtw_sta_mgt.c
@@ -722,7 +722,7 @@ u32 rtw_alloc_stainfo_hw(struct	sta_priv *stapriv, struct sta_info *psta)
 }
 
 /* using pstapriv->sta_hash_lock to protect */
-u32 static _rtw_free_core_stainfo(_adapter *padapter , struct sta_info *psta, u8 aid, const u8 *hwaddr)
+static u32 _rtw_free_core_stainfo(_adapter *padapter , struct sta_info *psta, u8 aid, const u8 *hwaddr)
 {
 	int i;
 	_queue *pfree_sta_queue;

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -7028,7 +7028,6 @@ static u8 fill_txreq_pkt_mgmt(_adapter *padapter, struct xmit_frame *pxframe)
 }
 #endif
 
-exit:
 	return _SUCCESS;
 
 fail:

--- a/os_dep/linux/ioctl_efuse.c
+++ b/os_dep/linux/ioctl_efuse.c
@@ -1591,7 +1591,7 @@ u8 rtw_efuse_bt_write_raw_hidden(_adapter * adapter, u16 addr, u16 cnts, u8 *dat
 		}
 		i++;
 	}
-exit :
+
 	if (efuse_arg)
 		_rtw_mfree(efuse_arg, sizeof(struct rtw_efuse_phl_arg));
 

--- a/os_dep/linux/ioctl_efuse.c
+++ b/os_dep/linux/ioctl_efuse.c
@@ -450,10 +450,10 @@ static u8 rtw_efuse_mask_file_load(_adapter *padapter, u8 *filepath, u8 efuse_ty
 	if (filepath) {
 		RTW_INFO("efuse file path %s len %zu", filepath, strlen(filepath));
 		efuse_arg = _rtw_malloc(sizeof(struct rtw_efuse_phl_arg));
-		efuse_arg->status == RTW_PHL_STATUS_FAILURE;
 
 		if (efuse_arg) {
 			_rtw_memset((void *)efuse_arg, 0, sizeof(struct rtw_efuse_phl_arg));
+			efuse_arg->status = RTW_PHL_STATUS_FAILURE;
 			_rtw_memcpy(efuse_arg->pfile_path, filepath, strlen(filepath));
 			if (efuse_type == RTW_EFUSE_WIFI)
 				rtw_efuse_cmd(padapter, efuse_arg, RTW_EFUSE_CMD_FILE_MASK_LOAD);

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -6204,7 +6204,6 @@ static int rtw_phl_test_set(struct net_device *dev,
 	core_cmd_phl_handler(padapter, extra);
 #endif
 
-exit:
 	return 0;
 }
 #endif

--- a/phl/hal_g6/mac/mac_ax/fwcmd.c
+++ b/phl/hal_g6/mac/mac_ax/fwcmd.c
@@ -3748,8 +3748,6 @@ static u32 get_usr_txrpt_info_event(struct mac_ax_adapter *adapter,
 {
 	*id = MSG_EVT_USR_TX_RPT;
 
-	c2h_info = c2h->content;
-
 	return MACSUCCESS;
 }
 

--- a/phl/hal_g6/mac/mac_ax/hw.c
+++ b/phl/hal_g6/mac/mac_ax/hw.c
@@ -882,7 +882,7 @@ static void set_delay_tx_cfg(struct mac_ax_adapter *adapter,
 	struct mac_ax_intf_ops *ops = adapter_to_intf_ops(adapter);
 
 	val32 = MAC_REG_R32(R_AX_SS_CTRL);
-	SET_CLR_WORD(val32, cfg->en, B_AX_SS_DELAY_TX_BAND_SEL);
+	val32 = SET_CLR_WORD(val32, cfg->en, B_AX_SS_DELAY_TX_BAND_SEL);
 	MAC_REG_W32(R_AX_SS_CTRL, val32);
 
 	val32 = SET_WORD(cfg->vovi_to_b0, B_AX_SS_VOVI_TO_0) |

--- a/phl/hal_g6/mac/mac_ax/tblupd.c
+++ b/phl/hal_g6/mac/mac_ax/tblupd.c
@@ -2514,8 +2514,8 @@ u32 mac_fwc2h_ofdma_sts_parse(struct mac_ax_adapter *adapter,
 			GET_FIELD(val, FWCMD_C2H_OFDMA_STS_TFSTS_AVG_UPH);
 		fw_c2h_sts->tfsts.tf_user_sts[i].minflag_per =
 			GET_FIELD(val, FWCMD_C2H_OFDMA_STS_TFSTS_MINFLAG_PER);
-		fw_c2h_sts->tfsts.tf_user_sts[i].avg_tb_evm =
 		val = le32_to_cpu(*(content++));
+		fw_c2h_sts->tfsts.tf_user_sts[i].avg_tb_evm =
 			GET_FIELD(val, FWCMD_C2H_OFDMA_STS_TFSTS_AVG_TB_EVM);
 		fw_c2h_sts->tfsts.tf_user_sts[i].tf_num =
 			GET_FIELD(val, FWCMD_C2H_OFDMA_STS_TFSTS_TF_NUM);

--- a/phl/hal_g6/phy/bb/halbb_ch_info.c
+++ b/phl/hal_g6/phy/bb/halbb_ch_info.c
@@ -123,21 +123,6 @@ static void halbb_ch_info_cr_dump(struct bb_info *bb)
 		 cur_cfg->ch_i_ele_bitmap, cur_cfg->ch_i_type, cur_cfg->ch_i_seg_len);
 }
 
-static void halbb_ch_info_physts_get_buf(struct bb_info *bb, u8 *rpt_buf,
-				 struct bb_ch_rpt_hdr_info *hdr,
-				 struct bb_phy_info_rpt *phy_info,
-				 struct bb_ch_info_drv_rpt *drv)
-{
-	struct bb_ch_rpt_info *ch_rpt = &bb->bb_ch_rpt_i;
-	struct bb_ch_info_physts_info *ch_physts = &ch_rpt->bb_ch_info_physts_i;
-	struct bb_ch_info_raw_info *buf = &ch_rpt->bb_ch_info_raw_i;
-
-	drv->get_ch_rpt_success = ch_physts->get_ch_rpt_success;
-	drv->seg_idx_curr = 0;
-	drv->raw_data_len = ch_physts->ch_info_len;
-	rpt_buf = (u8*)buf->octet;
-}
-
 static void halbb_ch_info_print(struct bb_info *bb, char input[][16], u32 *_used,
 			 char *output, u32 *_out_len)
 {

--- a/phl/hal_g6/phy/bb/halbb_psd.c
+++ b/phl/hal_g6/phy/bb/halbb_psd.c
@@ -500,14 +500,14 @@ void halbb_psd_deinit(struct bb_info *bb)
 		halbb_mem_free(bb, psd->rpt, sizeof(psd->rpt));
 }
 
-bool halbb_get_psd_result(struct bb_info *bb, u32 *psd_data, u16 *psd_len)
+bool halbb_get_psd_result(struct bb_info *bb, u32 **psd_data, u16 *psd_len)
 {
 	struct bb_psd_info *psd = &bb->bb_cmn_hooker->bb_psd_i;
 
 	if (!psd->rpt)
 		return false;
 
-	psd_data = psd->rpt;
+	*psd_data = psd->rpt;
 	*psd_len = psd->fft_point;
 	return true;
 }

--- a/phl/hal_g6/phy/bb/halbb_psd.h
+++ b/phl/hal_g6/phy/bb/halbb_psd.h
@@ -109,7 +109,7 @@ void halbb_psd_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 		   char *output, u32 *_out_len);
 void halbb_psd_init(struct bb_info *bb);
 void halbb_psd_deinit(struct bb_info *bb);
-bool halbb_get_psd_result(struct bb_info *bb, u32 *psd_data, u16 *psd_len);
+bool halbb_get_psd_result(struct bb_info *bb, u32 **psd_data, u16 *psd_len);
 void halbb_cr_cfg_psd_init(struct bb_info *bb);
 #endif
 

--- a/phl/phl_scanofld.c
+++ b/phl/phl_scanofld.c
@@ -369,25 +369,6 @@ _cmd_scanofld_start(struct phl_info_t *phl_info,
                              band_idx);
 }
 
-static void
-_scanofld_get_scan_ch_info(struct phl_info_t *phl_info,
-			   struct rtw_phl_scan_param *param,
-			   enum band_type band,
-			   u8 chnl,
-			   struct phl_scan_channel *scan_ch)
-{
-	u8 i = 0;
-
-	for (i = 0; i < param->ch_num; i++) {
-		if (param->ch[i].band == band && param->ch[i].channel == chnl) {
-			scan_ch = &param->ch[i];
-			return;
-		}
-	}
-
-	scan_ch = NULL;
-}
-
 enum phl_mdl_ret_code
 phl_cmd_scanofld_hdl_internal_evt(void* dispr,
 			       void* priv,


### PR DESCRIPTION
Closes the small-class warning tail after #7/#10: `-Wunused-label` 12 -> 0, `-Wunused-value` 4 -> 0, `-Wrestrict` 1 -> 0, `-Wunused-but-set-parameter` 4 -> 0, `-Wold-style-declaration` 1 -> 0.

Five warnings were real defects: `set_delay_tx_cfg()` discarded the `SET_CLR_WORD()` result so the delay-tx band-select field was never written; `avg_tb_evm` was assigned the raw dword due to a misplaced line; `==` instead of `=` (plus a deref before the NULL check) in `rtw_efuse_mask_file_load()`; `for (i <=0 ;)` comparing instead of initializing; and a self-overlapping `sprintf` (UB) in `mp_query_psd()`.

Two dead static functions whose only output was a by-value pointer assignment are removed; `halbb_get_psd_result()` now takes `u32 **` per its evident intent.

Verified with kernel 7.1 (rockchip64 config): target classes 22 -> 0, all other warning classes bit-identical, 0 errors.
