### PR TITLE
Fix mixed-enum usage outside h2cb_alloc (-Wenum-conversion 143 -> 116)

### DIFF
--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -7296,13 +7296,13 @@ static enum phl_mdl_ret_code _ap_add_del_sta_req_acquired(void *dispr, void *pri
 	if (!add_del_sta_obj) {
 		RTW_ERR(FUNC_ADPT_FMT": add_del_sta_obj is null\n",
 			FUNC_ADPT_ARG(padapter));
-			return status;
+			return MDL_RET_FAIL;
 	}
 
 	psta = add_del_sta_obj->sta;
 	if (!psta) {
 		RTW_ERR(FUNC_ADPT_FMT": psta is null\n", FUNC_ADPT_ARG(padapter));
-		return status;
+		return MDL_RET_FAIL;
 	}
 
 	RTW_INFO(FUNC_ADPT_FMT ": %s STA\n",
@@ -7319,7 +7319,7 @@ static enum phl_mdl_ret_code _ap_add_del_sta_req_acquired(void *dispr, void *pri
 
 	RTW_DBG(FUNC_ADPT_FMT ": -\n", FUNC_ADPT_ARG(padapter));
 
-	return status;
+	return status == RTW_PHL_STATUS_SUCCESS ? MDL_RET_SUCCESS : MDL_RET_FAIL;
 
 }
 
@@ -7522,7 +7522,7 @@ free_token:
 
 	_ap_add_del_sta_cmd_done(padapter); /* free token */
 	_rtw_spinunlock_bh(&padapter->ap_add_del_sta_lock);
-	return status;
+	return status == RTW_PHL_STATUS_SUCCESS ? MDL_RET_SUCCESS : MDL_RET_FAIL;
 }
 
 static enum phl_mdl_ret_code _ap_add_del_sta_req_set_info(void *dispr, void *priv, struct phl_module_op_info* info)

--- a/core/rtw_chplan.c
+++ b/core/rtw_chplan.c
@@ -608,7 +608,7 @@ exit:
 	return buf;
 }
 
