### PR TITLE
Silence -Wmaybe-uninitialized (84 -> 0) and bound the mp ioctl input copy

### DIFF
--- a/core/rtw_debug.c
+++ b/core/rtw_debug.c
@@ -575,7 +575,7 @@ ssize_t proc_set_defs_param(struct file *file, const char __user *buffer, size_t
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct mlme_priv *mlme = &adapter->mlmepriv;
 
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 defs_lmt_sta;
 	u32 defs_lmt_time;
 
@@ -606,7 +606,7 @@ ssize_t proc_set_write_reg(struct file *file, const char __user *buffer, size_t 
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 addr, val, len;
 
 	if (count < 3) {
@@ -685,7 +685,7 @@ int proc_get_read_reg(struct seq_file *m, void *v)
 
 ssize_t proc_set_read_reg(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[16];
+	char tmp[16] = {0};
 	u32 addr, len;
 
 	if (count < 2) {
@@ -1040,7 +1040,7 @@ ssize_t proc_set_roam_flags(struct file *file, const char __user *buffer, size_t
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 flags;
 
 	if (count < 1)
@@ -1086,7 +1086,7 @@ ssize_t proc_set_roam_param(struct file *file, const char __user *buffer, size_t
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct mlme_priv *mlme = &adapter->mlmepriv;
 
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 rssi_diff_th;
 	u32 scanr_exp_ms;
 	u32 scan_int;
@@ -1123,7 +1123,7 @@ ssize_t proc_set_roam_tgt_addr(struct file *file, const char __user *buffer, siz
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 addr[ETH_ALEN];
 
 	if (count < 1)
@@ -1321,7 +1321,7 @@ ssize_t proc_set_scan_param(struct file *file, const char __user *buffer, size_t
 }
 ssize_t proc_set_scan_abort(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[32];
+	char tmp[32] = {0};
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	u32 timeout = 0;
@@ -1921,7 +1921,7 @@ ssize_t proc_set_rate_ctl(struct file *file, const char __user *buffer, size_t c
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u16 fix_rate = NO_FIX_RATE;
 	u8 data_fb = 0;
 
@@ -1976,7 +1976,7 @@ ssize_t proc_set_bmc_tx_rate(struct file *file, const char __user *buffer, size_
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 bmc_tx_rate;
 
 	if (count < 1)
@@ -2014,7 +2014,7 @@ ssize_t proc_set_tx_power_offset(struct file *file, const char __user *buffer, s
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 power_offset = 0;
 
 	if (count < 1)
@@ -2059,7 +2059,7 @@ ssize_t proc_set_bw_ctl(struct file *file, const char __user *buffer, size_t cou
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 fix_bw;
 
 	if (count < 1)
@@ -2105,7 +2105,7 @@ ssize_t proc_set_rx_cnt_dump(struct file *file, const char __user *buffer, size_
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 dump_rx_cnt_mode;
 
 	if (count < 1)
@@ -2133,7 +2133,7 @@ ssize_t proc_set_rx_cnt_dump(struct file *file, const char __user *buffer, size_
 
 ssize_t proc_set_del_rx_ampdu_test_case(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -2151,7 +2151,7 @@ ssize_t proc_set_del_rx_ampdu_test_case(struct file *file, const char __user *bu
 
 ssize_t proc_set_wait_hiq_empty(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -2169,7 +2169,7 @@ ssize_t proc_set_wait_hiq_empty(struct file *file, const char __user *buffer, si
 
 ssize_t proc_set_sta_linking_test(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -2196,7 +2196,7 @@ ssize_t proc_set_sta_linking_test(struct file *file, const char __user *buffer, 
 #ifdef CONFIG_AP_MODE
 ssize_t proc_set_ap_linking_test(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -2266,7 +2266,7 @@ ssize_t proc_set_ps_dbg_info(struct file *file, const char __user *buffer, size_
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct dvobj_priv *dvobj = adapter->dvobj;
 	struct debug_priv *pdbgpriv = &dvobj->drv_dbg;
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 ps_dbg_cmd_id;
 
 	if (count < 1)
@@ -2582,7 +2582,7 @@ ssize_t proc_set_hw_status(struct file *file, const char __user *buffer, size_t 
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct dvobj_priv *dvobj = padapter->dvobj;
 	struct registry_priv *regsty = dvobj_to_regsty(dvobj);
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 enable;
 
 	if (count < 1)
@@ -2705,7 +2705,7 @@ ssize_t proc_set_rx_signal(struct file *file, const char __user *buffer, size_t 
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 is_signal_dbg, signal_strength;
 
 	if (count < 1)
@@ -2768,7 +2768,7 @@ ssize_t proc_set_ht_enable(struct file *file, const char __user *buffer, size_t 
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 mode;
 
 	if (count < 1)
@@ -2810,7 +2810,7 @@ ssize_t proc_set_bw_mode(struct file *file, const char __user *buffer, size_t co
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 mode;
 	u8 bw_2g;
 	u8 bw_5g;
@@ -2856,7 +2856,7 @@ ssize_t proc_set_ampdu_enable(struct file *file, const char __user *buffer, size
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 mode;
 
 	if (count < 1)
@@ -2930,7 +2930,7 @@ ssize_t proc_set_rx_ampdu(struct file *file, const char __user *buffer, size_t c
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 accept;
 	u8 size;
 
@@ -2974,7 +2974,7 @@ ssize_t proc_set_rx_ampdu_factor(struct file *file, const char __user *buffer
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 factor;
 
 	if (count < 1)
@@ -3047,7 +3047,7 @@ ssize_t proc_set_tx_ampdu_num(struct file *file, const char __user *buffer
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
 	struct rtw_phl_com_t *phl_com = GET_PHL_COM(dvobj);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 hw_band_idx;
 	u32 tx_ampdu_num;
 
@@ -3094,7 +3094,7 @@ ssize_t proc_set_rx_ampdu_density(struct file *file, const char __user *buffer, 
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 density;
 
 	if (count < 1)
@@ -3138,7 +3138,7 @@ ssize_t proc_set_tx_ampdu_density(struct file *file, const char __user *buffer, 
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 density;
 
 	if (count < 1)
@@ -3183,7 +3183,7 @@ ssize_t proc_set_tx_quick_addba_req(struct file *file, const char __user *buffer
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 enable;
 
 	if (count < 1)
@@ -3238,7 +3238,7 @@ ssize_t proc_set_tx_amsdu(struct file *file, const char __user *buffer, size_t c
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct xmit_priv *pxmitpriv = &padapter->xmitpriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 i, amsdu;
 
 	if (count < 1)
@@ -3288,7 +3288,7 @@ ssize_t proc_set_tx_amsdu_rate(struct file *file, const char __user *buffer, siz
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 amsdu_rate;
 
 	if (count < 1)
@@ -3334,7 +3334,7 @@ ssize_t proc_set_vht_24g_enable(struct file *file, const char __user *buffer,
 	struct net_device *dev = data;
 	struct _ADAPTER *a = (struct _ADAPTER *)rtw_netdev_priv(dev);
 	struct registry_priv *regpriv = &a->registrypriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 mode;
 
 
@@ -3563,7 +3563,7 @@ ssize_t proc_set_stbc_cap(struct file *file, const char __user *buffer, size_t c
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 mode;
 
 	if (count < 1)
@@ -3604,7 +3604,7 @@ ssize_t proc_set_ldpc_cap(struct file *file, const char __user *buffer, size_t c
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 mode;
 
 	if (count < 1)
@@ -3645,7 +3645,7 @@ ssize_t proc_set_txbf_cap(struct file *file, const char __user *buffer, size_t c
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 mode;
 
 	if (count < 1)
@@ -3682,7 +3682,7 @@ ssize_t proc_set_txbf_cap(struct file *file, const char __user *buffer, size_t c
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 enable=0;
 
 	if (count < 1)
@@ -4051,7 +4051,7 @@ ssize_t proc_set_best_channel(struct file *file, const char __user *buffer, size
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct rtw_chset *chset = adapter_to_chset(padapter);
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -4101,7 +4101,7 @@ ssize_t proc_set_sreset(struct file *file, const char __user *buffer, size_t cou
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	HAL_DATA_TYPE	*pHalData = GET_PHL_COM(adapter_to_dvobj(padapter));
 	struct sreset_priv *psrtpriv = &pHalData->srestpriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	s32 trigger_point;
 
 	if (count < 1)
@@ -4519,7 +4519,7 @@ ssize_t proc_set_tx_ring_ext(struct file *file, const char __user *buffer, size_
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct xmit_priv *pxmitpriv = &padapter->xmitpriv;
 	struct dvobj_priv *pdvobjpriv = adapter_to_dvobj(padapter);
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 reset = 0;
 	u32 dump = 0;
 	unsigned long sp_flags;
@@ -4575,7 +4575,7 @@ ssize_t proc_set_wow_enable(struct file *file, const char __user *buffer,
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv *registry_pair = &padapter->registrypriv;
-	char tmp[8];
+	char tmp[8] = {0};
 	int num = 0;
 	int mode = 0;
 
@@ -4982,7 +4982,7 @@ ssize_t proc_set_ps_info(struct file *file, const char __user *buffer, size_t co
 	struct rtw_phl_com_t *phl_com = dvobj->phl_com;
 	struct rtw_ps_cap_t *ps_cap_p = &phl_com->dev_cap.ps_cap;
 	struct registry_priv  *registry_par = &adapter->registrypriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	int num = 0, ps_mode = 0, ps_cap = 0;
 	u8 lps_cap = 0;
 
@@ -5067,7 +5067,7 @@ ssize_t proc_set_tdls_enable(struct file *file, const char __user *buffer, size_
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 en_tdls = 0;
 
 	if (count < 1)
@@ -5422,7 +5422,7 @@ int proc_get_monitor(struct seq_file *m, void *v)
 
 ssize_t proc_set_monitor(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[32];
+	char tmp[32] = {0};
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	u16 target_type;
@@ -5479,7 +5479,7 @@ ssize_t proc_set_xmit_block(struct file *file, const char __user *buffer, size_t
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 xb_mode, xb_reason;
 
 	if (count < 1)
@@ -5621,7 +5621,7 @@ ssize_t proc_set_tx_sa_query(struct file *file, const char __user *buffer, size_
 	/* struct macid_ctl_t *macid_ctl = dvobj_to_macidctl(dvobj); */
 	struct sta_info *psta;
 	_list	*plist, *phead;
-	char tmp[16];
+	char tmp[16] = {0};
 	u8	mac_addr[NUM_STA][ETH_ALEN];
 	u32 key_type;
 	u8 index;
@@ -5707,7 +5707,7 @@ ssize_t proc_set_tx_deauth(struct file *file, const char __user *buffer, size_t 
 	/* struct macid_ctl_t *macid_ctl = dvobj_to_macidctl(dvobj); */
 	struct sta_info *psta;
 	_list	*plist, *phead;
-	char tmp[16];
+	char tmp[16] = {0};
 	u8	mac_addr[NUM_STA][ETH_ALEN];
 	u8 bc_addr[ETH_ALEN] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 	u32 key_type = 0;
@@ -5806,7 +5806,7 @@ ssize_t proc_set_tx_auth(struct file *file, const char __user *buffer, size_t co
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct mlme_priv *pmlmepriv = &(padapter->mlmepriv);
-	char tmp[16];
+	char tmp[16] = {0};
 	u32 tx_auth;
 
 
@@ -5866,7 +5866,7 @@ ssize_t proc_set_ack_timeout(struct file *file, const char __user *buffer, size_
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 tmp_v1 = 0, tmp_v2 = 0;
 	u8 ack_to_ms = 0, ack_to_cck_ms = 0;
 
@@ -5929,7 +5929,7 @@ ssize_t proc_set_fw_offload(struct file *file, const char __user *buffer, size_t
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	_adapter *pri_adapter = GET_PRIMARY_ADAPTER(adapter);
 	HAL_DATA_TYPE *hal = GET_PHL_COM(adapter_to_dvobj(adapter));
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 iqk_offload_enable = 0, ch_switch_offload_enable = 0;
 
 	if (buffer == NULL) {
@@ -5991,7 +5991,7 @@ ssize_t proc_set_txss_tp(struct file *file, const char __user *buffer, size_t co
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct mlme_ext_priv *pmlmeext = &(adapter->mlmeextpriv);
 
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 enable = 0;
 	u32 txss_tx_tp = 0;
 	int txss_chk_cnt = 0;
@@ -6055,7 +6055,7 @@ ssize_t proc_set_txss_ctrl(struct file *file, const char __user *buffer, size_t 
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct mlme_ext_priv *pmlmeext = &(adapter->mlmeextpriv);
 
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 tx_1ss = 0;
 
 	if (buffer == NULL) {
@@ -6118,7 +6118,7 @@ ssize_t proc_set_iqk(struct file *file, const char __user *buffer, size_t count,
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 recovery, clear, segment;
 
 	if (count < 1)
@@ -6157,7 +6157,7 @@ ssize_t proc_set_lck(struct file *file, const char __user *buffer, size_t count,
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 trigger;
 
 	if (count < 1)
@@ -6190,7 +6190,7 @@ ssize_t proc_set_smps(struct file *file, const char __user *buffer, size_t count
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct mlme_ext_priv *pmlmeext = &(adapter->mlmeextpriv);
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 enable = 0;
 	u32 smps_en, smps_tx_tp = 0, smps_rx_tp = 0;
 	u32 smps_test = 0, smps_test_en = 0;
@@ -6478,7 +6478,7 @@ ssize_t proc_set_disconnect_info(struct file *file, const char __user *buffer,
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct mlme_ext_priv *pmlmeext = &padapter->mlmeextpriv;
 	struct mlme_ext_info *pmlmeinfo = &(pmlmeext->mlmext_info);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 clear;
 
 	if (!pmlmeinfo)
@@ -6527,7 +6527,7 @@ int proc_get_chan(struct seq_file *m, void *v)
 
 ssize_t proc_set_chan(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[32];
+	char tmp[32] = {0};
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	u8 target_ch, target_offset, target_bw;
@@ -6583,7 +6583,7 @@ int proc_get_mr_test(struct seq_file *m, void *v)
 
 ssize_t proc_set_mr_test(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[32];
+	char tmp[32] = {0};
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
@@ -6711,7 +6711,7 @@ ssize_t proc_set_deny_legacy(struct file *file, const char __user *buffer, size_
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv *pregpriv = &padapter->registrypriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 legacy;
 
 	if (count < 1)
@@ -6755,7 +6755,7 @@ ssize_t proc_set_tx_ul_mu_disable(struct file *file, const char __user *buffer, 
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct rtw_he_actrl_om om_info = {0};
 	u8 om_mask = 0;
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 ul_mu_disable;
 	/* ToDo CONFIG_RTW_MLD: [currently primary link only] */
 	struct _ADAPTER_LINK *padapter_link = GET_PRIMARY_LINK(padapter);
@@ -6977,7 +6977,7 @@ ssize_t proc_set_vcs(struct file *file, const char __user *buffer, size_t count,
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv *pregpriv = &padapter->registrypriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 vcs, vcs_t, hw_rts;
 	u16 rts_th;
 

--- a/core/rtw_debug.c
+++ b/core/rtw_debug.c
@@ -582,7 +582,7 @@ ssize_t proc_set_defs_param(struct file *file, const char __user *buffer, size_t
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -614,7 +614,7 @@ ssize_t proc_set_write_reg(struct file *file, const char __user *buffer, size_t 
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -693,7 +693,7 @@ ssize_t proc_set_read_reg(struct file *file, const char __user *buffer, size_t c
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -731,7 +731,7 @@ ssize_t proc_set_mac_dbg_status_dump(struct file *file, const char __user *buffe
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -779,7 +779,7 @@ ssize_t proc_set_ignore_go_and_low_rssi_in_scan(struct file *file,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -882,7 +882,7 @@ ssize_t proc_set_sta_tx_stat(struct file *file, const char __user *buffer, size_
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1046,7 +1046,7 @@ ssize_t proc_set_roam_flags(struct file *file, const char __user *buffer, size_t
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1095,7 +1095,7 @@ ssize_t proc_set_roam_param(struct file *file, const char __user *buffer, size_t
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1129,7 +1129,7 @@ ssize_t proc_set_roam_tgt_addr(struct file *file, const char __user *buffer, siz
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1285,7 +1285,7 @@ ssize_t proc_set_scan_param(struct file *file, const char __user *buffer, size_t
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1331,7 +1331,7 @@ ssize_t proc_set_scan_abort(struct file *file, const char __user *buffer, size_t
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1379,7 +1379,7 @@ ssize_t proc_set_survey_info(struct file *file, const char __user *buffer, size_
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1929,7 +1929,7 @@ ssize_t proc_set_rate_ctl(struct file *file, const char __user *buffer, size_t c
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1982,7 +1982,7 @@ ssize_t proc_set_bmc_tx_rate(struct file *file, const char __user *buffer, size_
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2020,7 +2020,7 @@ ssize_t proc_set_tx_power_offset(struct file *file, const char __user *buffer, s
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2065,7 +2065,7 @@ ssize_t proc_set_bw_ctl(struct file *file, const char __user *buffer, size_t cou
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2111,7 +2111,7 @@ ssize_t proc_set_rx_cnt_dump(struct file *file, const char __user *buffer, size_
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2138,7 +2138,7 @@ ssize_t proc_set_del_rx_ampdu_test_case(struct file *file, const char __user *bu
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2156,7 +2156,7 @@ ssize_t proc_set_wait_hiq_empty(struct file *file, const char __user *buffer, si
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2174,7 +2174,7 @@ ssize_t proc_set_sta_linking_test(struct file *file, const char __user *buffer, 
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2201,7 +2201,7 @@ ssize_t proc_set_ap_linking_test(struct file *file, const char __user *buffer, s
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2272,7 +2272,7 @@ ssize_t proc_set_ps_dbg_info(struct file *file, const char __user *buffer, size_
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2588,7 +2588,7 @@ ssize_t proc_set_hw_status(struct file *file, const char __user *buffer, size_t 
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2711,7 +2711,7 @@ ssize_t proc_set_rx_signal(struct file *file, const char __user *buffer, size_t 
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2774,7 +2774,7 @@ ssize_t proc_set_ht_enable(struct file *file, const char __user *buffer, size_t 
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2818,7 +2818,7 @@ ssize_t proc_set_bw_mode(struct file *file, const char __user *buffer, size_t co
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2862,7 +2862,7 @@ ssize_t proc_set_ampdu_enable(struct file *file, const char __user *buffer, size
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2937,7 +2937,7 @@ ssize_t proc_set_rx_ampdu(struct file *file, const char __user *buffer, size_t c
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2980,7 +2980,7 @@ ssize_t proc_set_rx_ampdu_factor(struct file *file, const char __user *buffer
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3054,7 +3054,7 @@ ssize_t proc_set_tx_ampdu_num(struct file *file, const char __user *buffer
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3100,7 +3100,7 @@ ssize_t proc_set_rx_ampdu_density(struct file *file, const char __user *buffer, 
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3144,7 +3144,7 @@ ssize_t proc_set_tx_ampdu_density(struct file *file, const char __user *buffer, 
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3189,7 +3189,7 @@ ssize_t proc_set_tx_quick_addba_req(struct file *file, const char __user *buffer
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3244,7 +3244,7 @@ ssize_t proc_set_tx_amsdu(struct file *file, const char __user *buffer, size_t c
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3294,7 +3294,7 @@ ssize_t proc_set_tx_amsdu_rate(struct file *file, const char __user *buffer, siz
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3341,7 +3341,7 @@ ssize_t proc_set_vht_24g_enable(struct file *file, const char __user *buffer,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3372,7 +3372,7 @@ ssize_t proc_set_dyn_rrsr(struct file *file, const char __user *buffer, size_t c
 	if (count < 2)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3569,7 +3569,7 @@ ssize_t proc_set_stbc_cap(struct file *file, const char __user *buffer, size_t c
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3610,7 +3610,7 @@ ssize_t proc_set_ldpc_cap(struct file *file, const char __user *buffer, size_t c
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3651,7 +3651,7 @@ ssize_t proc_set_txbf_cap(struct file *file, const char __user *buffer, size_t c
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3691,7 +3691,7 @@ ssize_t proc_set_txbf_cap(struct file *file, const char __user *buffer, size_t c
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3956,7 +3956,7 @@ ssize_t proc_set_rtkm_info(struct file *file, const char __user *buffer,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4056,7 +4056,7 @@ ssize_t proc_set_best_channel(struct file *file, const char __user *buffer, size
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4107,7 +4107,7 @@ ssize_t proc_set_sreset(struct file *file, const char __user *buffer, size_t cou
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4151,7 +4151,7 @@ ssize_t proc_set_pci_bridge_conf_space(struct file *file, const char __user *buf
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4227,7 +4227,7 @@ ssize_t proc_set_pci_conf_space(struct file *file, const char __user *buffer, si
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4527,7 +4527,7 @@ ssize_t proc_set_tx_ring_ext(struct file *file, const char __user *buffer, size_
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4582,7 +4582,7 @@ ssize_t proc_set_wow_enable(struct file *file, const char __user *buffer,
 	if (count < 1) 
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4748,7 +4748,7 @@ ssize_t proc_set_wakeup_event(struct file *file, const char __user *buffer,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4845,7 +4845,7 @@ ssize_t proc_set_wowlan_gpio_info(struct file *file, const char __user *buffer,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4890,7 +4890,7 @@ ssize_t proc_set_wow_gpio_duration(struct file *file, const char __user *buffer,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4986,7 +4986,7 @@ ssize_t proc_set_ps_info(struct file *file, const char __user *buffer, size_t co
 	int num = 0, ps_mode = 0, ps_cap = 0;
 	u8 lps_cap = 0;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -5073,7 +5073,7 @@ ssize_t proc_set_tdls_enable(struct file *file, const char __user *buffer, size_
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -5435,7 +5435,7 @@ ssize_t proc_set_monitor(struct file *file, const char __user *buffer, size_t co
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -5485,7 +5485,7 @@ ssize_t proc_set_xmit_block(struct file *file, const char __user *buffer, size_t
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -5589,7 +5589,7 @@ ssize_t proc_set_efuse_map(struct file *file, const char __user *buffer, size_t 
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -5870,7 +5870,7 @@ ssize_t proc_set_ack_timeout(struct file *file, const char __user *buffer, size_
 	u32 tmp_v1 = 0, tmp_v2 = 0;
 	u8 ack_to_ms = 0, ack_to_cck_ms = 0;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -5942,7 +5942,7 @@ ssize_t proc_set_fw_offload(struct file *file, const char __user *buffer, size_t
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		RTW_INFO("input length is too large\n");
 		rtw_warn_on(1);
 		return -EFAULT;
@@ -6006,7 +6006,7 @@ ssize_t proc_set_txss_tp(struct file *file, const char __user *buffer, size_t co
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		RTW_INFO("input length is too large\n");
 		rtw_warn_on(1);
 		return -EFAULT;
@@ -6068,7 +6068,7 @@ ssize_t proc_set_txss_ctrl(struct file *file, const char __user *buffer, size_t 
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		RTW_INFO("input length is too large\n");
 		rtw_warn_on(1);
 		return -EFAULT;
@@ -6124,7 +6124,7 @@ ssize_t proc_set_iqk(struct file *file, const char __user *buffer, size_t count,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -6163,7 +6163,7 @@ ssize_t proc_set_lck(struct file *file, const char __user *buffer, size_t count,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -6205,7 +6205,7 @@ ssize_t proc_set_smps(struct file *file, const char __user *buffer, size_t count
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		RTW_INFO("input length is too large\n");
 		rtw_warn_on(1);
 		return -EFAULT;
@@ -6281,7 +6281,7 @@ ssize_t proc_set_hang_info(struct file *file, const char __user *buffer,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -6487,7 +6487,7 @@ ssize_t proc_set_disconnect_info(struct file *file, const char __user *buffer,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -6543,7 +6543,7 @@ ssize_t proc_set_chan(struct file *file, const char __user *buffer, size_t count
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -6597,7 +6597,7 @@ ssize_t proc_set_mr_test(struct file *file, const char __user *buffer, size_t co
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -6717,7 +6717,7 @@ ssize_t proc_set_deny_legacy(struct file *file, const char __user *buffer, size_
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -6763,7 +6763,7 @@ ssize_t proc_set_tx_ul_mu_disable(struct file *file, const char __user *buffer, 
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -6984,7 +6984,7 @@ ssize_t proc_set_vcs(struct file *file, const char __user *buffer, size_t count,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}

--- a/core/rtw_sta_mgt.c
+++ b/core/rtw_sta_mgt.c
@@ -1393,7 +1393,7 @@ struct sta_info *rtw_get_bcmc_stainfo(_adapter *padapter, struct _ADAPTER_LINK *
 u16 rtw_aid_alloc(_adapter *adapter, struct sta_info *sta)
 {
 	struct sta_priv *stapriv = &adapter->stapriv;
-	u16 aid, i, used_cnt = 0;
+	u16 aid = 0, i, used_cnt = 0;
 
 	for (i = 0; i < stapriv->max_aid; i++) {
 		aid = ((i + stapriv->started_aid - 1) % stapriv->max_aid) + 1;

--- a/os_dep/linux/ioctl_mp.c
+++ b/os_dep/linux/ioctl_mp.c
@@ -17,6 +17,21 @@
 #include <drv_types.h>
 #include <rtw_mp.h>
 
+/*
+ * Copy the iwpriv argument string into a fixed on-stack buffer.
+ * wrqu->length comes from user space and may exceed the buffer.
+ * The result is always NUL-terminated.
+ */
+static int rtw_mp_copy_input(char *input, size_t size, struct iw_point *wrqu)
+{
+	if (wrqu->length >= size)
+		return -EINVAL;
+	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+		return -EFAULT;
+	input[wrqu->length] = '\0';
+	return 0;
+}
+
 #define RTW_IWD_MAX_LEN	128
 
 /*
@@ -39,15 +54,11 @@ int rtw_mp_write_reg(struct net_device *dev,
 	u32 addr, data;
 	int ret;
 	_adapter *padapter = rtw_netdev_priv(dev);
-	char input[RTW_IWD_MAX_LEN];
+	char input[RTW_IWD_MAX_LEN] = {0};
 	struct rtw_mp_reg_arg	reg_arg;
 
-	_rtw_memset(input, 0, sizeof(input));
-
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
-
-	input[wrqu->length] = '\0';
 
 	_rtw_memset(extra, 0, wrqu->length);
 
@@ -142,7 +153,7 @@ int rtw_mp_read_reg(struct net_device *dev,
 		    struct iw_request_info *info,
 		    struct iw_point *wrqu, char *extra)
 {
-	char input[RTW_IWD_MAX_LEN];
+	char input[RTW_IWD_MAX_LEN] = {0};
 	char *pch, *pnext;
 	char *width_str;
 	char width;
@@ -154,14 +165,9 @@ int rtw_mp_read_reg(struct net_device *dev,
 
 	char *pextra = extra;
 
-	if (wrqu->length > 128)
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
-	_rtw_memset(input, 0, sizeof(input));
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
-		return -EFAULT;
-
-	input[wrqu->length] = '\0';
 	_rtw_memset(extra, 0, wrqu->length);
 	_rtw_memset(data, '\0', sizeof(data));
 	_rtw_memset(tmp, '\0', sizeof(tmp));
@@ -302,11 +308,10 @@ int rtw_mp_write_rf(struct net_device *dev,
 	int ret;
 	_adapter *padapter = rtw_netdev_priv(dev);
 	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
-	char input[RTW_IWD_MAX_LEN];
+	char input[RTW_IWD_MAX_LEN] = {0};
 
 
-	_rtw_memset(input, 0, wrqu->length);
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
 
@@ -344,7 +349,7 @@ int rtw_mp_read_rf(struct net_device *dev,
 		   struct iw_request_info *info,
 		   struct iw_point *wrqu, char *extra)
 {
-	char input[RTW_IWD_MAX_LEN];
+	char input[RTW_IWD_MAX_LEN] = {0};
 	char *pch, *pnext;
 	char data[20], tmp[20];
 	u32 path, addr, strtou;
@@ -353,10 +358,7 @@ int rtw_mp_read_rf(struct net_device *dev,
 	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
 	char *pextra = extra;
 
-	if (wrqu->length > 128)
-		return -EFAULT;
-	_rtw_memset(input, 0, wrqu->length);
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
 	ret = sscanf(input, "%d,%x", &path, &addr);
@@ -471,17 +473,15 @@ int rtw_mp_rate(struct net_device *dev,
 		struct iw_point *wrqu, char *extra)
 {
 	u16 rate = MPT_RATE_1M;
-	u8		input[RTW_IWD_MAX_LEN];
+	u8		input[RTW_IWD_MAX_LEN] = {0};
 	_adapter *padapter = rtw_netdev_priv(dev);
 	struct mp_priv *pmp_priv = (struct mp_priv *)&padapter->mppriv;
 	char *pextra = extra;
 	u8 i = 0;
 
-	_rtw_memset(input, 0, sizeof(input));
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
-	input[wrqu->length] = '\0';
 	rate = rtw_mp_rate_parse(padapter, input);
 	padapter->mppriv.rateidx = rate;
 
@@ -530,14 +530,11 @@ int rtw_mp_channel(struct net_device *dev,
 {
 	_adapter *padapter = rtw_netdev_priv(dev);
 	struct mp_priv *pmp_priv = (struct mp_priv *)&padapter->mppriv;
-	u8		input[RTW_IWD_MAX_LEN];
+	u8		input[RTW_IWD_MAX_LEN] = {0};
 	int	channel = 1;
 
-	_rtw_memset(input, 0, sizeof(input));
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
-
-	input[wrqu->length] = '\0';
 
 	if (kstrtoint(input, 10, &channel) != 0) {
 		RTW_INFO("Failed to convert string to int\n");
@@ -592,14 +589,12 @@ int rtw_mp_trxsc_offset(struct net_device *dev,
 
 	_adapter *padapter = rtw_netdev_priv(dev);
 	struct mp_priv *pmp_priv = (struct mp_priv *)&padapter->mppriv;
-	u8		input[RTW_IWD_MAX_LEN];
+	u8		input[RTW_IWD_MAX_LEN] = {0};
 	u32	trxsc_offset = 0;
 
-	_rtw_memset(input, 0, sizeof(input));
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
-	input[wrqu->length] = '\0';
 	trxsc_offset = rtw_atoi(input);
 	RTW_INFO("%s: ch offset = %d\n", __func__, trxsc_offset);
 
@@ -621,9 +616,9 @@ int rtw_mp_bandwidth(struct net_device *dev,
 	u8 bandwidth = 0, sg = 0;
 	_adapter *padapter = rtw_netdev_priv(dev);
 	struct mp_priv *pmp_priv = (struct mp_priv *)&padapter->mppriv;
-	u8		input[RTW_IWD_MAX_LEN];
+	u8		input[RTW_IWD_MAX_LEN] = {0};
 
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
 	if (sscanf(input, "40M=%hhd,shortGI=%hhd", &bandwidth, &sg) > 0)
@@ -657,22 +652,16 @@ int rtw_mp_txpower_index(struct net_device *dev,
 			 struct iw_point *wrqu, char *extra)
 {
 	_adapter *padapter = rtw_netdev_priv(dev);
-	char input[RTW_IWD_MAX_LEN];
+	char input[RTW_IWD_MAX_LEN] = {0};
 	u32 rfpath = 0 ;
 	u32 txpower_inx = 0, tarpowerdbm = 0;
 	char *pextra = extra;
 	u8 rf_type = GET_HAL_RFPATH(adapter_to_dvobj(padapter));
 	struct _ADAPTER_LINK *adapter_link = GET_PRIMARY_LINK(padapter);
 
-	if (wrqu->length > 128)
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
-	_rtw_memset(input, 0, sizeof(input));
-
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
-		return -EFAULT;
-
-	input[wrqu->length] = '\0';
 	_rtw_memset(extra, 0, strlen(extra));
 
 	if (wrqu->length == 2) {
@@ -747,7 +736,7 @@ int rtw_mp_txpower(struct net_device *dev,
 	u32 idx_a = 0, idx_b = 0, idx_c = 0, idx_d = 0;
 	int MsetPower = 1;
 	char pout_str_buf[8];
-	u8		input[RTW_IWD_MAX_LEN];
+	u8		input[RTW_IWD_MAX_LEN] = {0};
 	u8 rfpath_i = 0;
 	u16 agc_cw_val = 0;
 	_adapter *padapter = rtw_netdev_priv(dev);
@@ -756,7 +745,7 @@ int rtw_mp_txpower(struct net_device *dev,
 	u8 tx_nss = get_phy_tx_nss(padapter, padapter_link);
 	char *pextra = extra;
 
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
 	MsetPower = strncmp(input, "off", 3);
@@ -832,18 +821,16 @@ int rtw_mp_ant_tx(struct net_device *dev,
 		  struct iw_point *wrqu, char *extra)
 {
 	u8 i;
-	u8		input[RTW_IWD_MAX_LEN];
+	u8		input[RTW_IWD_MAX_LEN] = {0};
 	u8 antenna = 0;
 	u16 pwr_dbm = 0;
 	_adapter *padapter = rtw_netdev_priv(dev);
 	struct mp_priv *pmppriv = &padapter ->mppriv;
 	char *pextra = extra;
 
-	_rtw_memset(input, 0, sizeof(input));
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
-	input[wrqu->length] = '\0';
 	pextra += sprintf(pextra, "switch Tx antenna to %s\n", input);
 
 	for (i = 0; i < strlen(input); i++) {
@@ -884,14 +871,12 @@ int rtw_mp_ant_rx(struct net_device *dev,
 {
 	u8 i;
 	u16 antenna = 0;
-	u8		input[RTW_IWD_MAX_LEN];
+	u8		input[RTW_IWD_MAX_LEN] = {0};
 	_adapter *padapter = rtw_netdev_priv(dev);
 
-	_rtw_memset(input, 0, sizeof(input));
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
-	input[wrqu->length] = '\0';
 	/*RTW_INFO("%s: input=%s\n", __func__, input);*/
 	_rtw_memset(extra, 0, wrqu->length);
 
@@ -1099,15 +1084,11 @@ int rtw_mp_disable_bt_coexist(struct net_device *dev,
 			      struct iw_request_info *info,
 			      union iwreq_data *wrqu, char *extra)
 {
-	u8 input[RTW_IWD_MAX_LEN];
+	u8 input[RTW_IWD_MAX_LEN] = {0};
 	u32 bt_coexist;
 
-	_rtw_memset(input, 0, sizeof(input));
-
-	if (copy_from_user(input, wrqu->data.pointer, wrqu->data.length))
+	if (rtw_mp_copy_input(input, sizeof(input), &wrqu->data))
 		return -EFAULT;
-
-	input[wrqu->data.length] = '\0';
 
 	bt_coexist = rtw_atoi(input);
 
@@ -1140,12 +1121,12 @@ int rtw_mp_arx(struct net_device *dev,
 	_adapter *padapter = rtw_netdev_priv(dev);
 	struct mp_priv *pmppriv = &padapter->mppriv;
 	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
-	u8	input[RTW_IWD_MAX_LEN];
+	u8	input[RTW_IWD_MAX_LEN] = {0};
 	u32	ret;
 	char *pch, *token, *tmp[2] = {0x00, 0x00};
 	u32 i = 0, jj = 0, kk = 0, cnts = 0;
 
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
 	RTW_INFO("%s: %s\n", __func__, input);
@@ -1438,9 +1419,9 @@ int rtw_mp_pwrtrk(struct net_device *dev,
 	s32 ret = 0;
 	_adapter *padapter = rtw_netdev_priv(dev);
 	struct mp_priv *pmp_priv = (struct mp_priv *)&padapter->mppriv;
-	u8 input[RTW_IWD_MAX_LEN];
+	u8 input[RTW_IWD_MAX_LEN] = {0};
 
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
 	_rtw_memset(extra, 0, wrqu->length);
@@ -1458,7 +1439,6 @@ int rtw_mp_pwrtrk(struct net_device *dev,
 			enable = RTW_MP_TSSI_CAL;
 			sprintf(extra, "TSSI cal");
 		} else {
-			input[wrqu->length] = '\0';
 			enable = rtw_atoi(input);
 			sprintf(extra, "TSSI power tracking %d", enable);
 		}
@@ -1485,13 +1465,11 @@ int rtw_mp_psd(struct net_device *dev,
 	       struct iw_point *wrqu, char *extra)
 {
 	_adapter *padapter = rtw_netdev_priv(dev);
-	u8		input[RTW_IWD_MAX_LEN];
+	u8		input[RTW_IWD_MAX_LEN] = {0};
 
-	_rtw_memset(input, 0, sizeof(input));
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
-	input[wrqu->length] = '\0';
 	strcpy(extra, input);
 
 	wrqu->length = mp_query_psd(padapter, extra);
@@ -1611,12 +1589,12 @@ int rtw_mp_dump(struct net_device *dev,
 		struct iw_point *wrqu, char *extra)
 {
 	struct mp_priv *pmp_priv;
-	u8		input[RTW_IWD_MAX_LEN];
+	u8		input[RTW_IWD_MAX_LEN] = {0};
 	_adapter *padapter = rtw_netdev_priv(dev);
 
 	pmp_priv = &padapter->mppriv;
 
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
 	if (strncmp(input, "all", 4) == 0) {
@@ -1634,11 +1612,11 @@ int rtw_mp_phypara(struct net_device *dev,
 {
 
 	_adapter *padapter = rtw_netdev_priv(dev);
-	char	input[RTW_IWD_MAX_LEN];
+	char	input[RTW_IWD_MAX_LEN] = {0};
 	u32		invalxcap = 0, ret = 0;
 
 
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
 	RTW_INFO("%s:priv in=%s\n", __func__, input);
@@ -1668,14 +1646,14 @@ int rtw_mp_SetRFPath(struct net_device *dev,
 		     struct iw_request_info *info,
 		     struct iw_point *wrqu, char *extra)
 {
-	char	input[RTW_IWD_MAX_LEN];
+	char	input[RTW_IWD_MAX_LEN] = {0};
 #ifdef CONFIG_ANTENNA_DIVERSITY
 	u8 ret = _TRUE;
 #endif
 
 	RTW_INFO("%s:iwpriv in=%s\n", __func__, input);
 
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 #if 0
 	bMain = strncmp(input, "1", 2); /* strncmp TRUE is 0*/
@@ -1718,11 +1696,11 @@ int rtw_mp_switch_rf_path(struct net_device *dev,
 {
 	_adapter *padapter = rtw_netdev_priv(dev);
 	struct mp_priv *pmp_priv;
-	char	input[RTW_IWD_MAX_LEN];
+	char	input[RTW_IWD_MAX_LEN] = {0};
 	u8 ret = 0;
 
 
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
 	pmp_priv = &padapter->mppriv;
@@ -1762,11 +1740,11 @@ int rtw_mp_QueryDrv(struct net_device *dev,
 		    struct iw_request_info *info,
 		    union iwreq_data *wrqu, char *extra)
 {
-	char	input[RTW_IWD_MAX_LEN];
+	char	input[RTW_IWD_MAX_LEN] = {0};
 	int	qAutoLoad = 1;
 	//struct efuse_info *efuse = adapter_to_efuse(padapter);
 
-	if (copy_from_user(input, wrqu->data.pointer, wrqu->data.length))
+	if (rtw_mp_copy_input(input, sizeof(input), &wrqu->data))
 		return -EFAULT;
 	RTW_INFO("%s:iwpriv in=%s\n", __func__, input);
 
@@ -1789,15 +1767,14 @@ int rtw_mp_PwrCtlDM(struct net_device *dev,
 		    struct iw_request_info *info,
 		    struct iw_point *wrqu, char *extra)
 {
-	u8		input[RTW_IWD_MAX_LEN];
+	u8		input[RTW_IWD_MAX_LEN] = {0};
 	u8		pwrtrk_state = 0;
 	u8		pwtk_type[5][25] = {"Thermal tracking off","Thermal tracking on",
 					"TSSI tracking off","TSSI tracking on","TSSI calibration"};
 
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
-	input[wrqu->length] = '\0';
 	RTW_INFO("%s: in=%s\n", __func__, input);
 
 	if (wrqu->length == 2) {
@@ -1902,7 +1879,7 @@ int rtw_mp_get_tsside(struct net_device *dev,
 			 struct iw_point *wrqu, char *extra)
 {
 	_adapter *padapter = rtw_netdev_priv(dev);
-	char input[RTW_IWD_MAX_LEN];
+	char input[RTW_IWD_MAX_LEN] = {0};
 	u8 rfpath = 0xff;
 	s8 tssi_de = 0;
 	char pout_str_buf[8];
@@ -1914,14 +1891,8 @@ int rtw_mp_get_tsside(struct net_device *dev,
 	s32 tgrpwr = 0;
 	int i;
 
-	if (wrqu->length > 128)
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
-
-	_rtw_memset(input, 0, sizeof(input));
-
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
-		return -EFAULT;
-	input[wrqu->length] = '\0';
 
 	if (wrqu->length == 2) {
 		rfpath = rtw_atoi(input);
@@ -2061,13 +2032,13 @@ int rtw_mp_set_tsside(struct net_device *dev,
 {
 	int tsside_val = 0;
 	u8 rf_path = RF_PATH_A;
-	char input[RTW_IWD_MAX_LEN];
+	char input[RTW_IWD_MAX_LEN] = {0};
 
 	_adapter *padapter = rtw_netdev_priv(dev);
 	struct mp_priv *pmp_priv = &padapter->mppriv;
 
 
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
 	RTW_INFO("%s:input =[%s]\n", __func__, input);
@@ -3510,7 +3481,7 @@ int rtw_mp_link(struct net_device *dev,
 {
 	_adapter *padapter = rtw_netdev_priv(dev);
 	struct mp_priv *pmp_priv;
-	char	input[RTW_IWD_MAX_LEN];
+	char	input[RTW_IWD_MAX_LEN] = {0};
 	int		bgetrxdata = 0, btxdata = 0, bsetbt = 0;
 	int err = 0;
 	u32 i = 0, datalen = 0,jj, kk, waittime = 0;
@@ -3520,7 +3491,7 @@ int rtw_mp_link(struct net_device *dev,
 
 	pmp_priv = &padapter->mppriv;
 
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
 
 	_rtw_memset(extra, 0, wrqu->length);
@@ -3694,18 +3665,12 @@ static int rtw_mp_gpio(struct net_device *dev,
 {
 	_adapter *padapter = rtw_netdev_priv(dev);
 	struct mp_priv *pmp_priv = (struct mp_priv *)&padapter->mppriv;
-	char input[RTW_IWD_MAX_LEN];
+	char input[RTW_IWD_MAX_LEN] = {0};
 	u8 gpio_id, gpio_enable;
 	int ret = 0;
 
-	if (wrqu->length > 128)
+	if (rtw_mp_copy_input(input, sizeof(input), wrqu))
 		return -EFAULT;
-
-	_rtw_memset(input, 0, sizeof(input));
-
-	if (copy_from_user(input, wrqu->pointer, wrqu->length))
-		return -EFAULT;
-	input[wrqu->length] = '\0';
 
 	RTW_INFO("%s: input = %s\n", __func__, input);
 	_rtw_memset(extra, 0, wrqu->length);

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -133,7 +133,7 @@ static ssize_t proc_set_log_level(struct file *file, const char __user *buffer, 
 	if (count < 1)
 		return -EINVAL;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -180,7 +180,7 @@ static ssize_t proc_set_country_chplan_map(struct file *file, const char __user 
 	if (count < 1)
 		return -EINVAL;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -643,7 +643,7 @@ ssize_t proc_set_sdio_dbg(struct file *file, const char __user *buffer,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -767,7 +767,7 @@ ssize_t proc_set_led_config(struct file *file, const char __user *buffer, size_t
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -810,7 +810,7 @@ static ssize_t proc_set_aid_status(struct file *file, const char __user *buffer,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -851,7 +851,7 @@ static ssize_t proc_set_ap_b2u_flags(struct file *file, const char __user *buffe
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -932,7 +932,7 @@ static ssize_t proc_set_backop_flags_sta(struct file *file, const char __user *b
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -972,7 +972,7 @@ static ssize_t proc_set_backop_flags_ap(struct file *file, const char __user *bu
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1013,7 +1013,7 @@ static ssize_t proc_set_backop_flags_mesh(struct file *file, const char __user *
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1044,7 +1044,7 @@ static ssize_t proc_set_config_gpio(struct file *file, const char __user *buffer
 	if (count < 2)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1070,7 +1070,7 @@ static ssize_t proc_set_gpio_output_value(struct file *file, const char __user *
 	if (count < 2)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1109,7 +1109,7 @@ static ssize_t proc_set_gpio(struct file *file, const char __user *buffer, size_
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1141,7 +1141,7 @@ static ssize_t proc_set_rx_info_msg(struct file *file, const char __user *buffer
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1273,7 +1273,7 @@ static ssize_t proc_set_false_alarm_accumulated(struct file *file,
 	if (count < 1)
 		return -EINVAL;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1499,7 +1499,7 @@ static ssize_t proc_set_linked_info_dump(struct file *file, const char __user *b
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1552,7 +1552,7 @@ static ssize_t proc_set_sta_tp_dump(struct file *file, const char __user *buffer
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1611,7 +1611,7 @@ static ssize_t proc_set_turboedca_ctrl(struct file *file, const char __user *buf
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp))
+	if (count >= sizeof(tmp))
 		return -EFAULT;
 
 	if (buffer && !copy_from_user(tmp, buffer, count)) {
@@ -1694,7 +1694,7 @@ static ssize_t proc_set_chan_plan(struct file *file, const char __user *buffer, 
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1734,7 +1734,7 @@ static ssize_t proc_set_country_code(struct file *file, const char __user *buffe
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1808,7 +1808,7 @@ static ssize_t proc_set_cap_spt_op_class_ch(struct file *file, const char __user
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1840,7 +1840,7 @@ static ssize_t proc_set_reg_spt_op_class_ch(struct file *file, const char __user
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1872,7 +1872,7 @@ static ssize_t proc_set_cur_spt_op_class_ch(struct file *file, const char __user
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -1923,7 +1923,7 @@ static ssize_t proc_set_macaddr_acl(struct file *file, const char __user *buffer
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2058,7 +2058,7 @@ ssize_t proc_set_pre_link_sta(struct file *file, const char __user *buffer, size
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2136,7 +2136,7 @@ static ssize_t proc_set_ch_sel_policy(struct file *file, const char __user *buff
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2193,7 +2193,7 @@ static ssize_t proc_set_dfs_test_case(struct file *file, const char __user *buff
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2221,7 +2221,7 @@ static ssize_t proc_set_update_non_ocp(struct file *file, const char __user *buf
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2251,7 +2251,7 @@ static ssize_t proc_set_radar_detect(struct file *file, const char __user *buffe
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2293,7 +2293,7 @@ static ssize_t proc_set_dfs_ch_sel_e_flags(struct file *file, const char __user 
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2334,7 +2334,7 @@ static ssize_t proc_set_dfs_ch_sel_d_flags(struct file *file, const char __user 
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2376,7 +2376,7 @@ static ssize_t proc_set_dfs_slave_with_rd(struct file *file, const char __user *
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2427,7 +2427,7 @@ static ssize_t proc_set_rx_ampdu_size_limit(struct file *file, const char __user
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2474,7 +2474,7 @@ static ssize_t proc_set_rx_chk_limit(struct file *file, const char __user *buffe
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2516,7 +2516,7 @@ static ssize_t proc_set_udpport(struct file *file, const char __user *buffer, si
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2649,7 +2649,7 @@ static ssize_t proc_set_sec_cam(struct file *file, const char __user *buffer, si
 	char cmd[4];
 	u8 id_1 = 0, id_2 = 0;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2741,7 +2741,7 @@ static ssize_t proc_set_change_bss_chbw(struct file *file, const char __user *bu
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2838,7 +2838,7 @@ static ssize_t proc_set_tx_bw_mode(struct file *file, const char __user *buffer,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2886,7 +2886,7 @@ static ssize_t proc_set_ecsa_allow_reason(struct file *file,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -2980,7 +2980,7 @@ static ssize_t proc_set_tpc_settings(struct file *file, const char __user *buffe
 	u8 mode;
 	u16 m_constraint;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3021,7 +3021,7 @@ static ssize_t proc_set_tx_power_ext_info(struct file *file, const char __user *
 	char tmp[32] = {0};
 	char cmd[16] = {0};
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3187,7 +3187,7 @@ static ssize_t proc_set_skip_band(struct file *file, const char __user *buffer, 
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3271,7 +3271,7 @@ static ssize_t proc_set_acs(struct file *file, const char __user *buffer, size_t
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3365,7 +3365,7 @@ static ssize_t proc_set_rsvd_page_info(struct file *file, const char __user *buf
 	if (count < 2)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3402,7 +3402,7 @@ static ssize_t proc_set_fifo_info(struct file *file, const char __user *buffer, 
 	if (count < 3)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3501,7 +3501,7 @@ static ssize_t proc_set_napi_th(struct file *file, const char __user *buffer, si
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3538,7 +3538,7 @@ static ssize_t proc_set_dynamic_agg_enable(struct file *file, const char __user 
 	char tmp[32] = {0};
 	int enable = 0, i = 0;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3603,7 +3603,7 @@ static ssize_t proc_set_wds_en(struct file *file, const char __user *buffer, siz
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3628,7 +3628,7 @@ static ssize_t proc_set_sta_wds_en(struct file *file, const char __user *buffer,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3707,7 +3707,7 @@ static ssize_t proc_set_multi_ap_opmode(struct file *file, const char __user *bu
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3767,7 +3767,7 @@ ssize_t proc_set_unassoc_sta(struct file *file, const char __user *buffer, size_
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		RTW_WARN(FUNC_ADPT_FMT" input string too long\n", FUNC_ADPT_ARG(adapter));
 		rtw_warn_on(1);
 		return -EFAULT;
@@ -3919,7 +3919,7 @@ ssize_t proc_set_sta_assoc_req_frame_body(struct file *file, const char __user *
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -3956,7 +3956,7 @@ static ssize_t proc_set_ch_util_threshold(struct file *file, const char __user *
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4015,7 +4015,7 @@ static ssize_t proc_set_mesh_acnode_prevent(struct file *file, const char __user
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4060,7 +4060,7 @@ static ssize_t proc_set_mesh_offch_cand(struct file *file, const char __user *bu
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4105,7 +4105,7 @@ static ssize_t proc_set_mesh_peer_blacklist(struct file *file, const char __user
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4147,7 +4147,7 @@ static ssize_t proc_set_mesh_cto_mgate_require(struct file *file, const char __u
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4194,7 +4194,7 @@ static ssize_t proc_set_mesh_cto_mgate_blacklist(struct file *file, const char _
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4290,7 +4290,7 @@ static ssize_t proc_set_mesh_b2u_flags(struct file *file, const char __user *buf
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4342,7 +4342,7 @@ static ssize_t proc_set_mesh_gate_timeout(struct file *file, const char __user *
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4406,7 +4406,7 @@ proc_set_peer_alive_based_preq(struct file *file, const char __user *buffer,
 	int num = 0;
 	u8 enable = 0;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4458,7 +4458,7 @@ static ssize_t proc_set_scan_interval_thr(struct file *file,
 	u32 thr = 0;
 
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4504,7 +4504,7 @@ static ssize_t proc_set_scan_deny(struct file *file, const char __user *buffer,
 	int num = 0;
 	int enable = 0;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4571,7 +4571,7 @@ static ssize_t proc_set_go_hidden_ssid_mode(struct file *file, const char __user
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4637,7 +4637,7 @@ static ssize_t proc_set_amsdu_mode(struct file *file, const char __user *buffer,
 	if (count < 1)
 		return -EFAULT;
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4708,7 +4708,7 @@ static ssize_t proc_set_vendor_ie_filter(struct file *file, const char __user *b
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}
@@ -4763,7 +4763,7 @@ static ssize_t proc_set_enable_dfs(struct file *file, const char __user *buffer,
 		return -EFAULT;
 	}
 
-	if (count > sizeof(tmp)) {
+	if (count >= sizeof(tmp)) {
 		rtw_warn_on(1);
 		return -EFAULT;
 	}

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -125,7 +125,7 @@ static int proc_get_drv_cfg(struct seq_file *m, void *v)
 
 static ssize_t proc_set_log_level(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[32];
+	char tmp[32] = {0};
 #ifdef CONFIG_RTW_DEBUG
 	int log_level;
 #endif
@@ -174,7 +174,7 @@ static int proc_get_country_chplan_map(struct seq_file *m, void *v)
 
 static ssize_t proc_set_country_chplan_map(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[32];
+	char tmp[32] = {0};
 	int regd_info_val;
 
 	if (count < 1)
@@ -760,7 +760,7 @@ ssize_t proc_set_led_config(struct file *file, const char __user *buffer, size_t
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 strategy;
 	u8 iface_en_mask;
 
@@ -803,7 +803,7 @@ static ssize_t proc_set_aid_status(struct file *file, const char __user *buffer,
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct sta_priv *stapriv = &adapter->stapriv;
 
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 rr;
 	u16 started_aid;
 
@@ -846,7 +846,7 @@ static ssize_t proc_set_ap_b2u_flags(struct file *file, const char __user *buffe
 {
 	struct net_device *dev = data;
 	_adapter *adapter = rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -926,7 +926,7 @@ static ssize_t proc_set_backop_flags_sta(struct file *file, const char __user *b
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct mlme_ext_priv *mlmeext = &adapter->mlmeextpriv;
 
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 flags;
 
 	if (count < 1)
@@ -966,7 +966,7 @@ static ssize_t proc_set_backop_flags_ap(struct file *file, const char __user *bu
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct mlme_ext_priv *mlmeext = &adapter->mlmeextpriv;
 
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 flags;
 
 	if (count < 1)
@@ -1007,7 +1007,7 @@ static ssize_t proc_set_backop_flags_mesh(struct file *file, const char __user *
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct mlme_ext_priv *mlmeext = &adapter->mlmeextpriv;
 
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 flags;
 
 	if (count < 1)
@@ -1267,7 +1267,7 @@ static ssize_t proc_set_false_alarm_accumulated(struct file *file,
 	struct _ADAPTER_LINK *alink = GET_PRIMARY_LINK(padapter);
 	struct rtw_wifi_role_link_t *wrlink = alink->wrlink;
 	enum phl_band_idx hw_band = wrlink->hw_band;
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 false_clr;
 
 	if (count < 1)
@@ -1682,7 +1682,7 @@ static ssize_t proc_set_chan_plan(struct file *file, const char __user *buffer, 
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u16 chplan = RTW_CHPLAN_UNSPECIFIED;
 	u16 chplan_6g = RTW_CHPLAN_6G_UNSPECIFIED;
 
@@ -1727,7 +1727,7 @@ static ssize_t proc_set_country_code(struct file *file, const char __user *buffe
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	char alpha2[2];
 	int num;
 
@@ -1803,7 +1803,7 @@ static int proc_get_cap_spt_op_class_ch(struct seq_file *m, void *v)
 
 static ssize_t proc_set_cap_spt_op_class_ch(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -1835,7 +1835,7 @@ static int proc_get_reg_spt_op_class_ch(struct seq_file *m, void *v)
 
 static ssize_t proc_set_reg_spt_op_class_ch(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -1867,7 +1867,7 @@ static int proc_get_cur_spt_op_class_ch(struct seq_file *m, void *v)
 
 static ssize_t proc_set_cur_spt_op_class_ch(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -2129,7 +2129,7 @@ static ssize_t proc_set_ch_sel_policy(struct file *file, const char __user *buff
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct rf_ctl_t *rfctl = adapter_to_rfctl(adapter);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 within_sb;
 	int num;
 
@@ -2186,7 +2186,7 @@ static ssize_t proc_set_dfs_test_case(struct file *file, const char __user *buff
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct rf_ctl_t *rfctl = adapter_to_rfctl(adapter);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 radar_detect_trigger_non;
 	u8 choose_dfs_ch_first;
 
@@ -2214,7 +2214,7 @@ static ssize_t proc_set_update_non_ocp(struct file *file, const char __user *buf
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 band, ch, bw = CHANNEL_WIDTH_20, offset = CHAN_OFFSET_NO_EXT;
 	int ms = -1;
 
@@ -2245,7 +2245,7 @@ static ssize_t proc_set_radar_detect(struct file *file, const char __user *buffe
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct rf_ctl_t *rfctl = adapter_to_rfctl(adapter);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 fake_radar_detect_cnt = 0;
 
 	if (count < 1)
@@ -2286,7 +2286,7 @@ static ssize_t proc_set_dfs_ch_sel_e_flags(struct file *file, const char __user 
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct rf_ctl_t *rfctl = adapter_to_rfctl(adapter);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 e_flags;
 	int num;
 
@@ -2327,7 +2327,7 @@ static ssize_t proc_set_dfs_ch_sel_d_flags(struct file *file, const char __user 
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct rf_ctl_t *rfctl = adapter_to_rfctl(adapter);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 d_flags;
 	int num;
 
@@ -2369,7 +2369,7 @@ static ssize_t proc_set_dfs_slave_with_rd(struct file *file, const char __user *
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct rf_ctl_t *rfctl = adapter_to_rfctl(adapter);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 rd;
 	int num;
 
@@ -2420,7 +2420,7 @@ static ssize_t proc_set_rx_ampdu_size_limit(struct file *file, const char __user
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv *regsty = adapter_to_regsty(adapter);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 nss;
 	u8 limit_by_bw[4] = {0xFF};
 
@@ -2464,7 +2464,7 @@ static int proc_get_rx_chk_limit(struct seq_file *m, void *v)
 
 static ssize_t proc_set_rx_chk_limit(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
-	char tmp[32];
+	char tmp[32] = {0};
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	int rx_chk_limit;
@@ -2505,7 +2505,7 @@ static ssize_t proc_set_udpport(struct file *file, const char __user *buffer, si
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct recv_info *precvinfo = &(padapter->recvinfo);
 	int sink_udpport = 0;
-	char tmp[32];
+	char tmp[32] = {0};
 
 
 	if (!padapter)
@@ -2733,7 +2733,7 @@ static ssize_t proc_set_change_bss_chbw(struct file *file, const char __user *bu
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	int i;
-	char tmp[32];
+	char tmp[32] = {0};
 	s16 ch;
 	s8 bw = REQ_BW_NONE, offset = REQ_OFFSET_NONE, band = REQ_BAND_NONE;
 	u8 ifbmp = 0;
@@ -2832,7 +2832,7 @@ static ssize_t proc_set_tx_bw_mode(struct file *file, const char __user *buffer,
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 bw_mode;
 
 	if (count < 1)
@@ -2880,7 +2880,7 @@ static ssize_t proc_set_ecsa_allow_reason(struct file *file,
 	struct net_device *dev = data;
 	_adapter *a = (_adapter *)rtw_netdev_priv(dev);
 	struct core_ecsa_info *ecsa_info = &(a->ecsa_info);
-	char tmp[12];
+	char tmp[12] = {0};
 	u8 reason;
 
 	if (count < 1)
@@ -3181,7 +3181,7 @@ static ssize_t proc_set_skip_band(struct file *file, const char __user *buffer, 
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[6];
+	char tmp[6] = {0};
 	u8 skip_band;
 
 	if (count < 1)
@@ -3262,7 +3262,7 @@ static ssize_t proc_set_acs(struct file *file, const char __user *buffer, size_t
 #ifdef CONFIG_RTW_ACS_DBG
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 acs_state = 0;
 	u16 scan_ch_ms= 0, acs_scan_ch_ms = 0;
 	u8 scan_type = SCAN_ACTIVE, igi= 0, bw = 0;
@@ -3359,7 +3359,7 @@ static ssize_t proc_set_rsvd_page_info(struct file *file, const char __user *buf
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 page_offset, page_num;
 
 	if (count < 2)
@@ -3394,7 +3394,7 @@ static ssize_t proc_set_fifo_info(struct file *file, const char __user *buffer, 
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 fifo_sel = 0;
 	u32 fifo_addr = 0;
 	u32 fifo_size = 0;
@@ -3535,7 +3535,7 @@ static ssize_t proc_set_dynamic_agg_enable(struct file *file, const char __user 
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 	int enable = 0, i = 0;
 
 	if (count > sizeof(tmp)) {
@@ -3595,7 +3595,7 @@ static ssize_t proc_set_wds_en(struct file *file, const char __user *buffer, siz
 {
 	struct net_device *dev = data;
 	_adapter *adapter = rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (!(MLME_STATE(adapter) & (WIFI_AP_STATE | WIFI_STATION_STATE)))
 		return -EFAULT;
@@ -3623,7 +3623,7 @@ static ssize_t proc_set_sta_wds_en(struct file *file, const char __user *buffer,
 {
 	struct net_device *dev = data;
 	_adapter *adapter = rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -3699,7 +3699,7 @@ static ssize_t proc_set_multi_ap_opmode(struct file *file, const char __user *bu
 {
 	struct net_device *dev = data;
 	_adapter *adapter = rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (!(MLME_STATE(adapter) & (WIFI_AP_STATE | WIFI_STATION_STATE)))
 		return -EFAULT;
@@ -3951,7 +3951,7 @@ static ssize_t proc_set_ch_util_threshold(struct file *file, const char __user *
 {
 	struct net_device *dev = data;
 	_adapter *adapter = GET_PRIMARY_ADAPTER(rtw_netdev_priv(dev));
-	char tmp[4];
+	char tmp[4] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -4010,7 +4010,7 @@ static ssize_t proc_set_mesh_acnode_prevent(struct file *file, const char __user
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -4055,7 +4055,7 @@ static ssize_t proc_set_mesh_offch_cand(struct file *file, const char __user *bu
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -4100,7 +4100,7 @@ static ssize_t proc_set_mesh_peer_blacklist(struct file *file, const char __user
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -4142,7 +4142,7 @@ static ssize_t proc_set_mesh_cto_mgate_require(struct file *file, const char __u
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -4189,7 +4189,7 @@ static ssize_t proc_set_mesh_cto_mgate_blacklist(struct file *file, const char _
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -4285,7 +4285,7 @@ static ssize_t proc_set_mesh_b2u_flags(struct file *file, const char __user *buf
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -4337,7 +4337,7 @@ static ssize_t proc_set_mesh_gate_timeout(struct file *file, const char __user *
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
-	char tmp[32];
+	char tmp[32] = {0};
 
 	if (count < 1)
 		return -EFAULT;
@@ -4402,7 +4402,7 @@ proc_set_peer_alive_based_preq(struct file *file, const char __user *buffer,
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv  *rp = &adapter->registrypriv;
-	char tmp[8];
+	char tmp[8] = {0};
 	int num = 0;
 	u8 enable = 0;
 
@@ -4453,7 +4453,7 @@ static ssize_t proc_set_scan_interval_thr(struct file *file,
 	struct net_device *dev = data;
 	_adapter *adapter= (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv *rp = &adapter->registrypriv;
-	char tmp[12];
+	char tmp[12] = {0};
 	int num = 0;
 	u32 thr = 0;
 
@@ -4500,7 +4500,7 @@ static ssize_t proc_set_scan_deny(struct file *file, const char __user *buffer,
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
-	char tmp[8];
+	char tmp[8] = {0};
 	int num = 0;
 	int enable = 0;
 
@@ -4560,7 +4560,7 @@ static ssize_t proc_set_go_hidden_ssid_mode(struct file *file, const char __user
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
 	struct mlme_ext_priv *pmlmeext = &padapter->mlmeextpriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	int go_hidden_ssid_mode, feature_bit;
 
 	if (!padapter)
@@ -4631,7 +4631,7 @@ static ssize_t proc_set_amsdu_mode(struct file *file, const char __user *buffer,
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
 	struct registry_priv	*pregpriv = &padapter->registrypriv;
-	char tmp[32];
+	char tmp[32] = {0};
 	u32 mode;
 
 	if (count < 1)
@@ -4692,7 +4692,7 @@ static ssize_t proc_set_vendor_ie_filter(struct file *file, const char __user *b
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	struct mlme_priv *mlmepriv = &adapter->mlmepriv;
-	char tmp[MAX_VENDOR_IE_PARAM_LEN];
+	char tmp[MAX_VENDOR_IE_PARAM_LEN] = {0};
 	u8 vendor_ie_num = 0;
 	u8 *vendor_ie;
 	u8 enable;
@@ -4755,7 +4755,7 @@ static ssize_t proc_set_enable_dfs(struct file *file, const char __user *buffer,
 	struct net_device *dev = data;
 	_adapter *adapter = rtw_netdev_priv(dev);
 	char *alpha2;
-	char tmp[32];
+	char tmp[32] = {0};
 	u8 enable_dfs = 0;
 
 	if (count < 1) {

--- a/phl/phl_util.c
+++ b/phl/phl_util.c
@@ -177,7 +177,7 @@ void pq_del_node(void *d, struct phl_queue *q, _os_list *obj, enum lock_type typ
 u8 pq_insert(void *d, struct phl_queue *q, enum lock_type type, void *priv, _os_list *input,
 		  u8 (*pq_predicate)(void *d, void *priv,_os_list *input, _os_list *obj))
 {
-	_os_spinlockfg sp_flags;
+	_os_spinlockfg sp_flags = 0;
 	_os_list *obj = NULL;
 
 	_os_spinlock(d, &q->lock, type, &sp_flags);


### PR DESCRIPTION
On 7.1 headers copy_from_user() goes through check_object_size() and gcc
reports -Wmaybe-uninitialized for every uninitialised local buffer that
receives user input: 82 in the proc write handlers and mp ioctls, plus 2
ordinary ones (aid in rtw_aid_alloc, sp_flags in pq_insert).

- proc write handlers: zero-initialise the scratch buffers (109) and reject
  count >= sizeof(tmp) instead of > (136), so the terminator stays in bounds.
- mp ioctl: all 26 handlers copied wrqu->length bytes into a 128-byte stack
  buffer and wrote input[length] = '\0'; length is user controlled and the
  iwpriv args are declared up to 1024 bytes, so this was a real stack overflow.
  Only 5 had a check, and > 128 still let the terminator land one past the
  end. Route all sites through rtw_mp_copy_input() (reject, copy, terminate).
- aid = 0 / sp_flags = 0: gcc cannot prove them assigned; no behavioural change.

Build (arm64, 7.1.7 headers, CONFIG_PLATFORM_ARM_ROCKCHIP=y CONFIG_RTW_DEBUG=n):
-Wmaybe-uninitialized 84 -> 0, every other class unchanged, 0 errors.
Independent of #19.
