### PR TITLE
hal_ld_file: compose the external parameter file path after the folder is known

### DIFF
--- a/phl/hal_g6/hal_ld_file.c
+++ b/phl/hal_g6/hal_ld_file.c
@@ -1899,19 +1899,13 @@ _hal_dl_para_file(struct rtw_phl_com_t *phl_com,
 		}
 	} else if (para_info->para_src == RTW_PARA_SRC_EXTNAL) {
 		char para_path[MAX_PATH_LEN];
-		/* Use path in para_info if it is not empty. */
-		if (para_info->para_path[0] != 0) {
-			_os_snprintf(para_path, MAX_PATH_LEN,
-				     "%s%s", para_info->para_path,
-				     file_name);
-		} else {
-			_os_snprintf(para_path, MAX_PATH_LEN, "%s%s%s%s",
-				     hal_phy_folder, ic_name, _os_path_sep,
-				     file_name);
-		}
 
-		/* Determine parameter folder path */
-		if (para_info->hal_phy_folder != NULL) {
+		/* Determine parameter folder path: a caller-supplied
+		 * para_info->para_path takes precedence over hal_phy_folder */
+		if (para_info->para_path[0] != 0) {
+			_os_snprintf(hal_phy_folder, MAX_PATH_LEN, "%s",
+						 para_info->para_path);
+		} else if (para_info->hal_phy_folder != NULL) {
 			_os_snprintf(hal_phy_folder, MAX_PATH_LEN, "%s",
 						 para_info->hal_phy_folder);
 		} else {
@@ -1943,7 +1937,7 @@ _hal_dl_para_file(struct rtw_phl_com_t *phl_com,
 		}
 
 		/* Generate final parameter file full path */
-		_os_snprintf(para_info->para_path, MAX_PATH_LEN, "%s%s",
+		_os_snprintf(para_path, MAX_PATH_LEN, "%s%s",
 				 hal_phy_folder, para_file_name);
 
 		PHL_TRACE(COMP_PHL_DBG, _PHL_INFO_, "%s:: %s\n",__FUNCTION__,


### PR DESCRIPTION
In the `RTW_PARA_SRC_EXTNAL` branch the path handed to `_os_read_file()` was built at the top of the block — before `hal_phy_folder` was determined and before the user postfix was applied — from either the still-empty `hal_phy_folder` or the previously stored `para_info->para_path`. The first attempt read `<ic>/<file>` relative to cwd, every later attempt read `<full path><file>`; the file was never found and the driver fell back to the built-in tables. The correct full path was only ever stored in `para_info->para_path`, unused.

Build the local path from the resolved folder and file name. A non-empty `para_info->para_path` is kept as a caller-supplied folder override (precedence over `hal_phy_folder`) and is no longer overwritten, so it survives repeated loads. Affects the file types enabled by default in `rtw_load_phy_file` (TXPWR_TRACK / TXPWR_LMT / LMT_RU / LMT_6G / LMT_RU_6G); files are looked up as `<rtw_phy_file_path><name>`, default `/lib/firmware/`.

Compile-tested (arm64, 7.1.8 headers).