-static enum rtw_edcca_mode rtw_edcca_mode_get_strictest(enum rtw_edcca_mode_t a, enum rtw_edcca_mode_t b)
+static enum rtw_edcca_mode_t rtw_edcca_mode_get_strictest(enum rtw_edcca_mode_t a, enum rtw_edcca_mode_t b)
 {
 	if (a >= RTW_EDCCA_MODE_NUM)
 		return b < RTW_EDCCA_MODE_NUM ? b : RTW_EDCCA_MODE_NUM;

--- a/phl/hal_g6/hal_api_mac.c
+++ b/phl/hal_g6/hal_api_mac.c
@@ -552,7 +552,7 @@ rtw_hal_mac_dbcc_hci_ctrl(struct hal_info_t *hal_info, enum phl_band_idx band_id
 	struct mac_ax_dbcc_hci_ctrl info = {0};
 	u32 ret = 0;
 
-	info.band = band_idx;
+	info.band = (enum mac_ax_band)band_idx;
 	info.pause = pause; /*1: flush mode enabled, 0: flush mode disabled */
 	//info.u.usb_ctrl.rsvd;
 
@@ -573,7 +573,7 @@ rtw_hal_mac_dbcc_hci_ctrl(struct hal_info_t *hal_info, enum phl_band_idx band_id
 	struct mac_ax_dbcc_hci_ctrl info = {0};
 	u32 ret = 0;
 
-	info.band = band_idx;
+	info.band = (enum mac_ax_band)band_idx;
 	info.pause = pause;
 	//info.u.sdio_ctrl.rsvd;
 
@@ -3141,7 +3141,7 @@ rtw_hal_mac_lv1_rcvy(struct hal_info_t *hal_info, enum rtw_phl_ser_lv1_recv_step
 	u32 mac_err = 0;
 	struct mac_ax_adapter *mac = hal_to_mac(hal_info);
 
-	mac_err = mac->ops->lv1_rcvy(mac, step);
+	mac_err = mac->ops->lv1_rcvy(mac, (enum mac_ax_lv1_rcvy_step)step);
 	if (mac_err != MACSUCCESS) {
 		PHL_ERR("%s : mac status %d.\n", __func__, mac_err);
 		return RTW_HAL_STATUS_FAILURE;
@@ -7009,9 +7009,9 @@ rtw_hal_mac_lps_cfg(struct hal_info_t *hal_info,
 		ax_ps_mode = MAC_AX_PS_MODE_ACTIVE;
 	}
 
-	ax_lps_info.listen_bcn_mode = lps_info->listen_bcn_mode;
+	ax_lps_info.listen_bcn_mode = (enum mac_ax_listern_bcn_mode)lps_info->listen_bcn_mode;
 	ax_lps_info.awake_interval = lps_info->awake_interval;
-	ax_lps_info.smart_ps_mode = lps_info->smart_ps_mode;
+	ax_lps_info.smart_ps_mode = (enum mac_ax_smart_ps_mode)lps_info->smart_ps_mode;
 	ax_lps_info.bcnnohit_en = lps_info->bcnnohit_en;
 
 	if (mac->ops->cfg_lps(mac, (u8)lps_info->macid, ax_ps_mode,

--- a/phl/hal_g6/phy/bb/halbb_env_mntr.c
+++ b/phl/hal_g6/phy/bb/halbb_env_mntr.c
@@ -1459,7 +1459,7 @@ static void halbb_clm_init(struct bb_info *bb)
 	if (bb->ic_type & BB_IC_AX_SERIES)
 		env->clm_input_opt = CLM_CCA_INIT;
 	else
-		env->clm_input_opt = BE_CLM_CCA_INIT;
+		env->clm_input_opt = (enum clm_opt_input)BE_CLM_CCA_INIT;
 
 	if ((bb->ic_type != BB_RTL8852A) && (bb->ic_type != BB_RTL8852B) &&
 	    (bb->ic_type != BB_RTL8851B)) {
@@ -1556,7 +1556,7 @@ void halbb_clm_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 			if (bb->ic_type & BB_IC_AX_SERIES)
 				para.clm_input_opt = CLM_CCA_S80_S40_S20;
 			else
-				para.clm_input_opt = BE_CLM_CCA_S160_S80_S40_S20;
+				para.clm_input_opt = (enum clm_opt_input)BE_CLM_CCA_S160_S80_S40_S20;
 
 			if ((bb->ic_type != BB_RTL8852A) &&
 			    (bb->ic_type != BB_RTL8852B) &&
@@ -1569,7 +1569,7 @@ void halbb_clm_dbg(struct bb_info *bb, char input[][16], u32 *_used,
 			if (bb->ic_type & BB_IC_AX_SERIES)
 				para.clm_input_opt = (enum clm_opt_input)var[2];
 			else
-				para.clm_input_opt = (enum be_clm_opt_input)var[2];
+				para.clm_input_opt = (enum clm_opt_input)(enum be_clm_opt_input)var[2];
 
 			if ((bb->ic_type != BB_RTL8852A) &&
 			    (bb->ic_type != BB_RTL8852B) &&
@@ -3795,7 +3795,7 @@ void halbb_env_mntr(struct bb_info *bb)
 		if (bb->ic_type & BB_IC_AX_SERIES)
 			para.clm_input_opt = CLM_CCA_S80_S40_S20;
 		else
-			para.clm_input_opt = BE_CLM_CCA_S160_S80_S40_S20;
+			para.clm_input_opt = (enum clm_opt_input)BE_CLM_CCA_S160_S80_S40_S20;
 
 		para.nhm_app = NHM_BACKGROUND;
 		para.nhm_incld_cca = NHM_EXCLUDE_CCA;
@@ -4198,7 +4198,7 @@ static void halbb_env_mntr_dbg_trigger(struct bb_info *bb, u32 *_used, char *out
 	if (bb->ic_type & BB_IC_AX_SERIES)
 		para.clm_input_opt = CLM_CCA_S80_S40_S20;
 	else
-		para.clm_input_opt = BE_CLM_CCA_S160_S80_S40_S20;
+		para.clm_input_opt = (enum clm_opt_input)BE_CLM_CCA_S160_S80_S40_S20;
 
 	/*nhm para*/
 	para.nhm_app = NHM_DBG_11K;

--- a/phl/hal_g6/phy/bb/halbb_path_div.c
+++ b/phl/hal_g6/phy/bb/halbb_path_div.c
@@ -125,6 +125,7 @@ void halbb_set_tx_path_by_cmac_tbl(struct bb_info *bb, u8 macid, enum bb_path tx
 {
 	struct bb_pathdiv_info *bb_path_div = &bb->bb_path_div_i;
 	enum bb_path tx_path_sel = tx_path_sel_1ss;
+	enum rf_path tx_rf_path;
 	enum rtw_hal_status hal_status = RTW_HAL_STATUS_FAILURE;
 	u16 cfg = 0;
 
@@ -143,8 +144,8 @@ void halbb_set_tx_path_by_cmac_tbl(struct bb_info *bb, u8 macid, enum bb_path tx
 	BB_DBG(bb, DBG_PATH_DIV, "STA[%d] : path_sel= [%s]\n", macid,
 	       (tx_path_sel == BB_PATH_A) ? "A" : "B");
 	/*BB_PATH != RF_PATH*/
-	tx_path_sel = (tx_path_sel == BB_PATH_A) ? RF_PATH_A : RF_PATH_B;
-	cfg = halbb_cfg_cmac_tx_ant(bb, (enum rf_path)tx_path_sel);
+	tx_rf_path = (tx_path_sel == BB_PATH_A) ? RF_PATH_A : RF_PATH_B;
+	cfg = halbb_cfg_cmac_tx_ant(bb, tx_rf_path);
 
 	halbb_set_cctrl_tbl(bb, macid, cfg);
 

--- a/phl/hal_g6/phy/bb/halbb_psd.c
+++ b/phl/hal_g6/phy/bb/halbb_psd.c
@@ -297,11 +297,11 @@ u8 halbb_psd(struct bb_info *bb, enum igi_lv_sel igi_lv, u16 start_point,
 		BB_DBG(bb, DBG_DBG_API, "rtw_hal_rf_set_ch_bw PHY01 fail!\n");
 		return HALBB_SET_FAIL;
 	}
-	if(rtw_hal_rf_chl_rfk_trigger(hal_com, HW_PHY_0, true) != RTW_HAL_STATUS_SUCCESS) {
+	if(rtw_hal_rf_chl_rfk_trigger(hal_com, HW_PHY_0, RFK_TYPE_FORCE_DO) != RTW_HAL_STATUS_SUCCESS) {
 		BB_DBG(bb, DBG_DBG_API, "rtw_hal_rf_chl_rfk_trigger PHY0 fail!\n");
 		return HALBB_SET_FAIL;
 	}
-	if(rtw_hal_rf_chl_rfk_trigger(hal_com, HW_PHY_1, true) != RTW_HAL_STATUS_SUCCESS) {
+	if(rtw_hal_rf_chl_rfk_trigger(hal_com, HW_PHY_1, RFK_TYPE_FORCE_DO) != RTW_HAL_STATUS_SUCCESS) {
 		BB_DBG(bb, DBG_DBG_API, "rtw_hal_rf_chl_rfk_trigger PHY1 fail!\n");
 		return HALBB_SET_FAIL;
 	}

--- a/phl/hal_g6/phy/bb/halbb_pwr_ctrl.c
+++ b/phl/hal_g6/phy/bb/halbb_pwr_ctrl.c
@@ -174,7 +174,7 @@ void halbb_set_pwr_macid_idx(struct bb_info *bb, u16 macid, s8 pwr, bool pwr_en,
 	}
 	
 	/* phy idx is one to one mapping to mac hw band idx */
-	hw_band = bb->bb_phy_idx;
+	hw_band = (enum phl_band_idx)bb->bb_phy_idx;
 	/* pwr : S(8,1)*/
 	ret_v |= rtw_hal_mac_write_msk_pwr_reg(bb->hal_com, hw_band, reg_ofst, mask_pwr, pwr);
 	ret_v |= rtw_hal_mac_write_msk_pwr_reg(bb->hal_com, hw_band, reg_ofst, mask_en, pwr_en);

--- a/phl/hal_g6/phy/bb/halbb_ra.c
+++ b/phl/hal_g6/phy/bb/halbb_ra.c
@@ -568,7 +568,7 @@ static bool halbb_set_csi_rate(struct bb_info *bb, struct rtw_phl_stainfo_t *phl
 	ra_cfg->cr_tbl_sel = bb->hal_com->csi_para_ctrl_sel;
 	ra_cfg->band_num = phl_sta_i->rlink->hw_band;
 	ra_cfg->fixed_csi_rate_l = halbb_ss_mcs_2_mcs_ss_idx(bb,
-							     ra_sta_i->csi_rate.mode,
+							     (enum bb_mode_type)ra_sta_i->csi_rate.mode,
 							     ra_sta_i->csi_rate.ss,
 							     ra_sta_i->csi_rate.mcs_idx);
 

--- a/phl/hal_g6/phy/rf/halrf_dbg.c
+++ b/phl/hal_g6/phy/rf/halrf_dbg.c
@@ -2601,7 +2601,7 @@ void halrf_rfk_dbg_cmd(struct rf_info *rf, char input[][16], u32 *_used,
 		_os_sscanf(input[2], "%d", &val);
 		if (val >= HW_PHY_MAX)
 			val = HW_PHY_0;
-		halrf_chl_rfk_trigger(rf, val, true);
+		halrf_chl_rfk_trigger(rf, val, RFK_TYPE_FORCE_DO);
 		RF_DBG_CNSL(*_out_len, *_used, output + *_used, *_out_len - *_used,
 			 "RFK Trigger End !!!\n");
 	} else

--- a/phl/phl_ps.c
+++ b/phl/phl_ps.c
@@ -309,7 +309,7 @@ phl_ps_cfg_pwr_lvl(struct phl_info_t *phl_info, u8 ps_mode, u8 cur_pwr_lvl, u8 r
 
 	if (cur_pwr_lvl == req_pwr_lvl) {
 		PHL_TRACE(COMP_PHL_PS, _PHL_WARNING_, "[PS], %s(): pwr lvl is not change!\n", __func__);
-		return RTW_HAL_STATUS_SUCCESS;
+		return RTW_PHL_STATUS_SUCCESS;
 	}
 
 	_ps_ntfy_before_pwr_cfg(phl_info, ps_mode, cur_pwr_lvl, req_pwr_lvl);
@@ -432,7 +432,8 @@ phl_ps_ips_cfg(struct phl_info_t *phl_info, struct ps_cfg *cfg, u8 en)
 	ips_info.en = en;
 	ips_info.macid = cfg->macid;
 
-	return rtw_hal_ps_ips_cfg(phl_info->hal, &ips_info);
+	return rtw_hal_ps_ips_cfg(phl_info->hal, &ips_info) ==
+	       RTW_HAL_STATUS_SUCCESS ? RTW_PHL_STATUS_SUCCESS : RTW_PHL_STATUS_FAILURE;
 }
 
 enum rtw_phl_status

--- a/phl/phl_sta.c
+++ b/phl/phl_sta.c
@@ -4873,7 +4873,8 @@ enum rtw_phl_status
 phl_cmd_set_seciv_hdl(struct phl_info_t *phl_info, u8 *param)
 {
 	struct rtw_phl_stainfo_t *sta = (struct rtw_phl_stainfo_t *)param;
-	return rtw_hal_set_dctrl_tbl_seciv((void *)phl_info->hal, sta, sta->sec_iv);
+	return rtw_hal_set_dctrl_tbl_seciv((void *)phl_info->hal, sta, sta->sec_iv) ==
+	       RTW_HAL_STATUS_SUCCESS ? RTW_PHL_STATUS_SUCCESS : RTW_PHL_STATUS_FAILURE;
 }
 #endif
 

--- a/phl/phl_tx.c
+++ b/phl/phl_tx.c
@@ -2993,7 +2993,8 @@ phl_cmd_cfg_hw_seq_hdl(struct phl_info_t *phl_info, u8 *param)
 
 	PHL_INFO(" %s(), sta = %p !\n", __func__, sta);
 
-	return rtw_hal_set_dctrl_tbl_seq((void *)phl_info->hal, sta, sta->hw_seq);
+	return rtw_hal_set_dctrl_tbl_seq((void *)phl_info->hal, sta, sta->hw_seq) ==
+	       RTW_HAL_STATUS_SUCCESS ? RTW_PHL_STATUS_SUCCESS : RTW_PHL_STATUS_FAILURE;
 }
 #endif
 

--- a/phl/test/phl_dbg_cmd.c
+++ b/phl/test/phl_dbg_cmd.c
@@ -296,7 +296,7 @@ _phl_dbg_cmd_switch_chbw(struct phl_info_t *phl_info, char input[][MAX_ARGV],
 		chdef.bw = (enum channel_width)bw;
 		chdef.offset = (enum chan_offset)offset;
 
-		rtw_hal_set_ch_bw(phl_info->hal, (u8)band_idx, &chdef, false, false, false);
+		rtw_hal_set_ch_bw(phl_info->hal, (u8)band_idx, &chdef, RFK_TYPE_FORCE_NOT_DO, false, false);
 
 	} while (0);
 }


### PR DESCRIPTION
Fixes the 27 `-Wenum-conversion` warnings not caused by the `h2cb_alloc` prototype (those 116 are addressed by #12; together the class reaches 0).

Semantic fixes: hal→phl and phl→mdl_ret_code status returns converted with the SUCCESS-check ternary already used in `phl_txpwr.c` (the enum values diverge — e.g. `RTW_HAL_STATUS_TIMEOUT` would read as `RTW_PHL_STATUS_SH_TASK`, `RTW_PHL_STATUS_RESOURCE` as `MDL_RET_IGNORE`); a return-type typo in `rtw_edcca_mode_get_strictest()` (unrelated non-`_t` enum); `true`/`false` passed into `enum rfk_tri_type` parameters replaced with the named `RFK_TYPE_*` constants; `halbb_path_div.c` reused a `bb_path` variable for `rf_path` values — now a dedicated variable.

The rest are value-preserving explicit casts between 1:1 mirror enums (4 pairs in `hal_api_mac.c`, the deliberately dual-domain `clm_input_opt` field, `hal_rate_mode`→`bb_mode_type`, `phl_phy_idx`→`phl_band_idx`).

Verified with kernel 7.1 (rockchip64 config): `-Wenum-conversion` 143 → 116, all remaining are the `h2c_buf_class`/`rtw_h2c_pkt_type` pair; every other warning class bit-identical; 0 errors.
