### PR TITLE
Fix -Warray-bounds, -Wformat-truncation and -Wframe-larger-than (73/8/2 -> 0)

### DIFF
--- a/core/rtw_chplan.h
+++ b/core/rtw_chplan.h
@@ -456,7 +456,7 @@ struct get_chplan_resp {
 	struct chplan_confs confs;
 
 	u8 chs_len;
-	RT_CHANNEL_INFO chs[0];
+	RT_CHANNEL_INFO chs[];
 };
 
 struct get_channel_plan_param {

--- a/core/rtw_rf.c
+++ b/core/rtw_rf.c
@@ -2169,22 +2169,22 @@ exit:
 */
 void txpwr_idx_get_dbm_str(s8 idx, u8 txgi_max, s8 txgi_ww, u8 txgi_pdbm, SIZE_T cwidth, char dbm_str[], u8 dbm_str_len)
 {
-	char fmt[16];
+	char fmt[32];
 
 	if (idx == txgi_max) {
-		snprintf(fmt, 16, "%%%zus", cwidth >= 6 ? cwidth + 1 : 6);
+		snprintf(fmt, sizeof(fmt), "%%%zus", cwidth >= 6 ? cwidth + 1 : 6);
 		snprintf(dbm_str, dbm_str_len, fmt, "NA");
 	} else if (idx == txgi_ww) {
-		snprintf(fmt, 16, "%%%zus", cwidth >= 6 ? cwidth + 1 : 6);
+		snprintf(fmt, sizeof(fmt), "%%%zus", cwidth >= 6 ? cwidth + 1 : 6);
 		snprintf(dbm_str, dbm_str_len, fmt, "WW");
 	} else if (idx > -txgi_pdbm && idx < 0) { /* -0.xx */
-		snprintf(fmt, 16, "%%%zus-0.%%02d", cwidth >= 6 ? cwidth - 4 : 1);
+		snprintf(fmt, sizeof(fmt), "%%%zus-0.%%02d", cwidth >= 6 ? cwidth - 4 : 1);
 		snprintf(dbm_str, dbm_str_len, fmt, "", (rtw_abs(idx) % txgi_pdbm) * 100 / txgi_pdbm);
 	} else if (idx % txgi_pdbm) { /* d.xx */
-		snprintf(fmt, 16, "%%%zud.%%02d", cwidth >= 6 ? cwidth - 2 : 3);
+		snprintf(fmt, sizeof(fmt), "%%%zud.%%02d", cwidth >= 6 ? cwidth - 2 : 3);
 		snprintf(dbm_str, dbm_str_len, fmt, idx / txgi_pdbm, (rtw_abs(idx) % txgi_pdbm) * 100 / txgi_pdbm);
 	} else { /* d */
-		snprintf(fmt, 16, "%%%zud", cwidth >= 6 ? cwidth + 1 : 6);
+		snprintf(fmt, sizeof(fmt), "%%%zud", cwidth >= 6 ? cwidth + 1 : 6);
 		snprintf(dbm_str, dbm_str_len, fmt, idx / txgi_pdbm);
 	}
 }
@@ -2195,19 +2195,19 @@ void txpwr_idx_get_dbm_str(s8 idx, u8 txgi_max, s8 txgi_ww, u8 txgi_pdbm, SIZE_T
 */
 void txpwr_mbm_get_dbm_str(s16 mbm, SIZE_T cwidth, char dbm_str[], u8 dbm_str_len)
 {
-	char fmt[16];
+	char fmt[32];
 
 	if (mbm == UNSPECIFIED_MBM) {
-		snprintf(fmt, 16, "%%%zus", cwidth >= 6 ? cwidth + 1 : 6);
+		snprintf(fmt, sizeof(fmt), "%%%zus", cwidth >= 6 ? cwidth + 1 : 6);
 		snprintf(dbm_str, dbm_str_len, fmt, "NA");
 	} else if (mbm > -MBM_PDBM && mbm < 0) { /* -0.xx */
-		snprintf(fmt, 16, "%%%zus-0.%%02d", cwidth >= 6 ? cwidth - 4 : 1);
+		snprintf(fmt, sizeof(fmt), "%%%zus-0.%%02d", cwidth >= 6 ? cwidth - 4 : 1);
 		snprintf(dbm_str, dbm_str_len, fmt, "", (rtw_abs(mbm) % MBM_PDBM) * 100 / MBM_PDBM);
 	} else if (mbm % MBM_PDBM) { /* d.xx */
-		snprintf(fmt, 16, "%%%zud.%%02d", cwidth >= 6 ? cwidth - 2 : 3);
+		snprintf(fmt, sizeof(fmt), "%%%zud.%%02d", cwidth >= 6 ? cwidth - 2 : 3);
 		snprintf(dbm_str, dbm_str_len, fmt, mbm / MBM_PDBM, (rtw_abs(mbm) % MBM_PDBM) * 100 / MBM_PDBM);
 	} else { /* d */
-		snprintf(fmt, 16, "%%%zud", cwidth >= 6 ? cwidth + 1 : 6);
+		snprintf(fmt, sizeof(fmt), "%%%zud", cwidth >= 6 ? cwidth + 1 : 6);
 		snprintf(dbm_str, dbm_str_len, fmt, mbm / MBM_PDBM);
 	}
 }

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -5672,6 +5672,7 @@ void rtw_alloc_hwxmits(_adapter *padapter)
 
 	hwxmits = pxmitpriv->hwxmits;
 
+#if HWXMIT_ENTRY == 5
 	if (pxmitpriv->hwxmit_entry == 5) {
 		/* pxmitpriv->bmc_txqueue.head = 0; */
 		/* hwxmits[0] .phwtxqueue = &pxmitpriv->bmc_txqueue; */
@@ -5693,7 +5694,9 @@ void rtw_alloc_hwxmits(_adapter *padapter)
 		/* hwxmits[4] .phwtxqueue = &pxmitpriv->be_txqueue; */
 		hwxmits[4] .sta_queue = &pxmitpriv->be_pending;
 
-	} else if (pxmitpriv->hwxmit_entry == 4) {
+	} else
+#endif
+	if (pxmitpriv->hwxmit_entry == 4) {
 
 		/* pxmitpriv->vo_txqueue.head = 0; */
 		/* hwxmits[0] .phwtxqueue = &pxmitpriv->vo_txqueue; */

--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -265,7 +265,7 @@ typedef struct ieee_param {
 		struct {
 			u32 len;
 			u8 reserved[32];
-			u8 data[0];
+			u8 data[];
 		} wpa_ie;
 		struct {
 			int command;
@@ -278,7 +278,7 @@ typedef struct ieee_param {
 			u8 idx;
 			u8 seq[8]; /* sequence counter (set: RX, get: TX) */
 			u16 key_len;
-			u8 key[0];
+			u8 key[];
 		} crypt;
 #ifdef CONFIG_AP_MODE
 		struct {
@@ -290,7 +290,7 @@ typedef struct ieee_param {
 		} add_sta;
 		struct {
 			u8	reserved[2];/* for set max_num_sta */
-			u8	buf[0];
+			u8	buf[];
 		} bcn_ie;
 #endif
 
@@ -301,7 +301,7 @@ typedef struct ieee_param {
 typedef struct ieee_param_ex {
 	u32 cmd;
 	u8 sta_addr[ETH_ALEN];
-	u8 data[0];
+	u8 data[];
 } ieee_param_ex;
 
 struct sta_data {
@@ -1252,7 +1252,7 @@ struct ieee80211_info_element_hdr {
 struct ieee80211_info_element {
 	u8 id;
 	u8 len;
-	u8 data[0];
+	u8 data[];
 } __attribute__((packed));
 #endif
 

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -646,7 +646,7 @@ struct rtw_cbuf {
 	u32 write;
 	u32 read;
 	u32 size;
-	void *bufs[0];
+	void *bufs[];
 };
 
 bool rtw_cbuf_full(struct rtw_cbuf *cbuf);

--- a/include/wlan_bssdef.h
+++ b/include/wlan_bssdef.h
@@ -66,7 +66,7 @@ typedef struct _NDIS_802_11_FIXED_IEs {
 typedef struct _NDIS_802_11_VARIABLE_IEs {
 	u8  ElementID;
 	u8  Length;
-	u8  data[1];
+	u8  data[];
 } NDIS_802_11_VARIABLE_IEs, *PNDIS_802_11_VARIABLE_IEs;
 
 typedef enum _NDIS_802_11_AUTHENTICATION_MODE {
@@ -151,7 +151,7 @@ typedef struct _NDIS_802_11_FIXED_IEs {
 typedef struct _NDIS_802_11_VARIABLE_IEs {
 	u8  ElementID;
 	u8  Length;
-	u8  data[1];
+	u8  data[];
 } NDIS_802_11_VARIABLE_IEs, *PNDIS_802_11_VARIABLE_IEs;
 
 typedef enum _NDIS_802_11_AUTHENTICATION_MODE {

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4329,13 +4329,11 @@ static int rtw_set_security(struct _ADAPTER *a,
 			return -EINVAL;
 		wep_key_len = wep_key_len <= 5 ? 5 : 13;
 		wep_total_len = wep_key_len + FIELD_OFFSET(NDIS_802_11_WEP, KeyMaterial);
-		pwep = (NDIS_802_11_WEP *) rtw_malloc(wep_total_len);
+		pwep = (NDIS_802_11_WEP *) rtw_zmalloc(sizeof(*pwep));
 		if (pwep == NULL) {
 			RTW_INFO(" wpa_set_encryption: pwep allocate fail !!!\n");
 			return -ENOMEM;
 		}
-
-		_rtw_memset(pwep, 0, wep_total_len);
 
 		pwep->KeyLength = wep_key_len;
 		pwep->Length = wep_total_len;
@@ -4354,7 +4352,7 @@ static int rtw_set_security(struct _ADAPTER *a,
 			ret = -EOPNOTSUPP ;
 
 		if (pwep)
-			rtw_mfree((u8 *)pwep, wep_total_len);
+			rtw_mfree((u8 *)pwep, sizeof(*pwep));
 
 		if (ret < 0)
 			return ret;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -977,7 +977,7 @@ void rtw_cfg80211_indicate_connect(_adapter *padapter)
 	struct wireless_dev *pwdev = padapter->rtw_wdev;
 	struct rtw_wdev_priv *pwdev_priv = adapter_wdev_data(padapter);
 #if defined(CPTCFG_VERSION) || LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
-	struct cfg80211_roam_info roam_info ={};
+	struct cfg80211_roam_info *roam_info;
 #endif
 
 	RTW_INFO(FUNC_ADPT_FMT"\n", FUNC_ADPT_ARG(padapter));
@@ -1037,17 +1037,23 @@ check_bss:
 		#endif
 
 		#if defined(CPTCFG_VERSION) || LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
-		#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0)
-		roam_info.links[0].bssid = cur_network->network.MacAddress;
-		#else
-		roam_info.bssid = cur_network->network.MacAddress;
-		#endif
-		roam_info.req_ie = pmlmepriv->assoc_req + sizeof(struct rtw_ieee80211_hdr_3addr) + 2;
-		roam_info.req_ie_len = pmlmepriv->assoc_req_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 2;
-		roam_info.resp_ie = pmlmepriv->assoc_rsp + sizeof(struct rtw_ieee80211_hdr_3addr) + 6;
-		roam_info.resp_ie_len = pmlmepriv->assoc_rsp_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 6;
+		/* too large for the stack on recent kernels; may run under a bh-disabled lock */
+		roam_info = kzalloc(sizeof(*roam_info), GFP_ATOMIC);
+		if (roam_info) {
+			#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0)
+			roam_info->links[0].bssid = cur_network->network.MacAddress;
+			#else
+			roam_info->bssid = cur_network->network.MacAddress;
+			#endif
+			roam_info->req_ie = pmlmepriv->assoc_req + sizeof(struct rtw_ieee80211_hdr_3addr) + 2;
+			roam_info->req_ie_len = pmlmepriv->assoc_req_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 2;
+			roam_info->resp_ie = pmlmepriv->assoc_rsp + sizeof(struct rtw_ieee80211_hdr_3addr) + 6;
+			roam_info->resp_ie_len = pmlmepriv->assoc_rsp_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 6;
 
-		cfg80211_roamed(padapter->pnetdev, &roam_info, GFP_ATOMIC);
+			cfg80211_roamed(padapter->pnetdev, roam_info, GFP_ATOMIC);
+			kfree(roam_info);
+		} else
+			RTW_INFO(FUNC_ADPT_FMT" no memory for roam_info, roam not reported\n", FUNC_ADPT_ARG(padapter));
 		#else
 		cfg80211_roamed(padapter->pnetdev
 			#if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 39) || defined(COMPAT_KERNEL_RELEASE)

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -4720,13 +4720,11 @@ static int rtw_set_encryption(struct net_device *dev, struct ieee_param *param, 
 		if (wep_key_len > 0) {
 			wep_key_len = wep_key_len <= 5 ? 5 : 13;
 			wep_total_len = wep_key_len + FIELD_OFFSET(NDIS_802_11_WEP, KeyMaterial);
-			pwep = (NDIS_802_11_WEP *)rtw_malloc(wep_total_len);
+			pwep = (NDIS_802_11_WEP *)rtw_zmalloc(sizeof(*pwep));
 			if (pwep == NULL) {
 				RTW_INFO(" r871x_set_encryption: pwep allocate fail !!!\n");
 				goto exit;
 			}
-
-			_rtw_memset(pwep, 0, wep_total_len);
 
 			pwep->KeyLength = wep_key_len;
 			pwep->Length = wep_total_len;
@@ -4909,7 +4907,7 @@ static int rtw_set_encryption(struct net_device *dev, struct ieee_param *param, 
 exit:
 
 	if (pwep)
-		rtw_mfree((u8 *)pwep, wep_total_len);
+		rtw_mfree((u8 *)pwep, sizeof(*pwep));
 
 	return ret;
 

--- a/phl/hal_g6/phy/bb/halbb_cmn_rpt.c
+++ b/phl/hal_g6/phy/bb/halbb_cmn_rpt.c
@@ -556,9 +556,18 @@ static void halbb_basic_dbg_07_hist_su_per_path(struct bb_info *bb)
 	}
 
 	if (print_en) {
-		BB_DBG(bb, DBG_CMN, "[SNR path[A:D] = {%d, %d, %d, %d}\n", 
+#if HALBB_MAX_PATH > 3
+		BB_DBG(bb, DBG_CMN, "[SNR path[A:D] = {%d, %d, %d, %d}\n",
 		       avg->snr_per_path_avg[0], avg->snr_per_path_avg[1],
 		       avg->snr_per_path_avg[2], avg->snr_per_path_avg[3]);
+#elif HALBB_MAX_PATH > 2
+		BB_DBG(bb, DBG_CMN, "[SNR path[A:C] = {%d, %d, %d}\n",
+		       avg->snr_per_path_avg[0], avg->snr_per_path_avg[1],
+		       avg->snr_per_path_avg[2]);
+#else
+		BB_DBG(bb, DBG_CMN, "[SNR path[A:B] = {%d, %d}\n",
+		       avg->snr_per_path_avg[0], avg->snr_per_path_avg[1]);
+#endif
 	}
 }
 
@@ -1196,15 +1205,19 @@ static void halbb_rx_pkt_su_phy_hist_per_path(struct bb_info *bb, u32 physts_bit
 		//BB_DBG(bb, BIT14, "snr_acc[1](%d) += %d\n", acc->snr_per_path_acc[1], psts_r->snr_lgy);
 	}
 
+#if HALBB_MAX_PATH > 2
 	if (physts_bitmap & BIT(IE06_CMN_EXT_PATH_C)) {
 		psts_r = &physts->bb_physts_rslt_6_i;
 		acc->snr_per_path_acc[2] += psts_r->snr_lgy;
 	}
+#endif
 
+#if HALBB_MAX_PATH > 3
 	if (physts_bitmap & BIT(IE07_CMN_EXT_PATH_D)) {
 		psts_r = &physts->bb_physts_rslt_7_i;
 		acc->snr_per_path_acc[3] += psts_r->snr_lgy;
 	}
+#endif
 }
 
 static void halbb_rx_pkt_su_phy_hist(struct bb_info *bb)

--- a/phl/hal_g6/phy/bb/halbb_dbg_cnsl_out.c
+++ b/phl/hal_g6/phy/bb/halbb_dbg_cnsl_out.c
@@ -1785,7 +1785,7 @@ void halbb_basic_dbg_message_cnsl_dbg(struct bb_info *bb, char input[][16], u32 
 	struct bb_physts_info	*physts = &bb->bb_physts_i;
 	struct bb_cmn_dbg_info *cmn_dbg = &bb->bb_cmn_hooker->bb_cmn_dbg_i;
 	enum channel_width bw = bb->hal_com->band[bb->bb_phy_idx].cur_chandef.bw;
-	struct halbb_statistic_exp_t statistic_exp;
+	struct halbb_statistic_exp_t *statistic_exp;
 	u32 var[10] = {0};
 	bool dbg_en;
 	u8 fc = bb->hal_com->band[bb->bb_phy_idx].cur_chandef.center_ch;
@@ -1809,19 +1809,27 @@ void halbb_basic_dbg_message_cnsl_dbg(struct bb_info *bb, char input[][16], u32 
 		if (!dbg_en)
 			return;
 
-		halbb_statistic_exp(bb, &statistic_exp, bb->bb_phy_idx);
+		/* ~1.4 KB, too large for the stack */
+		statistic_exp = halbb_mem_alloc(bb, sizeof(*statistic_exp));
+		if (!statistic_exp) {
+			BB_DBG_CNSL(*_out_len, *_used, output + *_used, *_out_len - *_used,
+				    "no memory\n");
+			return;
+		}
+		halbb_statistic_exp(bb, statistic_exp, bb->bb_phy_idx);
 		BB_DBG_CNSL(*_out_len, *_used, output + *_used, *_out_len - *_used,
-			    "tx_rate=0x%x, tx_PER=%d\n", statistic_exp.tx_rate, statistic_exp.tx_per);
+			    "tx_rate=0x%x, tx_PER=%d\n", statistic_exp->tx_rate, statistic_exp->tx_per);
 		BB_DBG_CNSL(*_out_len, *_used, output + *_used, *_out_len - *_used,
-			    "pkt_cnt_ofdm=%d\n", statistic_exp.bb_pkt_cnt_exp.pkt_cnt_ofdm);
+			    "pkt_cnt_ofdm=%d\n", statistic_exp->bb_pkt_cnt_exp.pkt_cnt_ofdm);
 		BB_DBG_CNSL(*_out_len, *_used, output + *_used, *_out_len - *_used,
-			    "rssi_ofdm_avg=%d\n", statistic_exp.bb_rssi_su_avg_exp.rssi_ofdm_avg);
+			    "rssi_ofdm_avg=%d\n", statistic_exp->bb_rssi_su_avg_exp.rssi_ofdm_avg);
 		BB_DBG_CNSL(*_out_len, *_used, output + *_used, *_out_len - *_used,
-			    "evm_1ss=%d, evm_2ss={%d, %d}, SNR = %d\n", statistic_exp.evm_1ss,
-			    statistic_exp.evm_max, statistic_exp.evm_min, statistic_exp.snr_avg);
+			    "evm_1ss=%d, evm_2ss={%d, %d}, SNR = %d\n", statistic_exp->evm_1ss,
+			    statistic_exp->evm_max, statistic_exp->evm_min, statistic_exp->snr_avg);
 		BB_DBG_CNSL(*_out_len, *_used, output + *_used,
 			    *_out_len - *_used,
-			    "edcca_fb_pwdb=%d\n", statistic_exp.edcca_fb_pwdb);
+			    "edcca_fb_pwdb=%d\n", statistic_exp->edcca_fb_pwdb);
+		halbb_mem_free(bb, statistic_exp, sizeof(*statistic_exp));
 		return;
 	}
 

--- a/phl/hal_g6/phy/bb/halbb_rua_tbl.c
+++ b/phl/hal_g6/phy/bb/halbb_rua_tbl.c
@@ -1479,13 +1479,16 @@ u32 halbb_csiinfo_cfg(struct bb_info *bb, struct rtw_csiinfo_cfg *cfg)
 	// if (len != pkt_len)
 	//	 BB_WARNING("halbb_csiinfo_cfg: tble length mismatch!!\n");
 	csiinfo_i = hal_mem_alloc(bb->hal_com, pkt_len);
+	if (!csiinfo_i)
+		return ret;
 
 	bb_h2c = (u32 *) csiinfo_i;
 
 	csiinfo_i->macid = (u8)cfg->macid;
 	csiinfo_i->csi_info_bitmap = (u8)cfg->csi_info_bitmap;
 
-	BB_DBG(bb, DBG_RUA_TBL, "content %x %x %x \n", bb_h2c[0], bb_h2c[1], bb_h2c[2]);
+	/* struct csiinfo_cfg is a single u32 */
+	BB_DBG(bb, DBG_RUA_TBL, "content %x\n", bb_h2c[0]);
 	ret_v = halbb_fill_h2c_cmd(bb, pkt_len, RUA_H2C_CSIINFO, HALBB_H2C_RUA, bb_h2c);
 //out:
 	if (csiinfo_i)

--- a/phl/hal_g6/phy/rf/halrf_dbg.c
+++ b/phl/hal_g6/phy/rf/halrf_dbg.c
@@ -313,7 +313,7 @@ static void _halrf_dpk_info(struct rf_info *rf, char input[][16], u32 *_used,
 
 	u32 used = *_used;
 	u32 out_len = *_out_len;
-	char *ic_name = NULL;
+	char *ic_name = "unknown";
 	u32 dpk_ver = 0;
 	u32 rf_para = 0;
 	u32 rfk_init_ver = 0;
@@ -475,7 +475,7 @@ static void halrf_dpk_read_rc_mtx(struct rf_info *rf, char input[][16], u32 *_us
 	u32 used = *_used;
 	u32 out_len = *_out_len;
 	u32 addr = 0;
-	char *ic_name = NULL;
+	char *ic_name = "unknown";
 
 	switch (hal_i->chip_id) {
 #ifdef RF_8852C_SUPPORT
@@ -519,7 +519,7 @@ static void halrf_dpk_read_rx_sram(struct rf_info *rf, char input[][16], u32 *_u
 	u32 used = *_used;
 	u32 out_len = *_out_len;
 	u32 addr = 0;
-	char *ic_name = NULL;
+	char *ic_name = "unknown";
 
 	switch (hal_i->chip_id) {
 #ifdef RF_8852C_SUPPORT
@@ -561,7 +561,7 @@ static void halrf_dpk_read_coef(struct rf_info *rf, char input[][16], u32 *_used
 	u32 used = *_used;
 	u32 out_len = *_out_len;
 	u32 addr = 0;
-	char *ic_name = NULL;
+	char *ic_name = "unknown";
 
 	switch (hal_i->chip_id) {
 #ifdef RF_8852C_SUPPORT
@@ -699,7 +699,7 @@ void halrf_rx_dck_info(struct rf_info *rf, char input[][16], u32 *_used,
 
 	u32 used = *_used;
 	u32 out_len = *_out_len;
-	char *ic_name = NULL;
+	char *ic_name = "unknown";
 	u32 rxdck_ver = 0;
 	u8 path;
 	u32 addr = 0;
@@ -916,7 +916,7 @@ static void halrf_dack_dbg_info(struct rf_info *rf, char input[][16], u32 *_used
 
 	u32 used = *_used;
 	u32 out_len = *_out_len;
-	char *ic_name = NULL;
+	char *ic_name = "unknown";
 	u32 dack_ver = 0;
 	u32 rf_para = 0;
 	u8 i;
@@ -1054,7 +1054,7 @@ static void _halrf_tssi_info(struct rf_info *rf, char input[][16], u32 *_used,
 
 	u32 used = *_used;
 	u32 out_len = *_out_len;
-	char *ic_name = NULL;
+	char *ic_name = "unknown";
 	u32 tssi_ver = 0;
 
 	switch (hal_i->chip_id) {
@@ -1289,7 +1289,7 @@ static void _halrf_iqk_info(struct rf_info *rf, char input[][16], u32 *_used,
 
 	u32 used = *_used;
 	u32 out_len = *_out_len;
-	char *ic_name = NULL;
+	char *ic_name = "unknown";
 	u32 ver = 0;
 	u32 rfk_init_ver = 0;
 	u8 tmp = iqk_info->iqk_table_idx[0];
@@ -1879,7 +1879,7 @@ static void _halrf_gapk_info(struct rf_info *rf, char input[][16], u32 *_used,
 
 	u32 used = *_used;
 	u32 out_len = *_out_len;
-	char *ic_name = NULL;
+	char *ic_name = "unknown";
 	u32 txgapk_ver = 0;
 	u32 rf_para = 0;
 	u32 rfk_init_ver = 0;
@@ -2256,7 +2256,7 @@ void halrf_chl_rfk_dbg_cmd(struct rf_info *rf, char input[][16], u32 *_used,
 	u32 used = *_used;
 	u32 out_len = *_out_len;
 	u8 i;
-	char *ic_name = NULL;
+	char *ic_name = "unknown";
 
 	u8 dack_ver = 0;
 	u8 rxdck_ver = 0;


### PR DESCRIPTION
Warning classes that were hidden from the earlier counts. Seven commits: C99 flexible array members instead of the [0]/[1] trailing arrays (the kernel builds with -fstrict-flex-arrays=3 since 6.5; sizeof unchanged); allocate a whole NDIS_802_11_WEP instead of 25 bytes used as a 28-byte struct; halbb SNR report wrote paths C/D past HALBB_MAX_PATH=2 — compiled out; csiinfo debug print read three u32s from a 4-byte allocation (+ NULL check); rtw_alloc_hwxmits' unreachable 5-entry branch gated on HWXMIT_ENTRY; cfg80211_roam_info and halbb_statistic_exp_t moved off the stack; format-truncation in the txpwr string helpers (fmt[32]) and halrf_dbg (ic_name "unknown").

Verified on 7.1.7/arm64 (CONFIG_RTW_DEBUG=n, Armbian configuration): -Warray-bounds= 73 -> 0, -Wformat-truncation= 8 -> 0, -Wframe-larger-than= 2 -> 0, every other class unchanged, 0 errors.