### PR TITLE
Fix two clang findings: sscanf %7s overflow in mp ioctl, uninitialised max_bw in rtw_vht

### DIFF
--- a/core/rtw_vht.c
+++ b/core/rtw_vht.c
@@ -1383,7 +1383,7 @@ u32 rtw_restructure_vht_ie(_adapter *padapter, struct _ADAPTER_LINK *padapter_li
 					u8 *in_ie, u8 *out_ie, uint in_len, uint *pout_len, u8 channel)
 {
 	u32	ielen;
-	u8 max_bw;
+	u8 max_bw = CHANNEL_WIDTH_20;
 	u8 oper_ch, oper_bw = CHANNEL_WIDTH_20, oper_offset = CHAN_OFFSET_NO_EXT;
 	u8 *out_vht_op_ie, *ht_op_ie, *vht_cap_ie, *vht_op_ie;
 	enum band_type band = rtw_is_2g_ch(channel) ? BAND_ON_24G : BAND_ON_5G;

--- a/os_dep/linux/ioctl_mp.c
+++ b/os_dep/linux/ioctl_mp.c
@@ -746,7 +746,7 @@ int rtw_mp_txpower(struct net_device *dev,
 {
 	u32 idx_a = 0, idx_b = 0, idx_c = 0, idx_d = 0;
 	int MsetPower = 1;
-	char pout_str_buf[7];
+	char pout_str_buf[8];
 	u8		input[RTW_IWD_MAX_LEN];
 	u8 rfpath_i = 0;
 	u16 agc_cw_val = 0;
@@ -1905,8 +1905,8 @@ int rtw_mp_get_tsside(struct net_device *dev,
 	char input[RTW_IWD_MAX_LEN];
 	u8 rfpath = 0xff;
 	s8 tssi_de = 0;
-	char pout_str_buf[7];
-	char tgr_str_buf[7];
+	char pout_str_buf[8];
+	char tgr_str_buf[8];
 	u8 pout_signed_flag = 0 , tgrpwr_signed_flag = 0;
 	int int_num = 0;
 	u32 dec_num = 0;


### PR DESCRIPTION
A one-off clang build of the driver (LLVM=1, arm64, 7.1.7 headers) turned
up two real defects:

- rtw_mp_tx_power / rtw_mp_get_tsside read the dbm/pwr tokens with %7s
  into 7-byte buffers; a 7-character token needs 8 bytes with the NUL, so
  a long iwpriv argument wrote one byte past the buffer (-Wfortify-source).
  Size the buffers to 8.
- rtw_restructure_vht_ie() only assigns max_bw for 2.4/5 GHz and then
  compares it against CHANNEL_WIDTH_40; any other band read an
  uninitialised local (-Wsometimes-uninitialized). Start from 20 MHz.

The remaining clang-only output (fall-through into default: break,
((a == b)), a self-assignment, frame-larger-than in debug paths) is not
a defect and is left alone. Independent of #19 / #20.
