### PR TITLE
osdep_service_linux: release the path reference taken by kern_path()

### DIFF
--- a/os_dep/osdep_service_linux.c
+++ b/os_dep/osdep_service_linux.c
@@ -489,8 +489,13 @@ static int writeFile(struct file *fp, char *buf, int len)
 static int isDirReadable(const char *pathname, u32 *sz)
 {
 	struct path path;
+	int ret;
 
-	return kern_path(pathname, LOOKUP_FOLLOW, &path);
+	ret = kern_path(pathname, LOOKUP_FOLLOW, &path);
+	if (ret == 0)
+		path_put(&path);
+
+	return ret;
 }
 
 /*


### PR DESCRIPTION
`isDirReadable()` calls `kern_path()`, which on success takes a reference on the resolved dentry and mount and never drops it — every successful `rtw_is_dir_readable()` leaks a dentry/vfsmount reference. Release it with `path_put()`.

Compile-tested (arm64, 7.1.8 headers).