### PR TITLE
rtw_proc: reject unparsable input in three write handlers

### DIFF
--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -1280,6 +1280,9 @@ static ssize_t proc_set_false_alarm_accumulated(struct file *file,
 
 	if (buffer && !copy_from_user(tmp, buffer, count)) {
 		u32 num = sscanf(tmp, "%u ", &false_clr);
+
+		if (num != 1)
+			return -EINVAL;
 		ATOMIC_SET((ATOMIC_T *)&dvobj->fa_cnt_acc[hw_band],
 			   (int)false_clr);
 	} else {
@@ -2479,6 +2482,8 @@ static ssize_t proc_set_rx_chk_limit(struct file *file, const char __user *buffe
 	if (buffer && !copy_from_user(tmp, buffer, count)) {
 		int num = sscanf(tmp, "%d", &rx_chk_limit);
 
+		if (num != 1)
+			return -EINVAL;
 		rtw_set_rx_chk_limit(padapter, rx_chk_limit);
 	}
 
@@ -4641,6 +4646,8 @@ static ssize_t proc_set_amsdu_mode(struct file *file, const char __user *buffer,
 
 		int num = sscanf(tmp, "%d", &mode);
 
+		if (num != 1)
+			return -EINVAL;
 		if (mode == RTW_AMSDU_MODE_NON_SPP
 			|| mode == RTW_AMSDU_MODE_SPP
 			|| mode == RTW_AMSDU_MODE_ALL_DROP) {


### PR DESCRIPTION
`proc_set_false_alarm_clear()`, `proc_set_rx_chk_limit()` and `proc_set_amsdu_mode()` stored the `sscanf()` result in `num` and never looked at it, then used the parsed variable regardless — on malformed input that's an uninitialised value going into `fa_cnt_acc`, the rx check limit or the amsdu mode. Check for exactly one conversion like the other handlers in this file and return `-EINVAL` otherwise. Also removes the last three non-debug `-Wunused-variable` warnings (48 → 45, DEBUG=n, 7.1.7).