### PR TITLE
hal_ld_file: restore the missing continue in the TX power limit column-define stage

### DIFF
--- a/phl/hal_g6/hal_ld_file.c
+++ b/phl/hal_g6/hal_ld_file.c
@@ -812,6 +812,7 @@ line_start:
 		} else if (loadingstage == LD_STAGE_COLUMN_DEFINE) {
 			/* read "## #5# " */
 			if (sz_line[0] != '#' || sz_line[1] != '#')
+				continue;
 
 			/* skip the space */
 			i = 2;
@@ -1312,6 +1313,7 @@ line_start:
 		} else if (loadingstage == LD_STAGE_COLUMN_DEFINE) {
 			/* read "## #5# " */
 			if (sz_line[0] != '#' || sz_line[1] != '#')
+				continue;
 
 			/* skip the space */
 			i = 2;


### PR DESCRIPTION
In `hal_phy_store_tx_power_limit()` and `hal_phy_store_tx_power_limit_ru()` the `LD_STAGE_COLUMN_DEFINE` check for a `##` prefix has no body, so the following `i = 2;` silently became its body: for the expected `## #N#` line the column parser starts from whatever offset the START stage left in `i`, and any other line is parsed as garbage and aborts the table load. The six sibling checks in this file all `continue;` — do the same here.

Compile-tested (arm64, 7.1.8 headers).
